### PR TITLE
Record the first six decisions this repository is built on, and the privacy position

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 Every other board in this organisation carries a promise, which is right for them and makes them a bad place to try something that will probably fail. Without somewhere to fail, experiments either do not happen or they happen inside a board that then has to explain them. The rule that keeps this from becoming a graveyard is that every experiment states its question before it starts and its answer when it stops, and the answer may be no. An experiment with no written answer is not finished, it is abandoned, and the difference should be visible. Everything here is public from the first commit, which means a failed experiment is public too.
 
 Planning happens on the issue tracker first. Every decision that shapes
-the architecture is written down there with its reasons before the code
+the architecture is argued there with its reasons before the code
 that depends on it exists.
+
+What survives the argument is written down in
+[docs/decisions/](docs/decisions/). Each record is numbered, says what was
+decided, what it applies to, what else was considered and what each rejected
+option would have cost, and is replaced by a later record rather than edited.
 
 See [NOTICE.md](NOTICE.md) for the intended-use notice.

--- a/README.md
+++ b/README.md
@@ -11,4 +11,11 @@ What survives the argument is written down in
 decided, what it applies to, what else was considered and what each rejected
 option would have cost, and is replaced by a later record rather than edited.
 
+Because everything here is public, some things may never be committed. No
+credential, token or key, including expired ones. No personal data of any kind.
+No copy of a real media library, real account data or real logs from a running
+server. No file whose licence forbids it being here. The reasoning behind the
+list is in
+[docs/decisions/0006-everything-here-is-public.md](docs/decisions/0006-everything-here-is-public.md).
+
 See [NOTICE.md](NOTICE.md) for the intended-use notice.

--- a/README.md
+++ b/README.md
@@ -18,4 +18,9 @@ server. No file whose licence forbids it being here. The reasoning behind the
 list is in
 [docs/decisions/0006-everything-here-is-public.md](docs/decisions/0006-everything-here-is-public.md).
 
+Nothing here uploads, phones home or reports usage, and real data an experiment
+measures against stays on the machine it is already on.
+[docs/privacy.md](docs/privacy.md) is the whole position, including what it does
+not cover.
+
 See [NOTICE.md](NOTICE.md) for the intended-use notice.

--- a/docs/decisions/0000-how-decisions-are-recorded.md
+++ b/docs/decisions/0000-how-decisions-are-recorded.md
@@ -1,0 +1,93 @@
+# 0000. How decisions are recorded
+
+## What was decided
+
+Decisions that shape this repository live in `docs/decisions/`, one decision per
+file. A file is named `NNNN-short-slug.md`, where `NNNN` is a four-digit number
+that is never reused and never renumbered. This record is `0000` and it is the
+one every later record is written against.
+
+Each record carries four sections, in this order and under these headings:
+
+1. `## What was decided`
+2. `## What it applies to`
+3. `## What else was considered`
+4. `## What each rejected option would have cost`
+
+Section 3 lists the options that were not taken. Section 4 says, for each of
+them, what taking it would have cost. A record whose section 3 is empty is not a
+decision, it is an announcement, and the format is built so that a reader sees
+the difference without having to know the history. Where an option was rejected
+for a reason that is not a cost, section 4 still names the option and says so.
+
+A record is not edited once something depends on it. Fixing a typo before
+anything references the record is ordinary. Changing what it decided, after work
+has been done against it, is not, because a reader who followed the old text has
+no way to find out that the ground moved.
+
+Decisions change by superseding. A later record names the earlier one by number
+in its first section, says what moved and why, and the earlier record stays where
+it is with its text intact. The earlier record gains one line at the top naming
+the record that superseded it, and that line is the only edit a superseded record
+takes. So the reasoning that was true at the time is still readable, next to the
+reasoning that replaced it.
+
+Numbers come from the plan rather than from the order the files happen to arrive
+in. Each decision has an issue, and the issue names the number and the filename
+its record will carry, so two records written at the same time do not choose the
+same number.
+
+## What it applies to
+
+Every decision that shapes this repository and that later work depends on: the
+layout, the language the runner is built in, what an experiment record is, what
+may never be committed, what happens to code once an experiment has an answer,
+and anything else a person arriving later would otherwise have to reconstruct
+from a diff.
+
+It does not apply to the ordinary judgements inside one change. Which name a
+function gets, or how a check is written once its rule is decided, is argued in
+the change and read in review. A record for every such choice would bury the
+records that matter.
+
+It does not apply to the tracker either. Issues are where a decision is argued
+and where the evidence is collected. The record is what survives the argument, so
+a decision that exists only in an issue is not yet recorded.
+
+## What else was considered
+
+Keeping decisions in issue comments and linking to them from the code.
+
+Keeping one long document listing every decision in sequence.
+
+Keeping no separate record at all, and treating the commit message of the change
+that first depends on a decision as the record.
+
+Requiring a status field on each record, with values such as proposed, accepted
+and superseded.
+
+## What each rejected option would have cost
+
+Issue comments have no current state. An issue is a conversation, so a reader
+arriving later has to read the whole thread and work out which sentence won,
+and a decision that was revised three times reads as three decisions. The
+tracker can also be closed, exported or moved, and then nothing that depended on
+those comments has a source any more.
+
+One long document produces a merge conflict on every decision, because every
+change touches the same file, and it grows into something nobody reads to the
+end. It also makes superseding invisible, since the natural way to change such a
+document is to edit the paragraph that is wrong, which destroys the reasoning
+that was true before.
+
+Commit messages are attached to a change rather than to a subject. A decision
+that shapes five later changes lives in the message of whichever one happened
+first, which is not where anybody would look, and `git log` is a poor index for
+somebody who does not already know what they are searching for. History is also
+rewritten more often than a tracked file is.
+
+A status field costs an accuracy problem that has no owner. A record marked
+accepted stays marked accepted after it has been superseded unless somebody
+remembers to go back and change it, and an edit to a landed record is exactly
+what this decision refuses. Superseding by writing a later record needs no field
+to be kept true, because the later record's own existence is the status.

