### PR TITLE
Fix line endings and encodings before the first text check exists

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# Editors read this and produce the bytes .gitattributes would otherwise have to
+# correct on the way into git. The point is to prevent the problem rather than
+# catch it, so the two files say the same thing and neither is the only copy.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# YAML is whitespace-significant and two spaces is what the workflows already in
+# this tree use.
+[*.{yml,yaml}]
+indent_size = 2
+
+# Markdown carries prose. Trailing whitespace is still trimmed here, because
+# nothing in this tree uses the two-space line break and a rule with one
+# exception is a rule people stop trusting.
+[*.md]
+max_line_length = 80
+
+# Makefiles take a tab or they do not run, whatever any other rule says.
+[Makefile]
+indent_style = tab
+
+# Language-specific sections are deliberately absent. Which language the runner
+# is built in is decided in issue #2, and a section written before that answer
+# would be a guess that editors then enforce.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,30 @@
+# The checks this repository grows are text checks. They read tracked files byte
+# by byte, so every checkout has to agree on what those bytes are. This file is
+# what makes them agree, and it lands before the first checker exists.
+
+# Tracked text is stored with LF in git and checked out with LF everywhere.
+# `eol=lf` is unconditional: it overrides core.autocrlf, so a contributor whose
+# git converts by default still gets the same bytes as everybody else, and a
+# carriage return in a diff means somebody typed one.
+* text=auto eol=lf
+
+# The runner's own fixtures have to survive byte for byte. A fixture that exists
+# to prove a carriage return is refused loses that carriage return on the way
+# into git under the rule above, and the test then proves nothing while staying
+# green. `-text` turns every translation off for this tree, in both directions.
+testdata/** -text
+
+# Binary formats, marked so that no translation is attempted and so that a diff
+# does not try to render them as text.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.tar binary
+*.xz binary
+*.woff binary
+*.woff2 binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# What must not reach the tree. This is a convenience and not a control: the
+# list of things that may never be committed is in
+# docs/decisions/0006-everything-here-is-public.md, and nothing here refuses a
+# file somebody adds with `git add -f`.
+
+# Build output. Anchored to the root so a directory of the same name inside an
+# experiment is not ignored by accident.
+/bin/
+/dist/
+/out/
+/build/
+
+# Local scratch. A working directory somebody keeps beside the tree, never part
+# of it. Also anchored, for the same reason.
+/scratch/
+/tmp/
+
+# Editor and tooling state.
+.vscode/
+.idea/
+*.iml
+*.swp
+*.swo
+*~
+
+# Operating system leftovers.
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Local environment. These names carry secrets often enough to be ignored by
+# default, which does not make committing one impossible. Key and certificate
+# extensions are deliberately not listed: a fixture under testdata/ may
+# legitimately carry one, and an ignore rule that silently swallows a fixture is
+# worse than the rule is worth.
+.env
+.env.*
+
+# Language-specific output is deliberately absent for the same reason the
+# editor configuration has no language sections: which language the runner is
+# built in is decided in issue #2, and the answer brings its own list.


### PR DESCRIPTION
Three files, landed before any checker exists, so that every checkout agrees on
what the bytes of a tracked file are.

Closes #11.

## What is in it

`.gitattributes` stores tracked text as LF and checks it out as LF everywhere.
It uses `eol=lf` rather than `text` alone, because `text` leaves the working-tree
ending to each contributor's `core.autocrlf` and `eol=lf` overrides it. It also
marks `testdata/**` as `-text`, so the runner's fixtures pass through git
untranslated in both directions: a fixture that exists to prove a carriage return
is refused would otherwise lose that carriage return on the way in and go on
passing while proving nothing.

`.editorconfig` gives editors the same answer, so the bytes are right before git
sees them. It carries no language-specific section, because which language the
runner is built in is decided in #2 and a section written now would be a guess
that editors then enforce.

`.gitignore` keeps build output, editor state and local scratch out of the tree,
anchored at the root so a directory of the same name inside an experiment is not
swallowed. Key and certificate extensions are deliberately not listed: a fixture
under `testdata/` may legitimately carry one, and an ignore rule that silently
swallows a fixture costs more than it saves.

## The means

Git's own attribute file, an EditorConfig file and an ignore file. The property
has to hold at the moment a file enters or leaves git, which is where
`.gitattributes` sits and where nothing written in another language could reach.
It adds no runtime and no dependency, and `.editorconfig` is read by the editors
people already use rather than by anything installed for this.

## Evidence

Renormalising the existing tree changes no blob, so this fixes what happens next
rather than repairing what is here:

```
$ git add --renormalize . && git status --short
A  .editorconfig
A  .gitattributes
A  .gitignore
```

A fresh clone of this branch, made with the translating setting switched on, has
LF in every working-tree file and no carriage return anywhere:

```
$ git -c core.autocrlf=true clone --branch scaffolding/line-endings-and-encodings <repo> fresh-clone
$ cd fresh-clone && git config --get core.autocrlf
true
$ git ls-files --eol
i/lf    w/lf    attr/text=auto eol=lf   .editorconfig
i/lf    w/lf    attr/text=auto eol=lf   .gitattributes
i/lf    w/lf    attr/text=auto eol=lf   .github/workflows/dco.yml
i/lf    w/lf    attr/text=auto eol=lf   .github/workflows/dependency-review.yml
i/lf    w/lf    attr/text=auto eol=lf   .github/workflows/scorecard.yml
i/lf    w/lf    attr/text=auto eol=lf   .github/workflows/unicode-guard.yml
i/lf    w/lf    attr/text=auto eol=lf   .github/workflows/zizmor.yml
i/lf    w/lf    attr/text=auto eol=lf   .gitignore
i/lf    w/lf    attr/text=auto eol=lf   NOTICE.md
i/lf    w/lf    attr/text=auto eol=lf   README.md
$ grep -rlU $'\r' . --exclude-dir=.git
$
```

In that clone, `git hash-object` on each working-tree file equals the blob git
stores for it, which is the object every other clone of this commit holds:

```
$ git ls-files | while read -r f; do printf '%s  %s  %s\n' "$(git hash-object "$f")" "$(git rev-parse ":$f")" "$f"; done
2219322db76af2f6b2a793194c2ff06fcb8a5830  2219322db76af2f6b2a793194c2ff06fcb8a5830  .editorconfig
2487e091e87f23c415636b5a9a3bd512f02d5fd4  2487e091e87f23c415636b5a9a3bd512f02d5fd4  .gitattributes
5b53eab934abf424af0a207534d1864744c2395e  5b53eab934abf424af0a207534d1864744c2395e  .github/workflows/dco.yml
925674cff0008ad114b9cdf1f92c4f88bf4a512a  925674cff0008ad114b9cdf1f92c4f88bf4a512a  .github/workflows/dependency-review.yml
902f79336aff724c237ceea8a138e0a8091c4665  902f79336aff724c237ceea8a138e0a8091c4665  .github/workflows/scorecard.yml
60083b70eb2762026be377a0baa2d540f33719f7  60083b70eb2762026be377a0baa2d540f33719f7  .github/workflows/unicode-guard.yml
00e17fa0fa0a11496512e96585333d91681807d9  00e17fa0fa0a11496512e96585333d91681807d9  .github/workflows/zizmor.yml
49780e845d6f4d8b4f419d6494c659bb3a299f95  49780e845d6f4d8b4f419d6494c659bb3a299f95  .gitignore
c5d614a625f51be424403e8ce93512b17e404f84  c5d614a625f51be424403e8ce93512b17e404f84  NOTICE.md
4d5fd06c446d49255eb749536d254836dc8a4121  4d5fd06c446d49255eb749536d254836dc8a4121  README.md
```

## The guard bites

The same clone command, on the same machine, against `main`, which does not have
these files yet. Every tracked text file arrives with carriage returns:

```
$ git -c core.autocrlf=true clone --branch main <repo> clone-without-guard
$ cd clone-without-guard && git ls-files --eol
i/lf    w/crlf  attr/                   .github/workflows/dco.yml
i/lf    w/crlf  attr/                   .github/workflows/dependency-review.yml
i/lf    w/crlf  attr/                   .github/workflows/scorecard.yml
i/lf    w/crlf  attr/                   .github/workflows/unicode-guard.yml
i/lf    w/crlf  attr/                   .github/workflows/zizmor.yml
i/lf    w/crlf  attr/                   NOTICE.md
i/lf    w/crlf  attr/                   README.md
$ grep -rlU $'\r' . --exclude-dir=.git | sort
./.github/workflows/dco.yml
./.github/workflows/dependency-review.yml
./.github/workflows/scorecard.yml
./.github/workflows/unicode-guard.yml
./.github/workflows/zizmor.yml
./NOTICE.md
./README.md
```

So the difference between the two clones is these three files and nothing else.

## What this does not do

Both clones above were made on Windows. The Linux half of the Done-when was not
run here, so it is derived rather than measured: `eol=lf` is unconditional, and a
platform that does not translate by default has nothing to translate, so both
ends of the comparison are the stored blob. The measurement that would close that
gap is the same two commands on Linux, and #57 is where a run on more than one
platform gets built.

Nothing refuses a violation. `.gitattributes` shapes what git does; it does not
report a file somebody forces past it, and no check in this tree reads line
endings yet.

An existing checkout made before this lands keeps its carriage returns until the
files are checked out again. That is a property of git rather than of this
change, and it is why the fresh clones above are the measurement rather than this
working copy.

`.gitignore` names `/bin/`, `/dist/`, `/out/`, `/build/`, `/scratch/` and
`/tmp/` at the root, and `docs/decisions/0002-repository-layout.md` refuses a
root directory it does not name. Those two do not conflict today, because an
ignored directory is untracked and the layout record is about the tree, but the
refusal built in #65 has to decide which of the two it reads. It is named here so
that decision is taken rather than discovered.

`dependency-review` is red on this pull request for the repository-level reason
recorded in #73. It fails before it looks at the diff, and this change adds no
dependency.

This has not been read by a second person.
