### PR TITLE
Correct the workflow comments that describe another repository

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,9 +1,11 @@
-# Developer Certificate of Origin (DCO) sign-off gate (#746). A contributor
+# Developer Certificate of Origin (DCO) sign-off gate. A contributor
 # legal-authorization mechanism - OpenSSF Silver / OSPS-LE-01.01 - implemented as a
-# self-contained first-party check, no external DCO App or third-party action (the
-# same internal-only posture as the PR-hygiene gate). It verifies every non-merge
-# commit in the PR carries a `Signed-off-by:` trailer matching its author, i.e. the
-# author asserted the DCO in ./DCO. Fail-closed: any unsigned commit reds the check.
+# self-contained first-party check, with no external DCO App and no third-party
+# action, so the gate depends on nothing outside this repository. It verifies every
+# non-merge commit in the PR carries a `Signed-off-by:` trailer matching its author,
+# i.e. the author asserted the DCO. The DCO text is not in this tree yet; issue #8
+# adds it at ./DCO, which is the path the failure message below already points at.
+# Fail-closed: any unsigned commit reds the check.
 name: DCO
 
 on:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,10 +13,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # No `name:` on this job: the "Protect main" ruleset's required status check
-  # matches the literal check-run name, which defaults to the job id
-  # ("dependency-review") when no `name:` is set. Overriding it here would
-  # rename the check run and silently break the required-status-check gate.
+  # No `name:` on this job: the check-run name defaults to the job id
+  # ("dependency-review") when no `name:` is set, and a required status check
+  # matches that literal name. The ruleset on this board is called `gate` and
+  # requires no status check today, so overriding the name would break nothing
+  # yet. Issue #26 makes the surviving checks required, and from then on a job
+  # renamed in passing removes itself from the required set while the tab still
+  # looks green. Issue #71 builds the refusal that catches that.
   dependency-review:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -3,9 +3,9 @@
 # Scorecard scores the repository against the OpenSSF supply-chain best-practice
 # checks (Branch-Protection, Token-Permissions, Pinned-Dependencies,
 # Dangerous-Workflow, etc.) and uploads the findings as SARIF to the
-# code-scanning tab. The score is treated as a checklist, not a guarantee: each
-# check is triaged (fixed or documented-accept), same as the other security
-# insights.
+# code-scanning tab. The score is meant to be treated as a checklist and not as a
+# guarantee, with each check either fixed or accepted in writing. Nothing does
+# that triage today; issue #27 is where it happens.
 #
 # Runs where publishing is valid: on push to the default branch, on a weekly
 # schedule (keeps the Maintained check fresh and re-scores on upstream changes),
@@ -17,10 +17,11 @@
 # SHA-pinned with a version comment, checkout runs with persist-credentials:false,
 # permissions are declared read-only at the top level and the write scopes are
 # granted only on the job that needs them. This is a self-audit only - it does
-# not build, test, or touch the publish/release pipeline. Note: publish_results
-# below publishes the OpenSSF supply-chain *score* to the OpenSSF API (the public
-# badge), not any software artifact - it is unrelated to the plugin release
-# pipeline and only works when run from the default branch.
+# not build or test anything, and this repository publishes nothing today. Note:
+# publish_results below publishes the OpenSSF supply-chain *score* to the OpenSSF
+# API (the public badge), not any software artifact. When issue #41 builds the
+# release workflow, that is a separate route and this job is still no part of it.
+# publish_results only works when run from the default branch.
 name: Scorecard supply-chain security
 
 on:

--- a/.github/workflows/unicode-guard.yml
+++ b/.github/workflows/unicode-guard.yml
@@ -1,8 +1,9 @@
 name: unicode-guard
 
 on:
-  # Every branch and every PR: the guard is a cheap read-only scan and must cover
-  # any future release branch too, not just main (one code line since #954).
+  # Every branch and every PR: the guard is a cheap read-only scan, so there is no
+  # reason to narrow it to main, and it covers whatever branches this repository
+  # grows later without being edited again.
   push:
     branches: ["**"]
   pull_request:
@@ -39,9 +40,9 @@ jobs:
           # in the PR diff, which defeats the visual-deception the attack relies on). Em dashes,
           # accents, and other benign non-ASCII are not in the set. U+2060 (word joiner) is
           # included as an invisible control with no legitimate use in source. U+FEFF (BOM) is
-          # deliberately NOT listed: a leading UTF-8 BOM is legitimate (solution files often carry one),
-          # so banning it outright would false-positive, and the bidi reordering attack does not
-          # rely on it.
+          # deliberately NOT listed: a leading UTF-8 BOM is legitimate and some editors and
+          # toolchains emit one, so banning it outright would false-positive, and the bidi
+          # reordering attack does not rely on it.
           pattern='(*UTF)[\x{202A}-\x{202E}\x{2066}-\x{2069}\x{200E}\x{200F}\x{061C}\x{200B}-\x{200D}\x{2060}]'
           # git grep: 0 = a match was found, 1 = clean, >=2 = scanner/tooling error. Capture the
           # code (the `|| rc=$?` keeps `set -e` from aborting on the clean exit-1) and FAIL CLOSED

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,6 +1,8 @@
 # Static analysis of the GitHub Actions workflows themselves (zizmor). The