--- a/docs/decisions/0002-repository-layout.md
+++ b/docs/decisions/0002-repository-layout.md
@@ -1,0 +1,100 @@
+# 0002. Repository layout
+
+## What was decided
+
+Where a thing lives decides what can be checked about it. This record fixes the
+layout, and the list below is the whole of it.
+
+`experiments/<slug>/` holds one experiment and everything it needs. One
+directory, one question. Nothing outside this tree is an experiment.
+
+`experiments/<slug>/EXPERIMENT.md` is the record of that experiment. Its shape is
+decided separately. Its location is fixed here, so a checker finds every record
+by walking one directory instead of searching the tree.
+
+`cmd/lab/` and `internal/` hold the runner. `cmd/lab/` is the entry point and
+`internal/` is everything it is built from. The runner imports nothing from
+`experiments/`.
+
+`docs/decisions/` holds the decision records, in the shape record `0000` sets
+out. `docs/` holds everything else a reader needs and that is not a decision.
+
+`testdata/` holds the runner's own fixtures. These are fixtures and they are not
+experiments. A check exercised against the real `experiments/` tree proves the
+state of that tree on the day it ran and proves nothing about the check, so the
+fixtures a check is judged by live here.
+
+`.github/` holds the workflows and the templates. It is named because it is
+already in the tree, and a record that listed every directory except the one that
+was here first would be a record this repository disagreed with on the day it
+landed.
+
+At the commit this record lands on, the root of the tree holds two directories,
+`.github` and `docs`:
+
+    git ls-tree -d --name-only HEAD
+    .github
+    docs
+
+The rest of the list is where things go as they arrive, not a claim that they are
+here now.
+
+A directory at the root of the tree that this record does not name is refused
+rather than tolerated. Adding one is a change to this decision, argued in an
+issue and landed as a later record, rather than something that happens quietly
+while somebody is doing something else. The refusal is built in issue #65 and it
+reads this list.
+
+The rule that makes the layout worth having is that the runner and the
+experiments never mix. The runner imports nothing from `experiments/`, and
+nothing under `experiments/` is on the path any part of the runner is built from.
+The reason is that an experiment is allowed to be abandoned, deleted or rewritten
+in another language, and none of that may have any consequence for the tool that
+judges it. The same separation lets the tool be released on its own schedule,
+because its sources do not move when an experiment does.
+
+## What it applies to
+
+The whole tree, and every change that adds a file to it. It applies at the root
+strictly, because that is where the refusal reads, and inside the named
+directories loosely, because what a runner needs under `internal/` is an ordinary
+judgement rather than a decision.
+
+It applies to the checks too. A check that has to guess where a record lives is a
+check that goes wrong quietly, so anything the runner walks is named here.
+
+## What else was considered
+
+A flat tree, with experiments at the root and the runner mixed in among them.
+
+Keeping the runner in a separate repository from the experiments.
+
+Leaving the root open, so a new directory needs no decision.
+
+Putting the experiment records in one directory of their own, separate from the
+experiment code they describe.
+
+## What each rejected option would have cost
+
+A flat tree costs the walk. There would be no directory a checker could walk to
+find every experiment record, so finding them means matching filenames across the
+whole tree, and a stray file with the right name becomes an experiment nobody
+meant to declare. It also removes the separation rule entirely, since an
+experiment and the runner would sit side by side with nothing between them.
+
+A separate repository buys the strongest possible separation and costs the thing
+this board is for. An experiment would then be a change in one repository judged
+by a tool in another, which is two checkouts, two issue trackers and a version
+skew between the record format and the checker that reads it. The import rule
+above buys most of the separation for none of that.
+
+An open root costs the property that makes the layout checkable. A directory
+nobody decided on appears during unrelated work, the refusal has nothing to read,
+and within a few months the tree is the one nobody can walk, which is the failure
+this board was opened to avoid.
+
+Splitting the records from the code they describe costs the one-directory rule.
+An experiment would live in two places, which means two things to move when it is
+renamed and two to delete when it is abandoned, and the code-removal decision
+becomes much harder to state, because removing an experiment's code would leave
+an empty directory in one tree and a record in the other.

