### PR TITLE
Refuse a directory under experiments with no record to read

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -52,6 +52,13 @@ const (
 	// allows that, and the record still says the measurement is in a script
 	// that no longer exists.
 	RecordNamesAPathThatDoesNotResolve = "record-names-a-path-that-does-not-resolve"
+
+	// ExperimentHasNoRecord refuses a directory under experiments/ that
+	// carries no record a reader can open. It catches somebody dropping code
+	// in and meaning to write the record later, and it fires on the change
+	// that creates the directory, which is the only moment when writing the
+	// question is still cheap.
+	ExperimentHasNoRecord = "experiment-has-no-record"
 )
 
 // pathInProse matches a repository-relative path written anywhere in a
@@ -196,19 +203,26 @@ func Walk(root string) (Result, error) {
 		}
 		res.Directories++
 
-		record := filepath.Join(dir, entry.Name(), RecordName)
+		experiment := filepath.Join(dir, entry.Name())
+		record := filepath.Join(experiment, RecordName)
 		recordInfo, err := os.Stat(record)
 		if err != nil {
 			if os.IsNotExist(err) {
-				// An experiment with no record is a thing this repository
-				// intends to refuse, and the refusal is built in its own
-				// change with the fixture that proves it. Counting it as a
-				// record that was not read is all this walk does today.
+				res.Refusals = append(res.Refusals, Refusal{
+					Property: ExperimentHasNoRecord,
+					Subject:  experiment,
+					Detail:   fmt.Sprintf("there is no %s in it, so it states no question", RecordName),
+				})
 				continue
 			}
 			return res, fmt.Errorf("cannot read %s: %w", record, err)
 		}
 		if !recordInfo.Mode().Type().IsRegular() {
+			res.Refusals = append(res.Refusals, Refusal{
+				Property: ExperimentHasNoRecord,
+				Subject:  experiment,
+				Detail:   fmt.Sprintf("its %s is not a file a reader can open", RecordName),
+			})
 			continue
 		}
 		data, err := readRecord(record)

--- a/testdata/cases/experiment-without-a-record/expected-refusals
+++ b/testdata/cases/experiment-without-a-record/expected-refusals
@@ -1,0 +1,1 @@
+experiment-has-no-record

--- a/testdata/cases/experiment-without-a-record/near-neighbour
+++ b/testdata/cases/experiment-without-a-record/near-neighbour
@@ -1,0 +1,1 @@
+one-experiment-with-a-record

--- a/testdata/cases/record-is-a-directory/expected-refusals
+++ b/testdata/cases/record-is-a-directory/expected-refusals
@@ -1,0 +1,1 @@
+experiment-has-no-record

--- a/testdata/cases/record-is-a-directory/near-neighbour
+++ b/testdata/cases/record-is-a-directory/near-neighbour
@@ -1,0 +1,1 @@
+one-experiment-with-a-record

--- a/testdata/cases/record-one-level-too-deep/expected-refusals
+++ b/testdata/cases/record-one-level-too-deep/expected-refusals
@@ -1,0 +1,1 @@
+experiment-has-no-record

--- a/testdata/cases/record-one-level-too-deep/near-neighbour
+++ b/testdata/cases/record-one-level-too-deep/near-neighbour
@@ -1,0 +1,1 @@
+one-experiment-with-a-record


### PR DESCRIPTION
The first of the two refusals #16 asks for. A directory under `experiments/`
with no `EXPERIMENT.md` a reader can open is refused, the message names the
directory and says which condition failed, and the run exits non-zero.

This does NOT close #16. The second refusal, over a record whose question
section is empty or absent, needs the record format, and that is #15 and is
open. The reason is written into #16 and the issue stays open.

## The means

Go, record `0001`, standard library only. The refusal sits at the two points in
the walk that already knew a record could not be read, so nothing new walks the
tree.

## Evidence

Green on a fresh clone of the branch head:

    git clone --branch records/an-experiment-with-no-record <this repo> fresh7
    cd fresh7 && git rev-parse --short HEAD
    05beb8d
    go build ./... && go vet ./...
    go test ./...
    ok  	github.com/Flowfin/lab/cmd/lab	1.515s
    ok  	github.com/Flowfin/lab/internal/check	1.628s

The run still passes on the current tree, and goes red with a non-zero exit on
a tree that carries the failure:

    go run ./cmd/lab check >/dev/null ; echo $?
    0
    go run ./cmd/lab check testdata/cases/experiment-without-a-record/tree ; echo $?
    examined testdata/cases/experiment-without-a-record/tree
    1 experiment directory walked, 0 records read
    1 refused
      ...\experiments\one: there is no EXPERIMENT.md in it, so it states no question (experiment-has-no-record)
    1

That is the first time the runner returns the refusal code from a real walk.
Until now the mapping from a refusal to code `1` was reached only through the
seam built in #52 to prove it before any refusal existed.

Both arms were removed and the suite went red for the reason each names. One at
a time, in a copy, each reverted before the next.

The property replaced at both sites:

    --- FAIL: TestCases/experiment-without-a-record
        check_test.go:45: expected refusal not produced: experiment-has-no-record
        check_test.go:45: refusal produced that no case expected: never
    --- FAIL: TestCases/record-is-a-directory
        check_test.go:45: expected refusal not produced: experiment-has-no-record

Only the second arm removed, which is the case the harness's own bound says it
cannot see on its own and which is caught here by a case existing for that arm:

    --- FAIL: TestCases/record-is-a-directory
        check_test.go:45: expected refusal not produced: experiment-has-no-record

## What is not covered

Nobody other than the author has read this change. The evidence above stands in
place of a second reader rather than alongside one.

The second refusal #16 asks for is absent, and #16 stays open for it.

Two refusal sites produce one property here, which is exactly the bound written
at the harness. A fixture for either arm satisfies the standing requirement for
both, and what catches the loss of one arm is the case for that arm existing,
which is a fixture somebody remembered rather than something the harness can
require. Both cases exist and the proof above exercises them separately.

This judges nothing about whether a question is a good question or really one
question. No reading of the tree makes that judgement and none is attempted.

The suite ran on one platform. Record `0012` names three that get a suite run
and #57 is what makes them all run.

Contributes to #16
