### PR TITLE
Fix the runner's exit codes and record the contract

### DIFF
--- a/cmd/lab/main.go
+++ b/cmd/lab/main.go
@@ -11,14 +11,19 @@ import (
 	"github.com/Flowfin/lab/internal/check"
 )
 
-// The exit codes this command can return today. The full contract, including
-// the codes the later verbs need, is decided in issue #52 and recorded there;
-// these two are chosen to fit that contract rather than to be moved by it.
+// The exit codes. Decision record 0011 is the contract and this is the only
+// place the numbers appear, so a caller keyed on one of them is reading the
+// record whether or not anybody told it so. A fifth code supersedes that
+// record rather than being added here.
 const (
 	// exitClean means the run completed and refused nothing. It does not
 	// mean the tree is good, only that nothing this runner judges was found
 	// wrong.
 	exitClean = 0
+
+	// exitRefused means the run completed and refused something. It is the
+	// only code that carries refusals, and the output names them.
+	exitRefused = 1
 
 	// exitCannot means the runner could not do its job: an argument it does
 	// not understand, a path that is not a directory, a file it cannot read
@@ -37,12 +42,18 @@ lab writes nothing to the tree it reads.
 `
 
 func main() {
-	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr, check.Walk))
 }
 
 // run is main with its edges passed in, so that what the command prints and
 // what it returns can both be read by a test without starting a process.
-func run(args []string, out, errOut io.Writer) int {
+//
+// The walk is a parameter for one reason: the mapping from a walk that refused
+// something to the exit code a refusal returns has to be proved before the
+// first refusal exists, and no real walk can produce one yet. The alternative
+// is landing that mapping untested and finding out on the day a gate should
+// have gone red.
+func run(args []string, out, errOut io.Writer, walk func(string) (check.Result, error)) int {
 	if len(args) == 0 {
 		fmt.Fprint(errOut, usage)
 		return exitCannot
@@ -68,18 +79,15 @@ func run(args []string, out, errOut io.Writer) int {
 			return exitCannot
 		}
 
-		result, err := check.Walk(root)
+		result, err := walk(root)
 		if err != nil {
 			fmt.Fprintf(errOut, "lab check: %v\n", err)
 			return exitCannot
 		}
 		fmt.Fprint(out, result.Report())
-		// Nothing here refuses anything yet, so a completed walk is always
-		// clean. The code a refusal returns is not written in advance: an
-		// untested branch that nothing can reach is a branch nobody has
-		// proved, and it would ship as the one deciding whether a gate goes
-		// red. It arrives with the first refusal and with the test that
-		// reaches it, under the contract issue #52 records.
+		if len(result.Refusals) > 0 {
+			return exitRefused
+		}
 		return exitClean
 
 	default:

--- a/cmd/lab/main_test.go
+++ b/cmd/lab/main_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Flowfin/lab/internal/check"
+)
+
+// realWalk is the walk the command uses when it is not being tested. A test
+// that wants the ordinary behaviour passes this, so a case exercising a
+// contrived walk is visible as one at the call site.
+var realWalk = check.Walk
+
+// TestExitCodes reaches every code this runner can return, and names the
+// record that decides what each one means. Decision record 0011 requires a
+// test per code, so that a code existing only in the document is caught here
+// rather than by an operator.
+func TestExitCodes(t *testing.T) {
+	refusing := func(string) (check.Result, error) {
+		return check.Result{
+			Root:               "somewhere",
+			ExperimentsPresent: true,
+			Directories:        1,
+			Records:            1,
+			Refusals:           []string{"a refusal"},
+		}, nil
+	}
+	failing := func(string) (check.Result, error) {
+		return check.Result{}, errors.New("cannot read the tree")
+	}
+
+	tests := []struct {
+		name string
+		args []string
+		walk func(string) (check.Result, error)
+		want int
+	}{
+		{
+			name: "a walk that refused nothing",
+			args: []string{"check", "../../testdata/cases/one-experiment-with-a-record/tree"},
+			walk: realWalk,
+			want: exitClean,
+		},
+		{
+			name: "help",
+			args: []string{"help"},
+			walk: realWalk,
+			want: exitClean,
+		},
+		{
+			// Nothing refuses anything yet, so the walk is the parameter
+			// here. What is proved is the mapping: a result carrying a
+			// refusal leaves this command with the code a refusal returns,
+			// and that is settled before the first refusal is written
+			// rather than after it.
+			name: "a walk that refused something",
+			args: []string{"check", "."},
+			walk: refusing,
+			want: exitRefused,
+		},
+		{
+			name: "a walk that could not read the tree",
+			args: []string{"check", "."},
+			walk: failing,
+			want: exitCannot,
+		},
+		{
+			name: "a path that is not a directory",
+			args: []string{"check", "main.go"},
+			walk: realWalk,
+			want: exitCannot,
+		},
+		{
+			name: "a path that is not there",
+			args: []string{"check", "no-such-directory"},
+			walk: realWalk,
+			want: exitCannot,
+		},
+		{
+			name: "a verb the runner does not have",
+			args: []string{"inspect"},
+			walk: realWalk,
+			want: exitCannot,
+		},
+		{
+			name: "no verb at all",
+			args: nil,
+			walk: realWalk,
+			want: exitCannot,
+		},
+		{
+			name: "more paths than check takes",
+			args: []string{"check", "one", "two"},
+			walk: realWalk,
+			want: exitCannot,
+		},
+		{
+			name: "help with an argument",
+			args: []string{"help", "check"},
+			walk: realWalk,
+			want: exitCannot,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var out, errOut bytes.Buffer
+			got := run(tc.args, &out, &errOut, tc.walk)
+			if got != tc.want {
+				t.Fatalf("exit code %d, want %d\nstdout: %s\nstderr: %s",
+					got, tc.want, out.String(), errOut.String())
+			}
+		})
+	}
+}
+
+// TestRefusalsAreNamedInTheOutput holds the half of record 0011 that the exit
+// code cannot carry. A caller reading only the number learns that something
+// was refused; a caller that wants to know what was refused reads the output,
+// and that only works if the output names it.
+func TestRefusalsAreNamedInTheOutput(t *testing.T) {
+	refusing := func(string) (check.Result, error) {
+		return check.Result{
+			Root:               "somewhere",
+			ExperimentsPresent: true,
+			Refusals:           []string{"the refusal a reader has to see"},
+		}, nil
+	}
+
+	var out, errOut bytes.Buffer
+	if got := run([]string{"check", "."}, &out, &errOut, refusing); got != exitRefused {
+		t.Fatalf("exit code %d, want %d", got, exitRefused)
+	}
+	if !strings.Contains(out.String(), "the refusal a reader has to see") {
+		t.Fatalf("the output does not name the refusal:\n%s", out.String())
+	}
+}
+
+// TestTheDocumentedCodesAreTheNumbersTheRecordFixes pins the three numbers
+// this command uses to the three record 0011 states. Renumbering any of them
+// reddens the suite, which is what a workflow keyed on one of these numbers
+// needs, since such a workflow is a reader of that record and would otherwise
+// change meaning without its own file being edited.
+//
+// It does not notice a fifth constant added beside these three. Nothing here
+// reads the record, so what would catch that is the review, and record 0011
+// says so in its own text rather than leaving this test to imply otherwise.
+func TestTheDocumentedCodesAreTheNumbersTheRecordFixes(t *testing.T) {
+	codes := map[string]int{
+		"clean":   exitClean,
+		"refused": exitRefused,
+		"cannot":  exitCannot,
+	}
+	want := map[string]int{"clean": 0, "refused": 1, "cannot": 2}
+
+	for name, code := range codes {
+		if code != want[name] {
+			t.Errorf("%s is %d, record 0011 says %d", name, code, want[name])
+		}
+	}
+	for name := range want {
+		if _, ok := codes[name]; !ok {
+			t.Errorf("record 0011 names %s and this command has no constant for it", name)
+		}
+	}
+}

--- a/docs/decisions/0011-the-exit-codes.md
+++ b/docs/decisions/0011-the-exit-codes.md
@@ -1,0 +1,99 @@
+# 0011. The runner's exit codes
+
+## What was decided
+
+Four codes and no others. A caller reading only the number learns which of four
+things happened, and a caller that wants to know what was refused reads the
+output, because an exit code is a summary and the run is the evidence.
+
+`0` means the run completed and refused nothing. It does not mean the tree is
+good. It means nothing this runner judges was found wrong, which is a narrower
+statement, and anything reading this code is entitled to no more than that.
+
+`1` means the run completed and refused something. This is the ordinary red a
+contributor sees, and it is the only code that carries refusals. A caller that
+sees it can rely on the output naming what was refused.
+
+`2` means the runner could not do its job. A path that is not a directory, a
+record it cannot read at all, a verb or an argument it does not understand.
+Separating this from `1` is the whole reason for having more than one non-zero
+code. A gate that treats them alike reports a broken invocation as either a
+clean tree or a violation, and both readings are wrong in the way nobody
+investigates: the first is silent and the second sends somebody looking for a
+refusal that was never made.
+
+`3` means the run was asked for something and delivered nothing. This is what
+the hardware harness needs when it was asked to run and every test skipped.
+Being asked for coverage and producing none is a failure of the request even
+though no assertion broke, and reporting it as `0` would let a run that
+exercised nothing pass for a run that found nothing.
+
+Two properties come with the set rather than after it.
+
+Every code the runner can return is reached by a test in the default suite. A
+code that exists only in this document is caught here rather than by an
+operator, and the test is what keeps the document and the runner from drifting
+apart.
+
+No code is added later without superseding this record. A workflow keyed on a
+number is a reader of this contract whether or not anybody told it so, and the
+day a fifth code appears is the day some job's meaning changes without its file
+being edited.
+
+What the runner returns at the commit this record lands on is narrower than the
+set, and the gap is written down rather than left for somebody to discover.
+`0` and `2` have producers and tests. `1` has its mapping in the runner and a
+test that reaches it through the walk's result, and no walk can produce a
+refusal yet, because nothing refuses anything yet. `3` has no producer at all,
+because the hardware harness it belongs to does not exist. Both arrive with the
+work that produces them, and neither is written into the runner as a branch
+nothing can reach, since an unreachable branch is one nobody has proved and it
+would be the branch deciding whether a gate goes red.
+
+## What it applies to
+
+Every verb the runner has and every verb it grows, including the ones that do
+not exist yet. It applies to the hardware harness when that is built, which is
+where `3` comes from.
+
+It applies to anything that reads the number: a workflow step, a pre-push hook,
+a person at a shell. Those readers are the reason the set is small and fixed.
+
+It does not apply to what the runner prints. The output says what was examined
+and what was refused whatever the code is, and a caller that needs the detail
+reads the output rather than a wider code space.
+
+## What else was considered
+
+One non-zero code for everything.
+
+A larger space modelled on a well-known tool, with a distinct code per class of
+problem.
+
+A code for a run that completed with refusals somebody had waived.
+
+Returning the number of refusals as the exit code.
+
+## What each rejected option would have cost
+
+One non-zero code collapses a broken invocation into a refusal, and the
+collapse is invisible because both look like a red check. Somebody investigating
+goes looking in the tree for the violation, finds none, and the actual fault is
+a mistyped path. The cost is paid every time it happens and it is paid by
+whoever did not write the gate.
+
+A larger space costs promises. A code nothing returns is a promise, and the
+operator guide would then explain outcomes that cannot happen, which teaches a
+reader that the document describes something other than this tool. It also
+grows without argument, because there is always one more distinction worth
+making, and each one is a number some workflow may already be keyed on.
+
+A waiver code costs the meaning of `1`. A refusal that was waived is still a
+refusal, and a separate code would let a job treat waived and clean alike while
+the output says otherwise. Whether a refusal can be waived at all is a question
+for whatever builds waivers, and it is not answered by adding a number here.
+
+Returning the count costs everything above 255 and everything below 4. A count
+of 256 refusals is zero on most systems, which reports the worst tree this
+runner could meet as a clean one, and a count of 2 is indistinguishable from
+the runner failing to start.


### PR DESCRIPTION
`docs/decisions/0011-the-exit-codes.md` fixes four codes, the runner returns the
three that have producers, and a test reaches each of those three.

## The means

Go, record `0001`, and the record in Markdown under `docs/decisions/` in the
shape record `0000` fixes. The numbers appear in one place in the source, so
the record and the runner cannot drift apart quietly:

    git grep -n 'exitClean\s*=\|exitRefused\s*=\|exitCannot\s*=' -- cmd internal
    cmd/lab/main.go:22:	exitClean = 0
    cmd/lab/main.go:26:	exitRefused = 1
    cmd/lab/main.go:33:	exitCannot = 2

The walk becomes a parameter of `run`. That is a seam and it is there for one
reason, written at the call site: nothing refuses anything yet, so the mapping
from a result carrying a refusal to the code a refusal returns cannot be
reached by any real walk, and landing it untested means finding out on the day
a gate should have gone red.

## Evidence

Green on a fresh clone of the branch head:

    git clone --branch scaffolding/the-exit-code-contract <this repo> fresh3
    cd fresh3 && git rev-parse --short HEAD
    a1b4168
    go build ./... && go vet ./...
    go test ./...
    ok  	github.com/Flowfin/lab/cmd/lab	1.767s
    ok  	github.com/Flowfin/lab/internal/check	1.817s

Each guard was removed and the suite went red for the reason it names. One at a
time, in a copy, each reverted before the next:

The refusal mapping deleted from `run`:

    --- FAIL: TestExitCodes/a_walk_that_refused_something
        main_test.go:113: exit code 0, want 1

`exitCannot` renumbered from 2 to 1:

    --- FAIL: TestTheDocumentedCodesAreTheNumbersTheRecordFixes
        main_test.go:161: cannot is 1, record 0011 says 2

The refusal lines dropped from the report, leaving the count behind:

    --- FAIL: TestRefusalsAreNamedInTheOutput
        main_test.go:138: the output does not name the refusal:
            examined somewhere
            0 experiment directories walked, 0 records read
            1 refused

That last one is the half the number cannot carry. A caller reading only the
code learns that something was refused, so the output has to name what, and a
report that prints `1 refused` and nothing else satisfies the count while
telling the reader nothing.

## What is not covered

Nobody other than the author has read this change. The evidence above stands in
place of a second reader rather than alongside one.

This does NOT close #52. Its done-condition also requires the operator guide to
explain the codes by pointing at the record, and there is no operator guide in
this tree. That is #42. The reason is written into #52 and the issue stays open.

Code `3` has no producer and none is added here:

    git grep -n 'exitNothing\|os.Exit(3)' -- cmd internal ; echo "rc=$?"
    rc=1

It belongs to the hardware harness, which is #30 and does not exist. Writing a
branch nothing can reach would ship the one deciding whether a gate goes red
with nothing having reached it, so the record names the code and the runner
does not pretend to return it. "A test in the default suite reaches every one
of them" is therefore met for the three the runner has and not for the fourth.

Code `1` is reached through the seam rather than through a walk, because no
walk can produce a refusal yet. What is proved is the mapping, not a refusal.

`TestTheDocumentedCodesAreTheNumbersTheRecordFixes` pins three numbers. It does
not read the record and it would not notice a fourth constant added beside
them; the record says so in its own text and so does the test's comment.

Contributes to #52