--- a/docs/decisions/0004-what-happens-to-the-code.md
+++ b/docs/decisions/0004-what-happens-to-the-code.md
@@ -1,0 +1,79 @@
+# 0004. What happens to an experiment's code once it has an answer
+
+## What was decided
+
+The record is permanent and the code is not.
+
+An `EXPERIMENT.md` record is not deleted, and it is not rewritten to hide what it
+said. An experiment that answered no keeps its record exactly as it was written,
+and so does an experiment that was abandoned. What a record gains over time is
+lines added to it, never lines replaced.
+
+Once an experiment has an answer, its code can be removed in a later commit if
+keeping it serves nobody. That is a choice and not an obligation. Code that still
+teaches somebody something stays.
+
+When the code is removed, the record gains one line naming the commit that
+removed it. The line carries the full commit hash and one clause saying what was
+removed, so a reader who wants the code can check it out from history and a
+reader who does not is not made to walk past it. The line is added under the
+answer, and nothing already in the record is touched.
+
+Removing code is not removing the experiment. An experiment whose code is gone
+still has its question, still has its answer, and still appears in the listing
+with both. Nothing about it is marked as lesser, because a prototype that was
+deleted after it answered its question is a finished piece of work rather than an
+incomplete one.
+
+What this refuses is silent removal. Code that disappears with no line in the
+record is indistinguishable from work that never happened, and the difference
+between those two is the thing this board exists to keep.
+
+## What it applies to
+
+Everything under `experiments/<slug>/` other than the record itself. The record
+is covered by the first sentence above and by the checks that read it.
+
+It applies once an answer is written and not before. An experiment still asking
+its question has no answer to leave behind, so removing its code leaves nothing
+readable, and that is deleting the experiment rather than removing its code.
+
+It says nothing about what happens to a result somebody wants to keep using. Code
+that is meant to keep working is not an experiment any more, and moving it
+somewhere it will be maintained is a separate path with its own decision.
+
+## What else was considered
+
+Keeping every line of every experiment forever.
+
+Deleting the code automatically once an answer is written.
+
+Deleting the whole experiment directory, record included, when the code goes.
+
+Moving removed code to an archive directory inside this repository instead of
+leaving it in history.
+
+## What each rejected option would have cost
+
+Keeping everything forever costs the reader. The tree fills with prototypes that
+answered their question years ago, and a person looking for the two experiments
+that matter walks past forty that do not. It also puts a quiet tax on anyone
+running a check across the tree, since every prototype is more surface for a
+scanner to trip over, and it makes an experiment expensive to start, which is the
+one thing this board is trying to make cheap.
+
+Automatic deletion costs the evidence. Code left behind by an experiment that
+answered no is often exactly how it failed, and a rule that removes it takes away
+the most useful part of a negative result. It also makes the answer dangerous to
+write, because writing it would trigger the deletion, and an author who wants to
+keep the code would then leave the experiment unfinished on purpose.
+
+Deleting the whole directory costs the record, which is the one thing this
+decision holds permanent. It would also make an abandoned experiment and a
+completed one look the same from outside, since both would be an absence.
+
+An archive directory costs the layout and buys nothing git does not already
+provide. The root list in record `0002` does not name one, history already holds
+every removed file, and a second copy inside the tree is a second thing to keep
+in step with the first. The commit hash in the record is a pointer to what git
+holds anyway.

