### PR TITLE
Add the DCO text the sign-off gate already points at

### DIFF
--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
`DCO` at the repository root, Developer Certificate of Origin version 1.1,
verbatim. The sign-off workflow's failure message already names `./DCO` and the
file was not there.

## The means

A plain text file at the root, which is where every project using this text puts
it and where the workflow's own message points. It is not Markdown, because the
text is a fixed document rather than something this repository formats, and
rendering it would invite the paraphrase the issue warns against.

## Evidence

The file was taken from the published text rather than retyped. It matches that
text line for line once trailing whitespace is stripped from both sides, which is
the departure `#8` allows and which `.editorconfig` requires of every file here:

    curl -sS -L https://developercertificate.org/ \
      | sed -n '/<pre>/,/<\/pre>/p' | sed -e 's#</\?pre>##' -e 's/[[:space:]]*$//' \
      | sed -e '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' \
      | diff - <(sed 's/[[:space:]]*$//' DCO) && echo "IDENTICAL (diff exit 0)"
    IDENTICAL (diff exit 0)

The bytes hold to this tree's file rules. ASCII only, no carriage return, no
trailing whitespace, 34 lines and a final newline:

    grep -nP '[^\x00-\x7F]|[ \t]+$|\r' DCO ; echo "rc=$?"
    rc=1
    wc -l DCO
    34 DCO

The path the failure message names now resolves. The message is in
`.github/workflows/dco.yml`:

    git grep -n 'See CONTRIBUTING.md and ./DCO' -- .github/workflows/dco.yml
    .github/workflows/dco.yml:79:            echo "::error::One or more commits lack a DCO Signed-off-by matching the author. Sign your work with 'git commit -s' (or add it retroactively with 'git rebase --signoff <base>'). See CONTRIBUTING.md and ./DCO."

## What is not covered

Nobody other than the author has read this change. The evidence above stands in
place of a second reader rather than alongside one.

The same failure message also names `CONTRIBUTING.md`, which is still not in the
tree. That file is #9 and it is not touched here, so one of the two paths the
message points at continues to resolve to nothing. #8 asks only for the DCO and
closing it does not close that half.

Nothing here changes the gate. The workflow was already refusing unsigned
commits and still is; what changes is that the text it asks a contributor to
certify can now be read.

Closes #8

