### PR TITLE
Refuse a record naming a path that no longer exists

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"unicode/utf8"
 )
 
@@ -41,7 +43,53 @@ const (
 	// less than deciding what every later check does with a string the rest
 	// of the runner cannot print.
 	RecordIsNotText = "record-is-not-text"
+
+	// RecordNamesAPathThatDoesNotResolve refuses a record naming a path
+	// inside this repository that is not there at the commit being checked.
+	// A record pointing at a file which is not there has quietly stopped
+	// being true, and it happens most often exactly when it matters: an
+	// experiment is answered, its code is removed under the decision that
+	// allows that, and the record still says the measurement is in a script
+	// that no longer exists.
+	RecordNamesAPathThatDoesNotResolve = "record-names-a-path-that-does-not-resolve"
 )
+
+// pathInProse matches a repository-relative path written anywhere in a
+// record, in a sentence or inside a link, because the paths that rot are the
+// ones written in a sentence rather than in a link.
+//
+// The first segment has to be a directory record 0002 names. That is what
+// keeps the pattern from reading a URL, a fraction or a word pair as a path:
+// the leading segment of https://example.com/x is not one of these, and
+// neither is the and of and/or. It also means a path this repository could
+// never hold is not this check's business, which is the right boundary,
+// because nothing here can say whether a file on somebody else's machine
+// exists.
+var pathInProse = regexp.MustCompile(
+	`(^|[^A-Za-z0-9._/-])((?:\./)?(?:experiments|cmd|internal|docs|testdata|\.github)(?:/[A-Za-z0-9._-]+)+)`)
+
+// pathsNamedInProse returns the repository-relative paths a text names, in
+// the order it names them, each once.
+//
+// The leading group is what keeps a URL out. The path segments of
+// https://example.invalid/docs/thing.md end in something this pattern would
+// otherwise read as a path in this repository, and a record refused for a
+// document on somebody else's server is the annoyance that gets a check
+// switched off.
+func pathsNamedInProse(text string) []string {
+	var named []string
+	seen := make(map[string]bool)
+
+	for _, match := range pathInProse.FindAllStringSubmatch(text, -1) {
+		path := strings.TrimRight(match[2], ".,;:")
+		if path == "" || seen[path] {
+			continue
+		}
+		seen[path] = true
+		named = append(named, path)
+	}
+	return named
+}
 
 // byteOrderMark is the UTF-8 encoding of U+FEFF.
 var byteOrderMark = []byte{0xEF, 0xBB, 0xBF}
@@ -169,9 +217,35 @@ func Walk(root string) (Result, error) {
 		}
 		res.Records++
 		res.Refusals = append(res.Refusals, refuseBytes(record, data)...)
+		res.Refusals = append(res.Refusals, refusePaths(root, record, data)...)
 	}
 
 	return res, nil
+}
+
+// refusePaths holds a record to the paths it names. A path that was removed
+// on purpose is the case this exists to catch rather than an exception to it:
+// the repair is to update the record to name the commit that removed the file,
+// which the code-removal decision already requires, and not to weaken this.
+//
+// Name no path you do not intend to resolve. A record naming an example path
+// that was never meant to exist is refused, and that is expected rather than a
+// defect in the check.
+func refusePaths(root, path string, data []byte) []Refusal {
+	var refusals []Refusal
+
+	for _, named := range pathsNamedInProse(string(data)) {
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(named))); err == nil {
+			continue
+		}
+		refusals = append(refusals, Refusal{
+			Property: RecordNamesAPathThatDoesNotResolve,
+			Subject:  path,
+			Detail:   fmt.Sprintf("it names %s, which is not in this tree", named),
+		})
+	}
+
+	return refusals
 }
 
 // refuseBytes holds a record to being the text every later check assumes it

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -274,3 +274,39 @@ func fingerprint(t *testing.T, root string) map[string]string {
 	}
 	return sums
 }