--- a/docs/decisions/0006-everything-here-is-public.md
+++ b/docs/decisions/0006-everything-here-is-public.md
@@ -1,0 +1,108 @@
+# 0006. Everything here is public, and what that means may never be committed
+
+## What was decided
+
+This decision has two halves and they belong together.
+
+### The first half, what being public buys
+
+Everything in this repository is public from the first commit, including the
+experiments that failed. That is deliberate, and it is worth saying out loud
+because it changes what people are willing to try.
+
+A failure that is visible is a failure somebody else does not have to repeat. An
+experiment that answered no is, on this board, a finished piece of work and it is
+presented as one. Its record sits next to the records of the experiments that
+answered yes, in the same format, with the same weight.
+
+Nothing here is hidden because it did not work. Nothing is quietly deleted
+because it is embarrassing. Where an experiment's code is removed, that happens
+under record `0004` and leaves a line saying so, which is the opposite of quiet.
+
+### The second half, what may never be committed
+
+Precisely because everything here is public, some things may never enter the
+tree. Git history does not forget, so this list is about what is committed at
+all, not about what is in the current checkout.
+
+- No credential, token, key or secret of any kind, including ones that have
+  expired or been rotated. An expired credential still reveals its format, its
+  issuer and often the account it belonged to.
+- No personal data of any kind, whether it belongs to the person running the
+  experiment or to anybody else. Names, addresses, e-mail addresses, device
+  identifiers and account identifiers are all covered.
+- No copy of a real media library, real account data, or real logs from a running
+  server, whoever runs it.
+- No file whose licence forbids it being here.
+
+Where an experiment genuinely needs real data to answer its question, the data
+stays on the host it is already on. It does not enter the tree, not as a fixture,
+not as a sample, not as an attachment to a record. The record carries what was
+measured and the command that measured it, and it carries no copy of the thing it
+was measured against.
+
+Whether an experiment on this board may work with real data at all, even on the
+host and never in the tree, is a wider question than this record settles. This
+record fixes only the boundary at the tree, and that boundary holds whichever way
+the wider question is answered.
+
+The reason the two halves are one decision is that a public board with no stated
+exclusions produces one bad commit and then a scramble. The exclusions are the
+price of the openness, and stating them apart from it invites somebody to read
+the first half without the second.
+
+Nothing in this repository can refuse a violation of the second half today. There
+is no scanner in the tree that reads a commit for a credential or for personal
+data, and this record does not create one. What stands behind the list is a
+person reading before they commit and a person reading the change, which is
+stated here rather than implied so that nobody mistakes the list for a gate.
+
+## What it applies to
+
+Every commit on every branch of this repository, and every file a change adds,
+including test fixtures, sample configuration, screenshots and anything attached
+to a record.
+
+It applies to the second half retroactively in the only sense that matters. A
+thing that reaches history is not removed by a later commit, so a mistake here is
+handled as an exposure and not as a revert, which means rotating what leaked and
+saying so.
+
+It does not apply to the tracker, which follows the same spirit but has its own
+route for taking something down.
+
+## What else was considered
+
+Making the board private, or private until an experiment succeeds.
+
+Publishing only the experiments that answered yes.
+
+Stating the openness and leaving the exclusions to a separate document written
+later.
+
+Listing the exclusions as guidance rather than as a rule, on the reasoning that
+nothing here refuses a violation anyway.
+
+## What each rejected option would have cost
+
+A private board costs the whole reason the board exists. A failure nobody can
+read saves nobody any work, and an experiment that becomes public only once it
+succeeds teaches the same lesson as every other board in this organisation, which
+is that only finished things are shown. It would also mean the interesting half
+of the corpus, the negative results, never reaches anybody.
+
+Publishing only the successes costs the record its meaning. The listing would
+show a board where everything worked, which is not a description of any research
+that has ever happened, and a reader would have no way to tell an experiment that
+answered no from one that was never run.
+
+Leaving the exclusions for later costs exactly one commit. The gap between
+opening a public board and writing down what may not go on it is the window in
+which the mistake happens, and the mistake is permanent. The two halves are one
+record so that the window does not exist.
+
+Guidance rather than a rule costs the ability to say a thing was violated. If the
+list is advice, then a commit carrying a credential broke nothing, and there is
+no clear statement to point at when deciding how to respond. The absence of a
+machine that refuses something is a reason to write the rule more plainly, not a
+reason to write it more weakly.

