### PR TITLE
Every refusal ships with a fixture that proves it bites

### DIFF
--- a/internal/check/harness_test.go
+++ b/internal/check/harness_test.go
@@ -14,11 +14,26 @@
 // The layout of a case:
 //
 //	testdata/cases/<name>/tree/               what the runner walks
-//	testdata/cases/<name>/expected            three lines, see readExpected
-//	testdata/cases/<name>/expected-refusals   one refusal per line, may be empty
+//	testdata/cases/<name>/expected            three lines, see readExpectation
+//	testdata/cases/<name>/expected-refusals   one property per line, may be empty
+//	testdata/cases/<name>/near-neighbour      the case that differs by the
+//	                                          smallest legal change, required
+//	                                          of a case that refuses
 //
 // This file decides that layout. Nothing restates it, so there is nothing to
 // drift against it.
+//
+// THE BOUND ON WHAT ANY OF THIS PROVES. Every comparison here is over which
+// properties were refused, and never over which line inside the runner refused
+// them. Two refusal sites producing one property are indistinguishable to
+// every leg, so an operator holding several of them can lose one and stay
+// green. That is the state of this tree rather than a hypothetical:
+// record-is-not-text is produced at two sites, one for a null byte and one for
+// an invalid sequence, and a fixture for either satisfies the standing
+// requirement for both. What catches the loss of one arm is a case existing
+// for that arm, which is a fixture somebody remembered and not something the
+// harness can require. Read this before quoting a green run as proof that a
+// refusal site is exercised.
 package check
 
 import (

--- a/internal/check/properties_test.go
+++ b/internal/check/properties_test.go
@@ -1,0 +1,189 @@
+package check
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// producibleProperties reads this package's own source and returns every
+// property a refusal site names.
+//
+// It is derived rather than listed. A list of properties written by hand is a
+// list that stops being true the moment somebody adds a refusal site and
+// forgets it, and the whole point of the requirement below is that it reaches
+// refusals nobody has written yet. What the source says a site can produce is
+// the only thing that cannot fall behind the source.
+//
+// It reads the package's non-test files, finds every composite literal field
+// named Property, and resolves the constant it names to the string that
+// constant holds. A site naming a string literal directly is resolved too. A
+// site naming anything else fails the test rather than being skipped, because
+// a property this cannot resolve is a property nothing below can require a
+// fixture for.
+func producibleProperties(t *testing.T) []string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(info os.FileInfo) bool {
+		return !strings.HasSuffix(info.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("cannot parse this package: %v", err)
+	}
+
+	constants := make(map[string]string)
+	var sites []ast.Expr
+
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				switch node := n.(type) {
+				case *ast.ValueSpec:
+					for i, name := range node.Names {
+						if i >= len(node.Values) {
+							continue
+						}
+						if lit, ok := node.Values[i].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+							value, err := strconv.Unquote(lit.Value)
+							if err == nil {
+								constants[name.Name] = value
+							}
+						}
+					}
+				case *ast.KeyValueExpr:
+					if key, ok := node.Key.(*ast.Ident); ok && key.Name == "Property" {
+						sites = append(sites, node.Value)
+					}
+				}
+				return true
+			})
+		}
+	}
+
+	if len(sites) == 0 {
+		t.Fatal("no refusal site in this package names a property, which cannot be right while the package refuses anything")
+	}
+
+	seen := make(map[string]bool)
+	var props []string
+	for _, site := range sites {
+		var value string
+		switch expr := site.(type) {
+		case *ast.Ident:
+			v, ok := constants[expr.Name]
+			if !ok {
+				t.Fatalf("a refusal site names %s and this cannot resolve it to a property", expr.Name)
+			}
+			value = v
+		case *ast.BasicLit:
+			v, err := strconv.Unquote(expr.Value)
+			if err != nil {
+				t.Fatalf("a refusal site names %s and this cannot read it: %v", expr.Value, err)
+			}
+			value = v
+		default:
+			t.Fatalf("a refusal site at %s names a property this cannot resolve", fset.Position(site.Pos()))
+		}
+		if !seen[value] {
+			seen[value] = true
+			props = append(props, value)
+		}
+	}
+	sort.Strings(props)
+	return props
+}
+
+// TestEveryRefusalHasAFixtureThatProvesItBites is the standing requirement. It
+// reaches refusals nobody has written yet, because the property list is read
+// out of the source rather than out of a list somebody maintains.
+//
+// Three legs, and a refusal is only proved when it has all three.
+//
+// The first leg is a fixture whose whole refusal set is exactly that one
+// property. Comparing the whole set is what makes the leg mean anything: a
+// fixture that also trips a second refusal proves neither of them cleanly.
+//
+// The second leg is a near neighbour of that fixture, differing by the
+// smallest change that makes it legal, refusing nothing. Without it, a check
+// that refuses everything passes its own test.
+//
+// The third leg is that the refusal names its subject, which
+// TestARefusalNamesItsSubject holds over every case in the tree.
+//
+// THE BOUND. Every leg compares which properties were refused, and never
+// which line inside the runner refused them. Two refusal sites producing one
+// property are indistinguishable to all three, so an operator holding several
+// of them can lose one and stay green. That is not hypothetical here:
+// record-is-not-text is produced at two sites, one for a null byte and one for
+// an invalid sequence, and a fixture for either satisfies this test for both.
+// What catches the loss of one arm is the case for that arm existing, which is
+// a fixture somebody remembered rather than a thing this test can require.
+func TestEveryRefusalHasAFixtureThatProvesItBites(t *testing.T) {
+	cases := loadCases(t)
+
+	provers := make(map[string][]string)
+	for name, exp := range cases {
+		if len(exp.refusals) == 1 {
+			provers[exp.refusals[0]] = append(provers[exp.refusals[0]], name)
+		}
+	}
+
+	for _, property := range producibleProperties(t) {
+		names := provers[property]
+		if len(names) == 0 {
+			t.Errorf("%s can be refused and no case declares exactly that refusal and no other", property)
+			continue
+		}
+		sort.Strings(names)
+
+		for _, name := range names {
+			neighbour := readNearNeighbour(t, name)
+			if neighbour == "" {
+				t.Errorf("case %s proves %s and declares no near neighbour, so nothing here would notice a check that refuses everything", name, property)
+				continue
+			}
+			exp, ok := cases[neighbour]
+			if !ok {
+				t.Errorf("case %s names %s as its near neighbour and there is no such case", name, neighbour)
+				continue
+			}
+			if len(exp.refusals) != 0 {
+				t.Errorf("case %s names %s as its near neighbour, and that case expects %v rather than nothing", name, neighbour, exp.refusals)
+			}
+		}
+	}
+}
+
+// TestANearNeighbourIsDeclaredOnlyWhereItMeansSomething refuses a near
+// neighbour declared by a case that refuses nothing. Such a declaration reads
+// as a proof and is not one, since a fixture that refuses nothing has no
+// refusal for a neighbour to be near to.
+func TestANearNeighbourIsDeclaredOnlyWhereItMeansSomething(t *testing.T) {
+	for name, exp := range loadCases(t) {
+		if len(exp.refusals) == 0 && readNearNeighbour(t, name) != "" {
+			t.Errorf("case %s refuses nothing and declares a near neighbour", name)
+		}
+	}
+}
+
+// readNearNeighbour returns the case a refusing case declares as its near
+// neighbour, or the empty string when it declares none.
+func readNearNeighbour(t *testing.T, name string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(casesDir, name, "near-neighbour"))
+	if os.IsNotExist(err) {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("case %s: %v", name, err)
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/testdata/cases/record-with-a-byte-order-mark/near-neighbour
+++ b/testdata/cases/record-with-a-byte-order-mark/near-neighbour
@@ -1,0 +1,1 @@
+record-without-the-byte-order-mark

--- a/testdata/cases/record-with-a-null-byte/near-neighbour
+++ b/testdata/cases/record-with-a-null-byte/near-neighbour
@@ -1,0 +1,1 @@
+record-with-no-null-byte

--- a/testdata/cases/record-with-an-invalid-sequence/near-neighbour
+++ b/testdata/cases/record-with-an-invalid-sequence/near-neighbour
@@ -1,0 +1,1 @@
+record-with-a-valid-sequence


### PR DESCRIPTION
A standing requirement rather than a habit. The set of properties the runner
can refuse is read out of the package's own source, so the requirement reaches
refusals nobody has written yet.

## The means

Go, record `0001`, and `go/ast` from the standard library to read the package's
own non-test files. A hand-written list of properties would stop being true the
moment somebody adds a refusal site and forgets it, which is the exact failure
this requirement exists against, so the list is derived from the source and a
site the reader cannot resolve fails the test rather than being skipped.

The near neighbour is declared in the fixture rather than inferred from a name,
because a naming convention is a rule nothing refuses.

## The three legs

A fixture whose whole refusal set is exactly one property. A near neighbour of
that fixture, differing by the smallest change that makes it legal and refusing
nothing. And the refusal naming its subject, which `TestARefusalNamesItsSubject`
already holds over every case.

## Evidence

Green on a fresh clone of the branch head:

    git clone --branch records/every-refusal-has-a-fixture <this repo> fresh5
    cd fresh5 && git rev-parse --short HEAD
    6867bfa
    go build ./... && go vet ./...
    go test ./...
    ok  	github.com/Flowfin/lab/cmd/lab	1.322s
    ok  	github.com/Flowfin/lab/internal/check	1.398s

Each leg was broken and the suite went red for the reason it names. One at a
time, in a copy, each reverted before the next.

A refusal site added with a new property and no fixture, which is the case the
requirement exists for:

    --- FAIL: TestEveryRefusalHasAFixtureThatProvesItBites
        properties_test.go:141: record-is-empty can be refused and no case declares exactly that refusal and no other

A near-neighbour declaration deleted:

    --- FAIL: TestEveryRefusalHasAFixtureThatProvesItBites
        properties_test.go:149: case record-with-a-byte-order-mark proves record-begins-with-a-byte-order-mark and declares no near neighbour, so nothing here would notice a check that refuses everything

A near neighbour made to expect a refusal:

    --- FAIL: TestEveryRefusalHasAFixtureThatProvesItBites
        properties_test.go:158: case record-with-a-byte-order-mark names record-without-the-byte-order-mark as its near neighbour, and that case expects [record-is-not-text] rather than nothing

## The bound, and where it is written

`internal/check/harness_test.go`, at the top, where the harness is defined.
Every leg compares which properties were refused and never which line inside
the runner refused them. Two refusal sites producing one property are
indistinguishable to all three legs, so an operator holding both can lose one
and stay green.

That is the state of this tree rather than a hypothetical, and the comment
names it: `record-is-not-text` is produced at two sites, one for a null byte
and one for an invalid sequence, and a fixture for either satisfies the
requirement for both. What catches the loss of one arm is a case existing for
that arm, which is a fixture somebody remembered rather than something the
harness can require.

## What is not covered

Nobody other than the author has read this change. The evidence above stands in
place of a second reader rather than alongside one.

The derivation reads composite-literal fields named `Property` in this one
package. A refusal produced some other way, in some other package, is outside
what it can see, and a site it cannot resolve fails the test rather than
passing quietly. There is no second package producing refusals today, and this
would not notice one arriving.

The suite ran on one platform. Record `0012` names three that get a suite run
and #57 is what makes them all run.

Closes #20
