### PR TITLE
Record the remaining decisions the first milestone owes

### DIFF
--- a/docs/decisions/0001-the-runner-is-written-in-go.md
+++ b/docs/decisions/0001-the-runner-is-written-in-go.md
@@ -1,0 +1,115 @@
+# 0001. The runner is written in Go
+
+## What was decided
+
+The runner is written in Go, and the version this repository pins is the 1.26
+line. The module declares it and every job that sets up a toolchain names the
+same line, so a contributor running the checker in a checkout and a job running
+it on a build machine are running the same language.
+
+Nothing in the tree pins anything yet, because the module does not exist. At the
+commit this record lands on there is no `go.mod`:
+
+    git ls-files go.mod
+    (no output)
+
+The record fixes the choice and issue #12 creates the module that carries it.
+Which patch release of the 1.26 line a given run uses is not written here. A
+version restated in a document drifts against the file that decides it, and the
+module is the file that decides it.
+
+Four reasons, in the order they matter to this repository.
+
+An operator can run the checker without installing anything. Go builds a single
+static binary per platform from one build machine, so somebody who wants to
+check this board's claims downloads a file and runs it. That matters more here
+than it would elsewhere, because the whole argument for this repository is that
+its claims can be checked by somebody who does not already trust it, and a
+person who has to install a toolchain belonging to the project they are
+checking is in a weaker position than one who does not.
+
+The runner's job is a job Go does with nothing outside its standard library.
+Reading a checkout, walking a directory, parsing text records and refusing the
+malformed ones is filesystem and string work. A checker that decides whether
+this repository's rules were kept is security relevant in the small way that
+matters, which is that somebody will eventually rely on its verdict, so the
+number of third-party packages that could change what that verdict says stays
+near zero.
+
+The test harness is part of the toolchain. This repository requires a test for
+every refusal it ships, so the harness is load-bearing rather than convenient,
+and a harness that arrives with the language is one nobody has to choose,
+version or replace later.
+
+It keeps the runner independent of the experiments. An experiment here is
+written in whatever the question needs, and the tool that judges the records is
+not allowed to acquire a dependency on any of that. Record `0002` already stops
+the runner importing anything under `experiments/`, and a language the
+experiments have no reason to share keeps that separation from eroding by
+habit.
+
+The cost being paid knowingly is that this organisation gains a second
+toolchain alongside .NET. It is accepted because the runner is not a plugin,
+never ships inside one, and is downloaded rather than built by most of the
+people who will use it, so the second toolchain is a cost carried by whoever
+works on the runner and by nobody else.
+
+## What it applies to
+
+The runner and everything under `cmd/lab/` and `internal/`. It applies to the
+checks that read records, since those are part of the runner, and to the
+runner's own fixtures under `testdata/`.
+
+It applies to nothing under `experiments/`. An experiment is written in whatever
+answers its question, and this record is not a preference for Go anywhere except
+in the tool that judges records. An experiment written in C#, Python or shell is
+in no tension with it.
+
+It does not settle what a released binary is or whether one is published at all.
+Which platforms the runner builds and runs its suite on is record `0012`.
+Whether this board publishes downloadable artefacts is entry four of issue #46
+and is not decided here.
+
+## What else was considered
+
+C# and .NET, which is what the plugin work in this organisation is built in.
+
+Python.
+
+Shell.
+
+Rust.
+
+## What each rejected option would have cost
+
+C# and .NET is the option with the strongest argument behind it, and the
+argument is about the wrong artefact. An experiment that graduates from this
+board is likely to be C#, because the boards it graduates to are, and that is a
+statement about the experiments rather than about the tool that reads their
+records. Choosing it would mean somebody who only wants to check this
+repository installs an SDK first, which costs exactly the property the first
+reason above was chosen for. It would also put the runner in the same toolchain
+as the code it is meant to stay independent of, so the separation record `0002`
+builds would rest on discipline rather than on the two having nothing in common.
+
+Python is good at the text work this runner does, and shipping it to an operator
+means shipping an interpreter or a bundler with it. That packaging cost is paid
+on every platform, every release, and it lands on the person who wanted to check
+a repository rather than on the person who chose the language. The writing
+convenience is real and it is smaller than what it costs at the far end.
+
+Shell costs the thing this repository's central claim rests on. A board whose
+argument is that a machine refuses violations cannot rest that machine on a
+language with no test harness and no type checking, so the proof that a refusal
+bites would have to be built from scratch and maintained by hand. Word splitting
+has broken gates of exactly this kind before, and the failure is quiet: a gate
+that word-splits its input refuses valid work and passes the rest, which reads
+as a strict check rather than as a broken one.
+
+Rust would meet every reason above and costs more than it buys here. The runner
+has no performance requirement worth the compile times and no memory-safety
+requirement that Go does not already meet for a program that reads text and
+exits, so the additional cost is paid in how long a contributor waits and in how
+many people can read the checker without learning a language first. It is not
+rejected as unsuitable, and if this tool ever grows a reason that Go cannot
+meet, superseding this record with one that takes it is the route.