--- a/docs/decisions/0009-the-checks-do-not-run-experiment-code.md
+++ b/docs/decisions/0009-the-checks-do-not-run-experiment-code.md
@@ -1,0 +1,109 @@
+# 0009. The checks do not build or run experiment code
+
+## What was decided
+
+Nothing that runs on its own builds or executes anything under `experiments/`.
+
+That covers the build and test workflow, the record checks, and any other job a
+pull request, a push or a timer starts. None of them compile an experiment, none
+of them run an experiment's tests, and none of them install a toolchain that
+exists only because some experiment wanted it.
+
+What runs on its own is the runner's own suite and the checks that read records.
+Those are this repository's own code and this repository's own text, and they run
+against `testdata/` fixtures rather than against the real `experiments/` tree.
+
+What runs only when asked is everything belonging to an experiment. A person can
+run an experiment's tests explicitly, from a checkout, at the moment they want
+the answer. The hardware harness is the named route for the experiments that
+cannot be answered without a real device. No automatic run ever takes either
+route.
+
+The first reason is the one this board was opened for. An experiment is allowed
+to fail, and the code left behind by an experiment that answered no is often
+exactly how it failed. A gate that goes red on that code leaves two ways out,
+deleting the evidence or rewriting the answer, and both destroy the thing the
+record exists to preserve. Record `0004` permits deleting a prototype and
+deliberately does not require it, which only holds if keeping a broken one costs
+nothing.
+
+The second is the dependency surface. Experiments are written in whatever
+language the question needs, which is the point of keeping the runner independent
+of them. Building all of them on every pull request means this repository's
+checks carry every toolchain any experiment ever wanted, on a board whose runner
+was chosen partly for carrying almost no dependencies at all.
+
+The third is smaller and harder to undo. Record `0002` keeps the runner from
+importing anything under `experiments/`, so that no experiment can break the tool
+that judges it. Executing experiment code inside the job that judges records
+would hand that back by a different route, with the tool and the thing it judges
+in one process again.
+
+Three consequences, written down here rather than left to be inferred.
+
+The headless requirement binds what runs on its own. That is the runner's suite
+and the record checks, and it means those complete with no display and no
+elevation. It is not a claim that every experiment's tests are headless, because
+nothing automatic runs them. That is narrower than the requirement looks at first
+reading, and it is written narrow here rather than broad in a document and narrow
+in practice.
+
+The declaration an experiment makes about which harness it needs is a statement
+to a reader deciding whether they can reproduce the work. It is checked for
+agreement with where that experiment's tests are registered, and the refusal over
+a mismatch is about the record being consistent with itself. It is not a
+scheduling instruction. No run reads it and acts on it, and an experiment
+declaring that it needs a device does not thereby cause anything to look for one.
+
+An experiment's measurements are produced by whoever runs the experiment. The
+record carries the command and what it produced. Nothing verifies that the
+command was run, that the machine it ran on was what the record says, or that the
+number is real. Review is what catches an unreproducible measurement, and the
+promotion checklist asks for it again at the point where the number starts
+mattering to somebody other than its author.
+
+## What it applies to
+
+Every automatic run this repository defines, now and later, and every path under
+`experiments/`.
+
+It does not apply to the record checks reading an experiment's `EXPERIMENT.md`.
+Reading a record as text is not executing the experiment, and those checks are
+the reason the tree is walkable at all.
+
+It does not constrain what a person does in their own checkout.
+
+## What else was considered
+
+Building and testing every experiment on every pull request.
+
+Building them in a separate automatic job that is not required to be green.
+
+Letting each experiment opt in to being built automatically.
+
+## What each rejected option would have cost
+
+Building everything on every pull request costs all three reasons above at once,
+and it costs one more thing that arrives sooner than any of them. The first
+abandoned prototype would hold the board red until somebody deleted it, so the
+board would be forced to choose between a permanently failing gate and destroying
+the evidence, on the day the first experiment answered no.
+
+A separate job nobody is allowed to act on is worse than no check. It teaches
+every reader that red is survivable on this board, and the next red one they walk
+past will be a real one. A check whose result changes nothing is not a weaker
+check, it is a check that trains people out of reading checks.
+
+Per-experiment opt-in is the strongest of the three and it is deferred rather
+than dismissed. It needs a contract between an experiment and the checks, saying
+what an opting-in experiment promises and what happens when it stops keeping that
+promise, and there is no experiment in the tree yet to write such a contract
+against. Writing it now would mean guessing at the shape of the first experiment,
+and the guess would be load-bearing for everything after it.
+
+## The condition that reopens this
+
+If experiments start carrying code that is meant to keep working, rather than
+code that answered a question and stopped, the opt-in option is the one to take.
+At that point this record is superseded by one that takes it, rather than argued
+with.

