### PR TITLE
Create the runner module and its first verb

### DIFF
--- a/cmd/lab/main.go
+++ b/cmd/lab/main.go
@@ -1,0 +1,90 @@
+// Command lab reads a checkout of this repository and reports what it
+// examined. It has one verb that does work, it takes no flags, and it writes
+// nothing to the tree it reads.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/Flowfin/lab/internal/check"
+)
+
+// The exit codes this command can return today. The full contract, including
+// the codes the later verbs need, is decided in issue #52 and recorded there;
+// these two are chosen to fit that contract rather than to be moved by it.
+const (
+	// exitClean means the run completed and refused nothing. It does not
+	// mean the tree is good, only that nothing this runner judges was found
+	// wrong.
+	exitClean = 0
+
+	// exitCannot means the runner could not do its job: an argument it does
+	// not understand, a path that is not a directory, a file it cannot read
+	// at all. It is deliberately not the code a refusal returns, because a
+	// gate that treats a broken invocation like a violation reports one as
+	// the other and nobody investigates either.
+	exitCannot = 2
+)
+
+const usage = `lab reads this repository and reports what it examined.
+
+    lab check [path]   walk the tree at path, default ".", and report
+    lab help           print this text
+
+lab writes nothing to the tree it reads.
+`
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run is main with its edges passed in, so that what the command prints and
+// what it returns can both be read by a test without starting a process.
+func run(args []string, out, errOut io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprint(errOut, usage)
+		return exitCannot
+	}
+
+	switch args[0] {
+	case "help":
+		if len(args) > 1 {
+			fmt.Fprintf(errOut, "lab help takes no arguments\n")
+			return exitCannot
+		}
+		fmt.Fprint(out, usage)
+		return exitClean
+
+	case "check":
+		root := "."
+		switch len(args) {
+		case 1:
+		case 2:
+			root = args[1]
+		default:
+			fmt.Fprintf(errOut, "lab check takes at most one path\n")
+			return exitCannot
+		}
+
+		result, err := check.Walk(root)
+		if err != nil {
+			fmt.Fprintf(errOut, "lab check: %v\n", err)
+			return exitCannot
+		}
+		fmt.Fprint(out, result.Report())
+		// Nothing here refuses anything yet, so a completed walk is always
+		// clean. The code a refusal returns is not written in advance: an
+		// untested branch that nothing can reach is a branch nobody has
+		// proved, and it would ship as the one deciding whether a gate goes
+		// red. It arrives with the first refusal and with the test that
+		// reaches it, under the contract issue #52 records.
+		return exitClean
+
+	default:
+		fmt.Fprintf(errOut, "lab: unknown verb %q\n\n", args[0])
+		fmt.Fprint(errOut, usage)
+		return exitCannot
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/Flowfin/lab
+
+go 1.26.0
+
+toolchain go1.26.5

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -1,0 +1,148 @@
+// Package check walks a checkout of this repository and reports what it
+// examined. It opens files for reading and creates, modifies or removes
+// nothing: a checker that repairs the tree it is judging cannot be trusted
+// about what it found, because the reader can no longer tell a tree that was
+// right from one that was corrected on the way past.
+package check
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ExperimentsDir is the one directory an experiment may live in. Decision
+// record 0002 fixes the layout, and the walk reads that single directory
+// rather than searching the tree, so a stray file with the right name
+// elsewhere is not an experiment nobody meant to declare.
+const ExperimentsDir = "experiments"
+
+// RecordName is the file that holds an experiment's record. Decision record
+// 0002 fixes its location; its shape is decided separately.
+const RecordName = "EXPERIMENT.md"
+
+// Result is what one walk examined. The counts are reported whatever they
+// are, including zero, because zero found and zero examined are different
+// statements and only one of them is evidence.
+type Result struct {
+	// Root is the directory the walk started from, as it was given.
+	Root string
+
+	// ExperimentsPresent says whether Root held an experiments directory at
+	// all. A tree with none is not an error and it is not the same as a tree
+	// whose experiments directory is empty, so the two are not collapsed
+	// into a count of zero that reads the same either way.
+	ExperimentsPresent bool
+
+	// Directories is the number of experiment directories walked.
+	Directories int
+
+	// Records is the number of experiment records read.
+	Records int
+
+	// Refusals is what the walk refused. There is nothing to refuse yet, so
+	// it is always empty; the refusals arrive in their own changes and each
+	// one ships with a fixture that proves it bites.
+	Refusals []string
+}
+
+// Walk examines the tree rooted at root and returns what it found. The error
+// it returns means the walk could not be made at all, which is a different
+// outcome from a walk that completed and refused something.
+func Walk(root string) (Result, error) {
+	res := Result{Root: root}
+
+	info, err := os.Stat(root)
+	if err != nil {
+		return res, fmt.Errorf("cannot read %s: %w", root, err)
+	}
+	if !info.IsDir() {
+		return res, fmt.Errorf("%s is not a directory", root)
+	}
+
+	dir := filepath.Join(root, ExperimentsDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// No experiments directory is an ordinary state for this tree and
+		// the caller is told about it rather than shown a zero that looks
+		// like an empty one. Anything else is a tree the walk cannot read,
+		// and reporting that as zero would be the failure this package
+		// exists to avoid.
+		if os.IsNotExist(err) {
+			return res, nil
+		}
+		return res, fmt.Errorf("cannot read %s: %w", dir, err)
+	}
+	res.ExperimentsPresent = true
+
+	for _, entry := range entries {
+		// os.ReadDir does not follow symbolic links, so a link pointing at a
+		// directory reports itself as a link and is not walked. The tree the
+		// runner reads is untrusted input, and following a link out of it is
+		// how a checker reads something nobody put in the repository.
+		if !entry.IsDir() {
+			continue
+		}
+		res.Directories++
+
+		record := filepath.Join(dir, entry.Name(), RecordName)
+		recordInfo, err := os.Stat(record)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// An experiment with no record is a thing this repository
+				// intends to refuse, and the refusal is built in its own
+				// change with the fixture that proves it. Counting it as a
+				// record that was not read is all this walk does today.
+				continue
+			}
+			return res, fmt.Errorf("cannot read %s: %w", record, err)
+		}
+		if !recordInfo.Mode().Type().IsRegular() {
+			continue
+		}
+		if _, err := readRecord(record); err != nil {
+			return res, err
+		}
+		res.Records++
+	}
+
+	return res, nil
+}
+
+// readRecord opens a record and returns its bytes. Nothing reads the contents
+// yet. It exists so that a record counted as read is one the walk actually
+// opened, rather than one it saw the name of, since a file that cannot be
+// opened would otherwise be counted as examined.
+func readRecord(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read %s: %w", path, err)
+	}
+	return data, nil
+}
+
+// Report writes what the walk examined, in the order a reader needs it: where
+// it looked, what it covered, and only then what it refused. A run that
+// covered less than the whole tree says so on its own line, so it cannot be
+// read as one that covered everything and found nothing.
+func (r Result) Report() string {
+	out := fmt.Sprintf("examined %s\n", r.Root)
+	if !r.ExperimentsPresent {
+		out += fmt.Sprintf("no %s directory in this tree\n", ExperimentsDir)
+	}
+	out += fmt.Sprintf("%d experiment %s walked, %d %s read\n",
+		r.Directories, plural(r.Directories, "directory", "directories"),
+		r.Records, plural(r.Records, "record", "records"))
+	out += fmt.Sprintf("%d refused\n", len(r.Refusals))
+	for _, refusal := range r.Refusals {
+		out += fmt.Sprintf("  %s\n", refusal)
+	}
+	return out
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}