--- a/docs/decisions/0003-the-experiment-lifecycle.md
+++ b/docs/decisions/0003-the-experiment-lifecycle.md
@@ -1,0 +1,117 @@
+# 0003. The experiment lifecycle
+
+## What was decided
+
+An experiment has three states and no others: `asking`, `answered`, `abandoned`.
+A record carries exactly one of them. A fourth state is a change to this record
+rather than a value somebody adds while writing an experiment up.
+
+`asking` means the question is written and the work is running. A record enters
+this state in the same commit that creates the experiment directory, so no
+experiment exists in this tree without a question. What the state requires is a
+question that a reader who was not there can tell has been answered or not. A
+question written as a topic rather than as a question fails that, and it fails
+it quietly, because a record whose question is "media transcoding" can never be
+shown to have missed its answer.
+
+`answered` means the work stopped and the answer is written. What the state
+requires is an answer that says what was learned. No is an answer. So is the
+finding that the question turned out to be the wrong question, and that one is
+often the most useful thing an experiment produces. An answered experiment is
+finished whichever way it went, and nothing here treats a no as a lesser
+outcome, because a board that did would collect experiments that were never
+allowed to fail.
+
+`abandoned` means the work stopped and nobody wrote an answer. It is a
+legitimate state and it is meant to be uncomfortable to sit in. What it requires
+is a sentence saying what stopped the work, which is a lower bar than an answer
+on purpose: the point is that moving here is always available and always cheaper
+than the alternative, which is leaving a record in `asking` while nothing
+happens. A record can be moved here honestly at any time, by the person who
+started it or by anybody else reading the tree.
+
+The transitions are `asking` to `answered` and `asking` to `abandoned`. An
+abandoned experiment that somebody picks up again returns to `asking`, because
+the work is running again and the record should say so. Nothing goes directly to
+`answered` without having been `asking`, since the question has to exist before
+the answer does, and the commit that creates the directory is where it starts.
+
+What a machine can do here is small and it is worth writing down next to the
+rule, so that nobody reads the three states as an enforcement mechanism.
+
+A machine can refuse a record that claims `answered` and carries no answer. It
+can refuse a record whose state is not one of the three. It can refuse a record
+that never wrote a question. It can make a record that has been in `asking`
+without movement visible in a listing, so that a stalled experiment is a line
+somebody reads rather than a directory nobody opens.
+
+What no machine here can do is make a person finish an experiment, write an
+honest answer, or move a dead record to `abandoned`. There is no measurement of
+whether an answer is true, whether it follows from the work, or whether the
+person who wrote it believed it. A record saying "no, this does not work" and a
+record saying it while the author knows otherwise are the same bytes. Review is
+the only thing that catches the second, and review is a person.
+
+The listing is therefore the load-bearing half rather than the refusals. A
+refusal stops a record that contradicts itself, which is a small class of
+mistake. Visibility is what stops the failure this board was opened against,
+which is a directory of half-finished things nobody can read, and it works by
+being read rather than by refusing anything.
+
+## What it applies to
+
+Every experiment under `experiments/`, from the commit that creates its
+directory onwards, and the record checks that read those records.
+
+It applies to the listing the runner prints, which reports the state of every
+record it finds and is the route by which a stalled experiment becomes visible.
+
+It does not apply to the decision records in `docs/decisions/`. Those are not
+experiments, they carry no state, and they change by superseding, which record
+`0000` sets out.
+
+It does not decide the shape of the record that carries the state. Which fields
+an `EXPERIMENT.md` has and how the state is written down is fixed separately, in
+issue #15, and this record fixes only what the states are and what each one
+requires.
+
+## What else was considered
+
+Two states, running and finished, with the answer optional.
+
+Four states, adding one for an experiment that is paused rather than abandoned.
+
+A state for an experiment whose answer was yes and which has been promoted
+elsewhere.
+
+No states at all, with a record read as finished once an answer section is
+present.
+
+## What each rejected option would have cost
+
+Two states cost the distinction this whole record exists to make. An experiment
+that stopped with an answer and one that stopped because somebody lost interest
+would read identically from outside, which is precisely the state this board was
+opened to make impossible. It also removes the only pressure that exists here:
+if there is no name for stopping without an answer, nobody has to admit to it.
+
+A paused state costs the discomfort. Paused is what abandoned is called by
+somebody who does not want to write the sentence saying what stopped the work,
+and it would absorb every record that should have moved to `abandoned` while
+looking like an active tree. The honest version of paused is `abandoned` with a
+sentence saying the work may resume, which costs one sentence and stays true if
+it never does.
+
+A promoted state costs the meaning of `answered`. An experiment that was
+promoted is still answered, and its answer did not change when somebody else
+picked the work up. Record `0005` makes promotion a section the record gains
+rather than a state it moves to, exactly so that the state keeps saying what
+happened to the question rather than what happened to the code afterwards. A
+promoted state would also have no honest value for an experiment that answered
+no, which is most of them.
+
+No states at all costs the refusal. A record read as finished because it has an
+answer section can be finished by adding an empty answer section, and there
+would be nothing for a check to compare against, since the claim and the
+evidence would be the same text. Naming the state separately from the answer is
+what makes "claims answered, carries no answer" a thing a machine can see.