--- a/docs/decisions/0010-a-flaw-in-shipped-software.md
+++ b/docs/decisions/0010-a-flaw-in-shipped-software.md
@@ -1,0 +1,113 @@
+# 0010. When an experiment finds a flaw in shipped software
+
+## What was decided
+
+Everything on this board is public from the first commit, and the questions this
+board is for sit next to software people run. Sooner or later an experiment asks
+whether something can be bypassed, overloaded or read that should not be, and the
+answer is yes. At that moment this board's central rule and responsible
+disclosure point in opposite directions. The rule says write the question before
+the work and the answer when it stops, in public. Disclosure says the affected
+project hears about it first.
+
+### Which experiments do not start here in public
+
+An experiment whose question is whether shipped software can be made to misbehave
+in a way that harms the people running it does not start here in public. That
+covers a question about bypassing an authentication or authorisation boundary,
+about reading data the software is meant to keep from the reader, about crashing
+or exhausting a service somebody is running, and anything else whose answer would
+be a working way to hurt an operator or their users.
+
+The question goes to the affected project through whatever private route that
+project publishes, and the work happens where that project asks for it. This
+board is not where such a flaw is first written down. No directory, no record, no
+issue and no branch here carries it before the affected project has it.
+
+An experiment that finds something unintended while asking a different question
+takes the same route, and that is the common case rather than the exception. The
+work stops, nothing sensitive is committed, and the report goes to the affected
+project. A gap in the tree while that happens is cheaper than a public record of
+a live flaw.
+
+### What is written afterwards, and what has to be true first
+
+What comes back here is the record. Two things have to be true before it is
+written. The flaw has to be fixed, and the affected project has to have said what
+it wants said.
+
+Once both hold, an experiment record is written in the ordinary shape, with the
+question, the answer and a pointer to the published advisory. That record is worth
+having, because how a thing broke is exactly the sort of result this board exists
+to keep, and by the time both conditions hold, publishing it costs nobody
+anything.
+
+How long such a record waits when the fix or the advisory never arrives is a
+judgement rather than an engineering answer, and it is not decided here. What the
+listing shows while a record is held back is part of the same question and is
+also not decided here.
+
+### Software this organisation does not ship
+
+Software this organisation does not ship is outside this decision. The same
+private route usually exists, this board does not set it, and whoever found the
+thing follows that project's own policy. Where that project publishes no policy at
+all, that is a fact about the project and not permission to publish here.
+
+### What enforces this
+
+Nothing. No check reads intent, and nothing in a checkout separates a question
+about performance from a question about a bypass. There is no route here that
+could refuse an experiment for the question it is asking, and this record does not
+create one.
+
+This is a rule a person follows. The only machinery behind it is that the security
+policy and the contributing guide both carry it where somebody reads before
+starting, so the person most likely to be about to break it is the person most
+likely to have just read it. The mechanism is a reader. Calling it anything else
+would be the assurance this repository refuses to make.
+
+## What it applies to
+
+Every experiment on this board, from the moment its question is chosen, and every
+person working on one.
+
+It applies to the question rather than to the finding. An experiment that was
+never going to ask about a flaw and then trips over one is inside this decision,
+which is why the paragraph about the common case is in the first section rather
+than in a footnote.
+
+It does not apply to a flaw in this repository's own runner, which has its own
+route in the security policy.
+
+## What else was considered
+
+Publishing everything immediately, on the reasoning that the board's rule about
+writing the question first admits no exception.
+
+Writing the question here in public but holding back the detail, so the listing
+shows that something is being asked without saying what.
+
+Keeping a private area inside this repository for this class of work.
+
+## What each rejected option would have cost
+
+Publishing immediately costs the people running the software. A public record of
+a live flaw is a working recipe handed to anybody who reads the board, before the
+project that could fix it has heard about it, and the cost lands on operators who
+had no part in the decision. It is also one commit and it cannot be taken back,
+which is why the rule is set before it happens rather than during.
+
+A public question with the detail held back costs more than it saves. A question
+naming the software and saying that its handling of something is being examined
+is most of a disclosure already, and it points a reader at exactly where to look
+while the fix does not exist yet. It also produces a record that says nothing,
+which is the shape this board most wants to avoid, and it would sit in the
+listing looking like an ordinary experiment.
+
+A private area inside this repository costs the one property the board is built
+on. It would mean a tree where some things are visible and some are not, so a
+reader could no longer take the listing as the whole of what is happening here,
+and the exception would be available for anything anybody preferred not to show.
+The private route the affected project publishes already exists and is already
+the right place, so this would be a second one with weaker reasons.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,97 @@
+# Privacy
+
+This board is public, its subject is software that sits next to people's media
+libraries and accounts, and sooner or later something here will want to measure
+against real data. This document says what that means for anybody running
+anything from this repository, in plain language and before the first experiment
+that touches anything real.
+
+## The position
+
+Personal data never leaves the host it is on unless the operator deliberately
+federates it.
+
+Nothing here uploads. Nothing phones home. Nothing reports usage, counts
+installations, sends crash reports or ships a sample anywhere. There is no
+telemetry to turn off, because there is none to turn on.
+
+Where an experiment needs real data to answer its question, the data stays on the
+operator's machine. Only the measurement is written down, and it is written in a
+form that describes what was measured rather than carrying the thing that was
+measured. A record can say that a library of a certain size took a certain time
+to scan. It cannot carry the library, a sample of it, or the names of anything in
+it.
+
+The list of what may never be committed is in
+[docs/decisions/0006-everything-here-is-public.md](decisions/0006-everything-here-is-public.md).
+This document is the operator-facing half of the same position.
+
+## What deliberately means
+
+Deliberately is the load-bearing word above, so it is defined here rather than
+left to be felt.
+
+An operator federates deliberately when they take a specific action whose purpose
+is to send data somewhere, knowing where it goes. Three properties, all of them
+required. The action exists to send. The destination is named where the action is
+taken. And doing nothing sends nothing.
+
+None of the following is deliberate, and a future change can be measured against
+this list:
+
+- A default that sends. If data leaves on first run, the operator did not choose,
+  they arrived.
+- A setting that is on unless the operator finds it and turns it off. Opting out
+  is not choosing.
+- A prompt worded so that agreeing is the easy path, or where the agreeing button
+  is the one styled to be pressed.
+- Sending as a side effect of something else the operator asked for, where the
+  sending is not what they asked for.
+- A single agreement that covers destinations added later. Consent to one
+  destination is not consent to the next one.
+
+## What this does not cover
+
+It says nothing about third-party services, which this board does not control. If
+an experiment talks to a service somebody else runs, what that service does with
+what it receives is between the operator and that service. A promise this board
+cannot keep would be worse than the gap it names.
+
+It says nothing about the operator's own machine. What else is running on the
+host, what the host's own logs retain, and what a backup of it carries are all
+outside anything written here.
+
+It does not settle whether an experiment may use real data at all. This document
+says what happens to real data if an experiment uses it. Whether that is
+permitted in the first place is a wider question, open on issue #46, and issue
+#35 is where the answer gets written down.
+
+It is not a legal characterisation. This is a statement of what the tooling does
+and does not do, not advice about what any particular law requires of an
+operator. The intended-use notice is where that responsibility is placed.
+
+## What stands behind this
+
+Nothing yet, and that is the honest answer rather than a temporary one.
+
+There is no runner in this tree, so the claim that it opens no network connection
+is a commitment about what will be built rather than a description of something
+that exists:
+
+```
+git ls-files cmd internal | wc -l
+0
+```
+
+Issue #34 is where that claim gets a test that proves it, and until that lands the
+sentence above is a promise a reader has to take on trust. Issue #27 keeps the
+list of what the repository depends on, which is the other half of the same
+argument, because a tool with no dependencies has very few places for a network
+call to hide.
+
+The rule about real data staying on the host has no mechanism behind it and can
+have none. Nothing in a checkout can tell a number somebody measured on their own
+machine from a number they made up, and no check reads what an experiment did
+before it wrote its record. Review is where a record carrying something it should
+not is caught, and this is stated plainly here rather than left for a reader to
+assume otherwise.