-# workflow YAML is release-critical attack surface - publish-beta.yml runs on
-# every push to main with contents:write - so it is audited like any other code.
+# workflow YAML is the only executable thing this repository has today, and it
+# already runs with write scopes: the scorecard job holds security-events:write
+# and id-token:write, and the job below holds security-events:write. That is
+# attack surface, so it is audited like any other code.
 #
 # The gate runs zizmor's regular persona at --min-severity=low: it fails the
 # build on any actionable (low/medium/high/critical) security finding -
@@ -10,9 +12,9 @@
 # actionable"). The pedantic persona is deliberately NOT used to gate: it adds
 # low-severity hygiene findings (undocumented permissions, missing concurrency,
 # pin-comment mismatches, unnamed jobs) that are stylistic, not security-blocking,
-# and some are context-blind (it would demand run-cancelling concurrency on the
-# release workflows, which must never be cancelled mid-publish). That backlog is
-# tracked as a code-quality task (#263), not gated here.
+# and some are context-blind (it would demand run-cancelling concurrency on a
+# publishing workflow, which must never be cancelled mid-publish). Those findings
+# are not gated here, and no issue on this tracker collects them today.
 #
 # Rule for future workflow changes: every new or edited workflow must pass this
 # gate before merge. Keep actions SHA-pinned, keep checkout on


### PR DESCRIPTION
The comments in the five workflows already in this tree are the only explanation
of why each gate is shaped the way it is. Several of them describe a repository
this is not, so a reader who checks one of the claims against this tree finds it
false, and the next person writing a workflow copies the shape and the sentence
together.

Closes #53.

## What changed, and why each was wrong

`dependency-review.yml` explained that the job carries no `name:` so that the
"Protect main" ruleset's required status check keeps matching. The ruleset on
this board is called `gate` and requires no status check at all:

```
$ gh api repos/Flowfin/lab/rulesets --jq '.[] | {id, name}'
{"id":20573693,"name":"gate"}
$ gh api repos/Flowfin/lab/rulesets/20573693 --jq '[.rules[].type]'
["deletion","non_fast_forward","pull_request"]
```

The reason was a good one and it becomes true in the parity milestone, so the
comment now says what holds today and names #26, which makes the checks
required, and #71, which builds the refusal that catches a rename.

`zizmor.yml` called the workflow YAML release-critical because `publish-beta.yml`
runs on every push to main with `contents:write`. There is no such file here and
nothing in this repository publishes anything:

```
$ git ls-files .github/workflows
.github/workflows/dco.yml
.github/workflows/dependency-review.yml
.github/workflows/scorecard.yml
.github/workflows/unicode-guard.yml
.github/workflows/zizmor.yml
```

The argument survives without that example, so it is now made from the write
scopes these workflows do hold: `security-events: write` and `id-token: write`
on the scorecard job, `security-events: write` on the zizmor job.

`scorecard.yml` separated the published score from a plugin release pipeline.
There is no plugin here. The distinction is still worth drawing, so it is drawn
against the release #41 builds, and the sentence says this repository publishes
nothing today.

Three comments cited `#746`, `#954` and `#263`. Those are another tracker's
numbering. Here they resolve to nothing today and to something unrelated once
this tracker reaches them, which costs more than no reference because a
reference gets followed. Every issue number a comment now cites resolves on this
tracker:

```
$ grep -Eo '#[0-9]+' .github/workflows/*.yml | sort -u
.github/workflows/dco.yml:#8
.github/workflows/dependency-review.yml:#26
.github/workflows/dependency-review.yml:#71
.github/workflows/scorecard.yml:#27
.github/workflows/scorecard.yml:#41
```

Two smaller claims went the same way. The scorecard header said each check is
triaged "same as the other security insights", which describes a practice this
board does not have; it now says nothing does that triage today and names #27.
The unicode guard justified its branch coverage with a decision from another
tracker; it now justifies it from the cost of the scan.

## The means

A text edit to the files themselves, which is the only place a comment can be
corrected. Nothing else was available and nothing was added to the tree.

## Evidence that behaviour is unchanged

Every line the diff touches is a comment line. This prints the changed lines
that are not comments, and it prints none:

```
$ git diff -U0 origin/main...HEAD -- .github/workflows \
    | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-][[:space:]]*#'
$
```

So every trigger, permission, pin, job name and check name is byte for byte what
it was. The check names on this pull request are the same ones the previous run
on this repository reported under.

No comment left under `.github/workflows/` names a ruleset, a file or a pipeline
absent from this repository:

```
$ grep -niE 'protect main|publish-beta|plugin|PR-hygiene|release pipeline' .github/workflows/*.yml
$
```

## What this does not do

The failure message inside the DCO job still points a contributor at
`CONTRIBUTING.md` and `./DCO`, neither of which is in the tree. That is a `run:`
string rather than a comment, and changing it would change what the job prints,
which this issue rules out. #8 adds the DCO text and #9 writes the guide; the
header comment now says the DCO text is not here yet and names #8.

Nothing checks any of this. No route reads a workflow comment for a claim about
the tree, so what stands behind the corrections is a reader.

`dependency-review` is red on this pull request for the same repository-level
reason it is red on every other one, recorded in #73. It fails before it looks at
the diff, and this change adds no dependency.

This has not been read by a second person.