--- a/docs/decisions/0005-how-a-result-leaves.md
+++ b/docs/decisions/0005-how-a-result-leaves.md
@@ -1,0 +1,113 @@
+# 0005. How a result leaves this board
+
+## What was decided
+
+Promotion is a hand-over rather than a transfer, and it is recorded on both
+sides.
+
+An experiment that answered yes and is wanted somewhere else gains a promotion
+section in its record. The experiment's state does not change, because it is
+still answered and record `0003` keeps the state saying what happened to the
+question. What changes is that the record now says where the answer went.
+
+The promotion section names four things and nothing about it is optional.
+
+The destination repository. Where the work continued, written as the repository
+rather than as a description of it.
+
+The issue on the destination board that has agreed to pick the work up. Agreed,
+not proposed. An issue that exists and says the work is wanted is the whole
+evidence that this was a hand-over and not something thrown over a wall.
+
+The commit range here that holds the result. What was handed over, at the
+granularity somebody can actually check out, so that a reader on the other side
+can see the thing as it was rather than as the tree became later.
+
+The licence the code carries out. The terms the receiving board is taking it
+under, stated at the moment of the hand-over rather than inferred afterwards
+from whatever this repository's licence file said on some later day.
+
+Promotion never happens by pushing code into another repository from here. A
+product board takes work by its own rules, through its own issue and its own
+review, and it is entitled to reject what it takes, rewrite it, or take the idea
+and none of the code. This board's part ends at producing something worth taking
+and a record that says what it is. Nothing in this repository ever writes to
+another one, and no route that would need such a write is built.
+
+The reason the destination issue is named rather than described is that a
+description drifts and a link does not. A reader following a promotion record
+should land on the place where the work continued, or on nothing at all, and
+never on a sentence that used to be true. Landing on nothing is a readable
+outcome, because it says the destination is gone; landing on prose that
+disagrees with the destination is not, because there is no way to tell which of
+the two is out of date.
+
+What this cannot do. Nothing here checks that the destination issue exists, that
+it agreed to anything, or that the commit range is the one the receiving board
+took. A promotion section can name an issue nobody opened. The refusal built in
+issue #39 catches a promotion section that points at nothing, which is the
+structural half, and the rest is what a reader sees when they follow the link.
+
+Whether a result may be promoted into a board whose terms differ from this one,
+and who is entitled to place a contributor's work under those terms, is entry
+three of issue #46 and is not decided here. This record fixes what the section
+names, which is the same either way, and the answer to that entry decides who
+may fill it in.
+
+## What it applies to
+
+Every experiment record under `experiments/` that has answered yes and whose
+result is wanted elsewhere. The section is added by the change that hands the
+work over.
+
+It applies to the promotion checklist in issue #38, which is what somebody works
+through before the section is written, and to the refusal in issue #39, which
+reads the section afterwards.
+
+It does not apply to an experiment that answered no. There is nothing to hand
+over, and the record is finished as it stands. It also does not apply to
+somebody copying an idea out of a record without any code moving, which needs no
+section, because nothing left this board.
+
+## What else was considered
+
+Moving the code into the destination repository directly, by pushing a branch
+there from here.
+
+Recording the promotion only on the destination board, since that is where the
+work continues.
+
+Recording it only here, and leaving the destination board to decide whether it
+wants to mention where the work came from.
+
+Moving a promoted experiment to a state of its own, or out of `experiments/`
+into a directory of things that graduated.
+
+## What each rejected option would have cost
+
+Pushing a branch into the destination repository costs that board its own
+process. Work would arrive already written, outside its review, against
+whatever conventions this board happens to have, and the receiving side would
+have to either take it as it is or unpick it. It also needs a credential here
+that can write to another repository, which is a permission this board has no
+reason to hold and every reason not to, on a tree that is public and that
+strangers are invited to read.
+
+Recording it only on the destination board costs this side its own history. A
+reader here would see an experiment that answered yes and stopped, with nothing
+saying the result went anywhere, and would have to search the organisation to
+find out. That reader is exactly the person the board exists for, since finding
+out what came of an experiment is why anybody reads one.
+
+Recording it only here costs the other half. A destination board carrying work
+whose origin is not written down loses the ability to answer where a thing came
+from, which is the question that gets asked when the work turns out to be wrong.
+Naming the destination issue is what makes it recorded on both sides at once,
+because the issue is on the other board and says the work was taken.
+
+A separate state or a graduated directory costs the meaning of `answered` and
+costs the walk. Record `0003` keeps the three states about the question rather
+than about what happened to the code afterwards, and record `0002` fixes one
+directory per experiment so a checker finds every record by walking one tree.
+Moving a promoted experiment out of that tree means the records a reader most
+wants to find are the ones that are no longer where the walk looks.