### PR DESCRIPTION
Six decision records from the first milestone, the privacy position, and the
three README paragraphs their Done-whens ask for. They land together because they
are documents with no code between them, three of them edit `README.md`, and
separate landings would move the mainline under each other for no gain.

One commit per issue, and every record carries the four sections that
`0000-how-decisions-are-recorded.md` fixes in this same change.

Closes #1, closes #3, closes #5, closes #7, closes #33, closes #49, closes #51.

## What is in it

`0000-how-decisions-are-recorded.md` (#1). The directory, the numbering, the
four sections, the rule that a record listing no rejected option is an
announcement rather than a decision, and superseding as the only way a decision
changes. `README.md` links to the directory.

`0002-repository-layout.md` (#3). Each directory and what belongs in it, the
root directories at the commit it lands on, the refusal of a root directory the
record does not name, and the separation rule with its reason.

`0004-what-happens-to-the-code.md` (#5). Records permanent, code removable once
an answer exists, and the line the record gains when code is removed.

`0006-everything-here-is-public.md` (#7). Both halves, and `README.md` carries
the exclusion list and links to the record.

`0009-the-checks-do-not-run-experiment-code.md` (#49). What runs on its own and
what runs only when asked, what the headless requirement therefore binds, what
the harness declaration is and is not, the three rejected options with their
costs, and the condition that reopens the question.

`0010-a-flaw-in-shipped-software.md` (#51). Which experiments do not start here
in public, what is written afterwards and what has to be true first, that
another party's software follows that party's policy, and that nothing enforces
any of it.

`privacy.md` (#33). The position in an operator's language, `deliberately`
defined as three required properties with five shapes that fail them, what the
position does not cover, and what stands behind it today, which is nothing.
`README.md` links it.

## The means

Markdown files in the tree, which is the means every Done-when in these seven
issues names. It carries no runtime and no dependency, it is what a reader
arriving in five years opens without tooling, and it is already what this
repository holds.

## Evidence

Every document is present and every filename matches the one its issue names:

```
$ git ls-tree -r --name-only HEAD -- docs
docs/decisions/0000-how-decisions-are-recorded.md
docs/decisions/0002-repository-layout.md
docs/decisions/0004-what-happens-to-the-code.md
docs/decisions/0006-everything-here-is-public.md
docs/decisions/0009-the-checks-do-not-run-experiment-code.md
docs/decisions/0010-a-flaw-in-shipped-software.md
docs/privacy.md
```

`0002` claims the root of the tree holds two directories at the commit it lands
on. Run at that commit:

```
$ git ls-tree -d --name-only f85871e
.github
docs
```

`privacy.md` claims there is no runner in the tree, which is what makes its
network sentence a commitment rather than a description. Run on this branch:

```
$ git ls-files cmd internal | wc -l
0
```

Every commit here is signed and carries a sign-off matching its author, which is
what the DCO gate reads:

```
$ git log --format='%h %G?' origin/main..HEAD
012be19 G
b6f6b8d G
f0ebfe9 G
4eb953c G
9af3825 G
f85871e G
5daa7d3 G
```

The change touches nothing outside `docs/` and `README.md`:

```
$ git diff --name-only origin/main...HEAD
README.md
docs/decisions/0000-how-decisions-are-recorded.md
docs/decisions/0002-repository-layout.md
docs/decisions/0004-what-happens-to-the-code.md
docs/decisions/0006-everything-here-is-public.md
docs/decisions/0009-the-checks-do-not-run-experiment-code.md
docs/decisions/0010-a-flaw-in-shipped-software.md
docs/privacy.md
```

## What this does not do

No check reads any of these documents. Nothing in the tree refuses a root
directory that `0002` does not name, refuses a commit carrying a credential,
refuses an experiment for the question it is asking, or proves that anything
here opens no network connection. Each document says so in its own text rather
than leaving it to be assumed, and #65, #34 and #27 are where those gaps are
held.

`0006` fixes the boundary at the tree and deliberately does not settle whether an
experiment may work with real data on the host at all. `privacy.md` says the same
thing from the operator's side and points at #35. `0010` deliberately does not
settle how long a held-back record waits. All three are open on #46 and no
Done-when here needs them.

`README.md` is edited here because three of the seven Done-whens require it. The
edits are additive apart from one word in the existing planning paragraph, which
said decisions are written down on the tracker and now says they are argued
there, because `0000` states that a decision existing only in an issue is not yet
recorded.

`dependency-review` is red, and it is red before it looks at the diff:

```
$ gh run view 31278417481 --repo Flowfin/lab --log-failed
##[error]Dependency review is not supported on this repository. Please ensure
that Dependency graph is enabled, see
https://github.com/Flowfin/lab/settings/security_analysis
```

This change declares no dependency, so there is nothing here for the action to
review. The failure is a repository setting and cannot be fixed inside a pull
request. Issue #73 holds it. This waits until that check reports a result or the
gate is dropped with its line of reasoning. Every other check on this pull
request is green.

This has not been read by a second person.