### PR DESCRIPTION
A Go module at the root, `cmd/lab/` as the entry point, `internal/check/` as
the walk, and one verb. `lab check` walks the tree and reports what it
examined. There is nothing to refuse yet, so it exits zero.

## The means

Go, as decision record `0001` fixed it, and the module declares the 1.26 line
that record names. The layout is record `0002`: the entry point under
`cmd/lab/`, everything it is built from under `internal/`, and nothing imported
from `experiments/`. No dependency outside the standard library, which is one of
the four reasons `0001` gives for the language.

The `toolchain` line fixes a floor rather than an exact version, because Go has
no way to pin an exact one from `go.mod`. A machine with a newer toolchain uses
its own. That is weaker than the word "pinned" in #12 suggests and it is written
here rather than left to be discovered.

## Evidence

Every claim below was run on a fresh clone of the branch head, not on the
working tree:

    git clone --branch scaffolding/the-runner-and-its-first-verb <this repo> fresh
    cd fresh && git rev-parse --short HEAD
    1799a23
    go build ./...
    go vet ./...
    go run ./cmd/lab check
    examined .
    no experiments directory in this tree
    0 experiment directories walked, 0 records read
    0 refused

`go build` and `go vet` both exited zero and printed nothing, which is what
they do when they find nothing. The walk exits zero, from a binary built in that same clone:

    go build -o lab.exe ./cmd/lab
    ./lab.exe check >/dev/null ; echo $?
    0

The output names both numbers when both are zero, and names the absent
directory on its own line, so a tree with no experiments cannot be read as a
tree whose experiments were all fine.

The runner returns 2, not 0 and not the refusal code, for every way it can fail
to do its job:

    ./lab.exe nonsense >/dev/null 2>&1 ; echo $?         # unknown verb
    2
    ./lab.exe >/dev/null 2>&1 ; echo $?                  # no verb
    2
    ./lab.exe check README.md >/dev/null 2>&1 ; echo $?  # path is not a directory
    2
    ./lab.exe check a b >/dev/null 2>&1 ; echo $?        # more than one path
    2

Nothing in the runner writes. This is the state of the source rather than a
proof, and it is written as the weaker claim it is:

    git grep -n 'os\.Create\|os\.WriteFile\|os\.Remove\|os\.Mkdir\|os\.Rename\|os\.OpenFile\|os\.Chmod\|os\.Symlink\|io\.Copy' -- cmd internal ; echo "rc=$?"
    rc=1

    gofmt -l .
    (no output)

## What is not covered

Nobody other than the author has read this change. The evidence above stands in
place of a second reader rather than alongside one.

There are no tests. The harness is #14 and it lands next, which is deliberate:
its own issue argues that the shape of the place where a refusal is proved has
to exist before the first refusal does, and building an ad-hoc test here would
be the retrofit it warns against. Until it lands, the read-only property above
is a grep and not a proof, and the walk is exercised by hand rather than by
anything that would notice a regression.

The exit codes here are two of the four #52 will record. `lab check` never
returns the refusal code, because nothing can produce a refusal yet and writing
an unreachable branch would ship the one deciding whether a gate goes red
without anything having reached it.

`.gitignore` still says the language-specific section is absent because the
runner's language was open. #2 answered that and this change does not update the
file, so a `go build ./cmd/lab` run from the root leaves an untracked binary
that nothing ignores.

Closes #12