--- a/docs/decisions/0007-headless-by-birth.md
+++ b/docs/decisions/0007-headless-by-birth.md
@@ -1,0 +1,111 @@
+# 0007. Headless and unelevated, as a birth requirement
+
+## What was decided
+
+Every test in the default run completes with no graphical session and as an
+ordinary user. Both halves bind from the first test this repository has, not
+from the milestone that builds the mechanisms enforcing them.
+
+The word that matters is birth. The test harness the scaffolding milestone
+builds already owes a green run with no display and no elevated privileges, so
+the requirement is load-bearing before the work that depends on it starts. A
+requirement written down after the first thing that depends on it has been
+retrofitted, whatever the document later says about it, and a retrofitted
+requirement is one that has already been negotiated with once.
+
+No display. Every test in the default run completes on a machine with no
+graphical session available at all. That is what makes the suite runnable on a
+build machine, inside a container, and over a remote shell, which between them
+are most of the places it will ever run. A suite that needs a display runs on
+one machine, and a suite that runs on one machine stops being evidence the first
+time that machine is unavailable and somebody says the tests passed yesterday.
+
+No elevation. Every test in the default run completes as an ordinary user. A
+test that needs administrator rights is a defect rather than a step to write
+into the instructions, and the reason is worth stating because the failure is
+subtle rather than loud. Where elevation is needed it is usually needed for one
+narrow thing, such as binding a socket to a real interface address instead of
+loopback, and the operating system responds by asking a question only an
+administrator can answer. On some systems that question is asked about the
+executable path rather than about the project, so answering it once settles
+nothing for the next build directory. The result is a suite that intermittently
+stops on a dialog nobody is watching, on somebody else's machine, which is
+indistinguishable from a hang.
+
+A test that genuinely cannot meet both halves does not get an exception. It
+moves to the separate hardware harness the headless milestone builds, which is a
+different thing with a different name and is not part of the default run. The
+default run stays clean, and a reader who sees it green knows what was covered
+because the things it cannot cover are somewhere else with their own name rather
+than skipped inside it. That harness does not exist at the commit this record
+lands on, and the record names the rule rather than the mechanism. That is the
+right order rather than a gap in it: the rule is what the harness will be built
+to serve.
+
+What the rule does not buy. Neither half is a security property. Running as an
+ordinary user is not a sandbox, it does not make the runner safe to point at an
+untrusted tree, and it does not bound what a test can read or write inside the
+account it runs as. Running without a display is not isolation either. Both
+halves are about where the evidence can be produced, so that a green suite means
+the same thing on every machine that runs it, and neither says anything about
+what the code under test is allowed to do. Treating this record as a security
+control would be reading a portability rule as a boundary.
+
+## What it applies to
+
+The default run: whatever this repository's suite executes when somebody runs it
+with no arguments and no opt-in, in a checkout or on a build machine.
+
+It applies to the record checks and to the runner's own tests, which are what
+runs on its own under record `0009`. It applies to any test added later that
+lands in the default run, whoever adds it and whatever it is for.
+
+It does not apply to the hardware harness. That harness exists precisely for the
+tests that cannot meet these halves, and holding it to them would leave nowhere
+for such a test to go.
+
+It does not apply to an experiment's own tests. Record `0009` keeps every
+automatic run out of `experiments/`, so nothing here runs them and this record
+makes no claim about them. An experiment that can only be answered on a machine
+with a screen attached is a legitimate experiment.
+
+## What else was considered
+
+Requiring it only of the checks that run automatically, and letting a test that
+somebody runs by hand need a display or elevation.
+
+Allowing a test to require elevation and documenting the requirement, so that
+whoever runs the suite knows to start it as an administrator.
+
+Allowing such a test to skip itself when it detects no display or no elevation.
+
+Deferring the rule to the milestone that builds the harness, on the reasoning
+that a rule with no mechanism is only prose.
+
+## What each rejected option would have cost
+
+Restricting the rule to automatic runs costs the case it exists for. The place
+where a display requirement hurts is a contributor's machine, a container, or a
+remote shell, and those are all hand runs. A rule that binds the build machine
+and releases the contributor produces a suite that is green in the one place
+nobody was worried about.
+
+Documenting an elevation requirement costs the evidence. A suite somebody starts
+as an administrator is a suite that runs differently on the machine of whoever
+did not read the instruction, and it moves the requirement onto every person who
+ever runs it rather than onto the one person who wrote the test. It also means
+the consent question above gets asked in the ordinary course of work, which
+trains whoever sits at the machine to answer it without reading it.
+
+A self-skipping test is the most expensive of the four, because it looks like
+the cheapest. The suite stays green while covering less, and the amount less is
+invisible unless somebody reads the run output carefully enough to notice a skip
+that has become normal. That is worse than a red test, because a red test is
+acted on. Issue #31 makes a skip in the hardware harness say what was missing,
+which is the same problem handled in the place where a skip is legitimate.
+
+Deferring the rule costs the word birth and nothing else, which is the whole
+point. The mechanism is not what this record is; the mechanism is issue #29,
+which proves the default suite runs with no display and no elevation. A rule
+written after the first suite exists is a rule the first suite was not built to,
+and every test written in between is one somebody has to go back and check.