+
+// TestWhatCountsAsAPathInProse holds the half that decides whether the path
+// refusal is useful or annoying. It has to read a path written in a sentence,
+// which is where paths rot, and it has to leave alone the things that look
+// like paths and are not.
+func TestWhatCountsAsAPathInProse(t *testing.T) {
+	tests := []struct {
+		text string
+		want []string
+	}{
+		{"the script in experiments/one/measure.sh produced it", []string{"experiments/one/measure.sh"}},
+		{"see [the layout](docs/decisions/0002-repository-layout.md)", []string{"docs/decisions/0002-repository-layout.md"}},
+		{"the walk is in `internal/check/check.go`", []string{"internal/check/check.go"}},
+		{"the workflow is .github/workflows/dco.yml", []string{".github/workflows/dco.yml"}},
+		{"relative, as ./docs/privacy.md", []string{"./docs/privacy.md"}},
+		{"published at https://example.invalid/docs/thing.md", nil},
+		{"either one and/or the other", nil},
+		{"two thirds, or 2/3 of them", nil},
+		{"a bare word, experiments, with no path after it", nil},
+		{"somebody else's tree at /usr/share/doc", nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.text, func(t *testing.T) {
+			got := pathsNamedInProse(tc.text)
+			if len(got) != len(tc.want) {
+				t.Fatalf("read %v as paths, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("read %v as paths, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/testdata/cases/record-naming-a-path-that-is-not-there/expected
+++ b/testdata/cases/record-naming-a-path-that-is-not-there/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-naming-a-path-that-is-not-there/expected-refusals
+++ b/testdata/cases/record-naming-a-path-that-is-not-there/expected-refusals
@@ -1,0 +1,1 @@
+record-names-a-path-that-does-not-resolve

--- a/testdata/cases/record-naming-a-path-that-is-not-there/near-neighbour
+++ b/testdata/cases/record-naming-a-path-that-is-not-there/near-neighbour
@@ -1,0 +1,1 @@
+record-naming-a-path-that-is-there

--- a/testdata/cases/record-naming-a-path-that-is-not-there/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-naming-a-path-that-is-not-there/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,8 @@
+# One
+
+slug one
+state answered
+
+The question, and the answer.
+The measurement was produced by the script in experiments/one/measure.sh
+and the numbers are beside it.

--- a/testdata/cases/record-naming-a-path-that-is-there/expected
+++ b/testdata/cases/record-naming-a-path-that-is-there/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-naming-a-path-that-is-there/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-naming-a-path-that-is-there/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,8 @@
+# One
+
+slug one
+state answered
+
+The question, and the answer.
+The measurement was produced by the script in experiments/one/measure.sh
+and the numbers are beside it.

--- a/testdata/cases/record-naming-a-path-that-is-there/tree/experiments/one/measure.sh
+++ b/testdata/cases/record-naming-a-path-that-is-there/tree/experiments/one/measure.sh
@@ -1,0 +1,1 @@
+# the script the record names


### PR DESCRIPTION
A record naming a path inside this repository that is not there at the commit
being checked is refused, and the message names the record and the path.

## The means

Go, record `0001`, standard library only. The pattern is a regular expression
whose first segment has to be a directory record `0002` names, so the set of
things that can be read as a path is derived from the layout decision rather
than from a guess about what a path looks like.

## The two details that decide whether this is useful or annoying

A path in prose counts. That is the whole value, because the paths that rot are
written in a sentence rather than in a link. The check reads the record as text,
so a path inside a link, inside backticks or in the middle of a sentence is
found the same way.

A match has to begin at a boundary. Without that, the tail of an ordinary link
to somebody else's server reads as a path in this repository, and a record
refused for a document nobody here controls is the annoyance that gets a check
switched off. That case was not reasoned about in advance: the pattern was
written, the table test caught it, and the boundary was added.

## Evidence

Green on a fresh clone of the branch head, and the run passes on the tree:

    git clone --branch records/paths-a-record-names <this repo> fresh6
    cd fresh6 && git rev-parse --short HEAD
    fa0713a
    go build ./... && go vet ./...
    go test ./...
    ok  	github.com/Flowfin/lab/cmd/lab	0.595s
    ok  	github.com/Flowfin/lab/internal/check	0.921s
    go run ./cmd/lab check ; echo $?
    examined .
    no experiments directory in this tree
    0 experiment directories walked, 0 records read
    0 refused
    0

The refusing fixture and its near neighbour are the same bytes. What differs
between them is one file existing in the tree, which is as close as a near miss
gets.

Each guard was broken and the suite went red for the reason it names. One at a
time, in a copy, each reverted before the next.

The refusal removed from the walk:

    --- FAIL: TestCases/record-naming-a-path-that-is-not-there
        check_test.go:45: expected refusal not produced: record-names-a-path-that-does-not-resolve

The boundary dropped from the pattern, so a URL is read as a path again:

    --- FAIL: TestWhatCountsAsAPathInProse/published_at_https://example.invalid/docs/thing.md
        check_test.go:303: read [docs/thing.md] as paths, want []

The file the near neighbour names deleted from its tree:

    --- FAIL: TestCases/record-naming-a-path-that-is-there
        check_test.go:45: refusal produced that no case expected: record-names-a-path-that-does-not-resolve

## What is not covered

Nobody other than the author has read this change. The evidence above stands in
place of a second reader rather than alongside one.

The pattern reads a path whose first segment is one of the directories record
`0002` names. A path this repository could never hold is left alone, which is
the right boundary, because nothing here can say whether a file on somebody
else's machine exists. It also means a record naming a file directly at the
root of the tree is not read as naming a path.

Resolution is against the filesystem at the walk root, not against what git
tracks. An untracked file present in a working tree resolves here and would not
resolve for a reader who cloned. That is a narrower guarantee than the issue's
word "tracked" and it is stated rather than glossed.

Name no path you do not intend to resolve. A record naming an example path that
was never meant to exist is refused, and that is expected rather than a defect
in the check.

The suite ran on one platform. Record `0012` names three that get a suite run
and #57 is what makes them all run.

Closes #18