--- a/docs/decisions/0012-the-supported-platforms.md
+++ b/docs/decisions/0012-the-supported-platforms.md
@@ -1,0 +1,133 @@
+# 0012. The supported platforms and the release targets
+
+## What was decided
+
+Three issues in this plan depend on a list of platforms and none of them creates
+it. The build workflow covers the platforms the release will later target, the
+suite runs on every platform the release ships a binary for, and the release
+workflow produces a binary for each platform the build already covers. All three
+point at a set nothing fixes. This record fixes it, before the first workflow is
+written against it.
+
+The list is decided from what the runner does. The runner reads a checkout, and
+the parts of that job which differ between machines are what earn a place:
+whether the filesystem folds case, what separates a path, and what a line ending
+arrives as. A platform differing in any of those is a platform the suite has to
+run on. A platform differing only in processor architecture is a platform the
+release builds for, and running the suite there buys much less.
+
+Six platforms. Three get a build and a suite run, three get a build only.
+
+`linux/amd64`, build and suite. Case-sensitive filesystem, `/` as the separator,
+LF endings. This is where the checks themselves run and where most build
+machines are, so it is the baseline every other entry is read against.
+
+`windows/amd64`, build and suite. The filesystem folds case, `\` separates a
+path, and text arrives with CRLF unless something stops it. It differs from the
+baseline in all three of the properties the runner's job depends on, which makes
+it the entry that would find the most defects if it were left off, and it is
+also where a large share of this organisation's contributors work.
+
+`darwin/arm64`, build and suite. `/` separates a path and endings are LF, so it
+agrees with the baseline on two of the three, and its default filesystem
+preserves case while comparing without it. That third property is a real
+difference and it is the one that behaves unlike either of the other two
+entries: a path that is refused on Linux and accepted on Windows may be accepted
+here while the bytes on disk keep the case that was written. A checker that gets
+case handling wrong stays green on the baseline, so the entry earns its run.
+
+`linux/arm64`, build only. Same filesystem behaviour, same separator, same
+endings as the baseline. What differs is the processor, and nothing the runner
+does is sensitive to it.
+
+`darwin/arm64` is covered above, so `darwin/amd64` is build only for the same
+reason: it differs from an entry that already runs the suite in processor
+architecture alone.
+
+`windows/arm64`, build only. It differs from `windows/amd64` in processor
+architecture alone, and `windows/amd64` runs the suite.
+
+So this repository builds for six platforms and produces evidence on three. The
+three it builds for and does not test on are `linux/arm64`, `darwin/amd64` and
+`windows/arm64`. That sentence is here rather than left to be inferred, because
+a green board across a matrix implies coverage, and on those three entries the
+green means the compiler accepted the source and nothing more.
+
+Whether a hosted runner is offered for each of those three is a separate
+question from this decision and does not move it. Where one is not offered, the
+entry is build-only by necessity rather than by choice, and the list is the
+same. What that question decides is whether the gap could be closed by paying
+for it, and the first workflow written against this record is where it gets
+settled, since a run either arrives on the label or does not. Until such a run
+exists, any statement here about which labels are available would be a claim
+rather than a measurement, so none is made.
+
+What each entry costs. Every platform on this list can hold a merge on its own,
+and that is the point of having it rather than a drawback of it. The suite
+entries cost a run each on every pull request, and they cost the slowest of the
+three in wall time, since a merge waits for the last one. The build-only entries
+cost a compile each and produce no evidence, so their whole value is that a
+release does not discover on the day it is cut that the source does not build
+somewhere. The shared cost across all six is that a platform nobody uses
+produces failures nobody acts on, which teaches readers that red is survivable,
+and that is the reason the list is six rather than everything the toolchain can
+target.
+
+This record fixes which platforms a release targets. It does not decide whether
+this board publishes downloadable release artefacts at all, which is entry four
+of issue #46 and is open. If the answer there is source only, the three
+build-only entries lose their reason and this record is superseded by one that
+says so. The three suite entries do not depend on that answer, because a
+contributor runs the checker in a checkout whether or not anything is ever
+published.
+
+## What it applies to
+
+The build and test workflow in issue #13, the platform suite in issue #57, and
+the release workflow in issue #41. Each of them names exactly the platforms this
+record names and no others, in the role this record gives them.
+
+It applies to the platform any later work assumes. A check written to a path
+separator or to a case-folding rule is written against this list rather than
+against whatever machine its author is sitting at.
+
+It does not apply to experiments. What an experiment runs on is a property of
+the question it asks, and record `0009` keeps every automatic run out of
+`experiments/` in any case.
+
+## What else was considered
+
+Building everything the toolchain can target.
+
+Building for one platform only.
+
+Running the suite on all six entries.
+
+Running the suite on the baseline only, and treating the other entries as build
+targets.
+
+## What each rejected option would have cost
+
+Building everything the toolchain can target costs the list its status as a
+decision. It would become a property of the compiler, changing when the compiler
+changes, and most of the entries would have no contributor, no runner and no way
+to reproduce a failure. A failing build on a platform nobody can check out is a
+merge held by something nobody can fix.
+
+Building for one platform only costs the tool its ability to read its own
+repository. Case folding and line endings are exactly the defects a checker of
+this kind has, and they are defects on the platforms this organisation's
+contributors actually use. Shipping a single-platform release means the people
+most likely to trip the checker are the people who cannot run it.
+
+Running the suite on all six costs twice the runs for evidence that repeats
+itself. An arm64 run of a program that reads text and exits exercises the same
+paths as the amd64 run beside it, so the second run of each pair would be a
+merge-holding job whose failures would almost always be infrastructure rather
+than the runner.
+
+Running the suite on the baseline only is the cheapest option and it costs the
+reason the list was written from the runner's job rather than from convention.
+The baseline is the one platform where case folding, path separators and line
+endings all behave the way the code was most likely written to assume, so it is
+the platform least able to catch the mistakes this checker will make.


### PR DESCRIPTION
Five decision records, one per commit, in the shape record `0000` fixes. They
are the decisions the rest of the plan is written against, and none of them
adds code.

- `0001-the-runner-is-written-in-go.md`, issue #2
- `0003-the-experiment-lifecycle.md`, issue #4
- `0005-how-a-result-leaves.md`, issue #6
- `0007-headless-by-birth.md`, issue #28
- `0012-the-supported-platforms.md`, issue #60

They share one branch because they are all documents under one directory and
nothing here builds. Landing them separately would move the base under each of
the others for no reading benefit.

## The means

Markdown under `docs/decisions/`, which is what record `0000` already fixed for
this class of artefact. Nothing else was weighed, because the means for a
decision record is not an open question on this board and choosing differently
would be the change rather than the record.

## Evidence

The records hold to the file rules this tree already carries. No line over the
80 columns `.editorconfig` sets for Markdown, no carriage return, no trailing
whitespace, no byte outside ASCII, and a final newline on each file:

    for f in docs/decisions/000{1,3,5,7}-*.md docs/decisions/0012-*.md; do
      awk 'length($0)>80 {print FILENAME": "NR}' "$f"
      grep -nP '[^\x00-\x7F]|[ \t]+$|\r' "$f"
    done
    (no output)

Every path named in prose resolves. `docs/decisions/0000-how-decisions-are-recorded.md`,
`0002-repository-layout.md` and `0009-the-checks-do-not-run-experiment-code.md`
are on the default branch, and `0003`, `0005`, `0009` and `0012` reference each
other inside this change:

    git ls-tree --name-only origin/main docs/decisions/
    docs/decisions/0000-how-decisions-are-recorded.md
    docs/decisions/0002-repository-layout.md
    docs/decisions/0004-what-happens-to-the-code.md
    docs/decisions/0006-everything-here-is-public.md
    docs/decisions/0009-the-checks-do-not-run-experiment-code.md
    docs/decisions/0010-a-flaw-in-shipped-software.md

The numbers come from the issues rather than from the order the files arrived
in, and none collides with a number already on the default branch.

## What is not covered

Nobody other than the author has read this change. There is no second reader on
it, and the evidence above stands in place of one rather than alongside one.

`0001` names the 1.26 line as what the module will declare and states that no
`go.mod` exists yet. It is a decision about what will be pinned, not a
measurement of what is pinned, and the record says so in its own text.

`0012` does not close #60. That issue's done-condition also requires the build
workflow, the platform suite and the release workflow to name exactly these
platforms and no others, and none of those three files exists in this tree yet.
The reason is written into #60 and the issue stays open.

`0012` also rests on an open question. Whether this board publishes downloadable
release artefacts at all is entry four of #46, and if the answer is source only
the three build-only entries lose their reason. The record names that dependency
in its own text rather than assuming the answer.

Closes #2
Closes #4
Closes #6
Closes #28
