### PR TITLE
Build the integration-hardware harness and keep it out of the default run

### DIFF
--- a/internal/hardware/hardware.go
+++ b/internal/hardware/hardware.go
@@ -1,0 +1,81 @@
+// Package hardware is the integration-hardware harness. Its name says out
+// loud what it is: it needs hardware, and it is not part of the default run.
+// A harness called something neutral gets mistaken for the main suite by
+// whoever reads the output next, and a green board then means less than it
+// appears to.
+//
+// Record 0007 keeps the default run headless and unelevated. This harness is
+// where a test that genuinely cannot meet those halves goes instead, so the
+// default run stays clean and the things it cannot cover are somewhere else
+// with their own name rather than skipped inside it.
+//
+// A measurement this harness produces is a measurement about the machine it
+// ran on. It is never reported as the default suite's result, on the board or
+// in any document, because that is what it would have to be to mean anything
+// there.
+//
+// Nothing runs from here unless it is asked for. The tests are behind a build
+// constraint, so the default run does not compile them, and Needs refuses to
+// let one run even when the constraint is satisfied and the harness was not
+// asked for.
+package hardware
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// Name is what this harness is called wherever it is referred to.
+const Name = "integration-hardware"
+
+// BuildTag is the constraint its tests are behind. The default run does not
+// compile them, which is a stronger exclusion than skipping at run time: a
+// test that is not compiled cannot be enabled by accident, and it cannot fail
+// the default run by failing to build against hardware that is not there.
+const BuildTag = "integration_hardware"
+
+// EnvVar is how the harness is asked for. It is deliberately a second gate
+// behind the build constraint, so that a person who builds with the tag out
+// of curiosity still gets nothing until they say they meant it.
+const EnvVar = "LAB_INTEGRATION_HARDWARE"
+
+// Asked reports whether this harness was asked for.
+func Asked() bool {
+	return os.Getenv(EnvVar) == "1"
+}
+
+// Disclosure is the line a run prints when this harness was not asked for. It
+// says that it was not asked for and what asking would cost, so a run that
+// covered less than the whole set cannot be read as one that covered it and
+// found nothing.
+func Disclosure() string {
+	return fmt.Sprintf(
+		"the %s harness was not asked for and nothing in it ran.\n"+
+			"asking costs a machine with the hardware each test names and an explicit request:\n"+
+			"    go test -tags %s ./internal/hardware\n"+
+			"with %s=1 in the environment. its results are about that machine and are not this suite's results.",
+		Name, BuildTag, EnvVar)
+}
+
+// Needs names the hardware a test requires, in words a person can act on, and
+// stops the test where the harness was not asked for.
+//
+// Every test in this harness calls it, and the default run holds them to that
+// rather than trusting it: a failure saying a device was unavailable is
+// useful, and one saying an assertion failed is not.
+//
+// What happens when the harness was asked for and the hardware is not there
+// is not decided here. That is issue #31, which is about what a skip says,
+// and this function is where it will go.
+func Needs(t *testing.T, hardware string) {
+	t.Helper()
+
+	if hardware == "" {
+		t.Fatal("this test names no hardware, so a reader cannot tell what it would take to run it")
+	}
+	if !Asked() {
+		t.Skipf("%s was not asked for. this test needs %s", Name, hardware)
+	}
+	t.Logf("this test needs %s, and it ran on whatever machine that is", hardware)
+}

--- a/internal/hardware/hardware_test.go
+++ b/internal/hardware/hardware_test.go
@@ -1,0 +1,151 @@
+package hardware
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestMain prints the disclosure on every default run. That line is the whole
+// point of the harness being separate: a run that covered less than the whole
+// set must not be readable as one that covered it and found nothing.
+func TestMain(m *testing.M) {
+	if !Asked() {
+		fmt.Println(Disclosure())
+	}
+	os.Exit(m.Run())
+}
+
+// TestTheHarnessIsNotInTheDefaultRun holds the exclusion rather than trusting
+// it. Every test of this harness is behind the build constraint, so the
+// default run does not compile them; this file has no constraint, so it runs
+// either way and can say which of the two it is in.
+func TestTheHarnessIsNotInTheDefaultRun(t *testing.T) {
+	if Asked() {
+		t.Skip("this run asked for the harness, so there is no default-run exclusion to check")
+	}
+
+	for _, name := range hardwareTestFiles(t) {
+		source, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("cannot read %s: %v", name, err)
+		}
+		// The first line, whatever ends it. A file that arrived through a
+		// translating checkout is a separate problem with its own message,
+		// and reporting it here as a missing constraint would send the
+		// reader to the wrong repair.
+		first, _, _ := strings.Cut(string(source), "\n")
+		if strings.TrimSpace(first) != "//go:build "+BuildTag {
+			t.Errorf("%s is a harness file and does not open with the %s build constraint, so the default run would compile it", name, BuildTag)
+		}
+	}
+}
+
+// TestEveryHardwareTestNamesItsHardware refuses a test in this harness that
+// does not say what it needs. A failure that says a device was unavailable is
+// useful and one that says an assertion failed is not, and the difference is
+// whether the test named the hardware.
+//
+// It reads the harness source rather than running it, because the harness is
+// not compiled into the default run and this test is. That is what makes the
+// requirement reach a hardware test nobody has written yet.
+func TestEveryHardwareTestNamesItsHardware(t *testing.T) {
+	files := hardwareTestFiles(t)
+	if len(files) == 0 {
+		t.Fatalf("no file in this package is behind the %s constraint, which cannot be right while the harness exists", BuildTag)
+	}
+
+	fset := token.NewFileSet()
+	found := 0
+
+	for _, name := range files {
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("cannot parse %s: %v", name, err)
+		}
+
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || !strings.HasPrefix(fn.Name.Name, "Test") || fn.Name.Name == "TestMain" {
+				continue
+			}
+			found++
+
+			if !callsNeeds(fn) {
+				t.Errorf("%s in %s does not name the hardware it requires, so a reader who cannot run it is told nothing", fn.Name.Name, name)
+			}
+		}
+	}
+
+	if found == 0 {
+		t.Error("the harness holds no test, so nothing here proves the requirement reaches one")
+	}
+}
+
+// callsNeeds reports whether a test calls Needs, which is the one place a
+// test names its hardware.
+func callsNeeds(fn *ast.FuncDecl) bool {
+	calls := false
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fun := call.Fun.(type) {
+		case *ast.Ident:
+			if fun.Name == "Needs" {
+				calls = true
+			}
+		case *ast.SelectorExpr:
+			if fun.Sel.Name == "Needs" {
+				calls = true
+			}
+		}
+		return true
+	})
+	return calls
+}
+
+// hardwareTestFiles returns the files this harness's tests live in, found by
+// their name rather than by a list. The naming rule matters more than the
+// exact string: a file whose name says integration hardware is a file nobody
+// mistakes for the default suite while reading a directory listing.
+func hardwareTestFiles(t *testing.T) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("cannot read this package: %v", err)
+	}
+
+	var files []string
+	for _, entry := range entries {
+		if name := entry.Name(); strings.HasSuffix(name, "_"+BuildTag+"_test.go") {
+			files = append(files, name)
+		}
+	}
+	return files
+}
+
+// TestNeedsRefusesATestThatNamesNothing proves the one thing Needs refuses on
+// its own. The requirement above is read out of the source, so it catches a
+// test with no call at all; this catches a call that names nothing, which the
+// source reader cannot tell from a good one.
+func TestNeedsRefusesATestThatNamesNothing(t *testing.T) {
+	fake := &testing.T{}
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		Needs(fake, "")
+	}()
+	<-done
+
+	if !fake.Failed() {
+		t.Error("Needs accepted a test that names no hardware")
+	}
+}

--- a/internal/hardware/storage_integration_hardware_test.go
+++ b/internal/hardware/storage_integration_hardware_test.go
@@ -1,0 +1,60 @@
+//go:build integration_hardware
+
+package hardware
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestSequentialWriteOnRealStorage is the first test in this harness and the
+// shape every later one follows: it names the hardware it needs in its first
+// line, it measures, and it reports the measurement rather than asserting a
+// number.
+//
+// It asserts nothing about how fast the storage is. A threshold would be a
+// claim about one machine written into a test that runs on another, which is
+// exactly the mistake this harness exists to keep out of the default run. What
+// it fails on is the write not working at all.
+//
+// The measurement is about the machine it ran on. It is not this suite's
+// result and it is not a property of this repository.
+func TestSequentialWriteOnRealStorage(t *testing.T) {
+	Needs(t, "the storage device the temporary directory is on, with room for 32 MiB")
+
+	const size = 32 << 20
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "block")
+
+	block := make([]byte, 1<<20)
+	for i := range block {
+		block[i] = byte(i)
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("cannot create %s: %v", path, err)
+	}
+
+	start := time.Now()
+	for written := 0; written < size; written += len(block) {
+		if _, err := file.Write(block); err != nil {
+			file.Close()
+			t.Fatalf("cannot write to %s: %v", path, err)
+		}
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		t.Fatalf("cannot flush %s to the device: %v", path, err)
+	}
+	elapsed := time.Since(start)
+	if err := file.Close(); err != nil {
+		t.Fatalf("cannot close %s: %v", path, err)
+	}
+
+	t.Logf("wrote and flushed %d MiB in %s, which is %.1f MiB per second on this machine",
+		size>>20, elapsed, float64(size>>20)/elapsed.Seconds())
+}


### PR DESCRIPTION
`internal/hardware/`, called `integration-hardware` everywhere it is referred
to, with one test in it and two gates in front of it.

This does NOT close #30. The clause asking the default run to print that the
harness was not asked for is met by the harness and not by `go test`, which
prints nothing for a package that passes. The detail and the command are below
and in #30, which stays open.

## The means

Go, record `0001`. A build constraint rather than a run-time skip for the outer
gate, because a test that is not compiled cannot be enabled by accident and
cannot redden the default run by failing to build against hardware that is not
there. The package sits under `internal/`, which record `0002` names; a new
directory at the root would be a change to that record.

## The two gates

    go test ./...                                       nothing here is compiled
    go test -tags integration_hardware ./internal/hardware   compiled, and skipped
    LAB_INTEGRATION_HARDWARE=1 go test -tags ... ./internal/hardware   run

Measured, in that order:

    go test -count=1 -tags integration_hardware -v -run TestSequentialWriteOnRealStorage ./internal/hardware
    === RUN   TestSequentialWriteOnRealStorage
        storage_integration_hardware_test.go:25: integration-hardware was not asked for. this test needs the storage device the temporary directory is on, with room for 32 MiB
    --- SKIP: TestSequentialWriteOnRealStorage (0.00s)

    LAB_INTEGRATION_HARDWARE=1 go test -count=1 -tags integration_hardware -v -run TestSequentialWriteOnRealStorage ./internal/hardware
    === RUN   TestSequentialWriteOnRealStorage
        storage_integration_hardware_test.go:25: this test needs the storage device the temporary directory is on, with room for 32 MiB, and it ran on whatever machine that is
        storage_integration_hardware_test.go:58: wrote and flushed 32 MiB in 26.0087ms, which is 1230.4 MiB per second on this machine
    --- PASS: TestSequentialWriteOnRealStorage (0.03s)

That number is about the machine it ran on. It is not this suite's result and
it is not a property of this repository, which is what the package
documentation says and what the log line repeats where somebody will actually
read it.

## Evidence

Green on a fresh clone of the branch head:

    git clone --branch headless/the-integration-hardware-harness <this repo> fresh8
    cd fresh8 && git rev-parse --short HEAD
    f311f70
    go build ./... && go vet ./...
    go test -count=1 ./...
    ok  	github.com/Flowfin/lab/cmd/lab	1.185s
    ok  	github.com/Flowfin/lab/internal/check	1.267s
    ok  	github.com/Flowfin/lab/internal/hardware	1.399s

Each guard was broken and the default run went red for the reason it names.
One at a time, in a copy, each reverted before the next.

The build constraint removed from a harness file:

    --- FAIL: TestTheHarnessIsNotInTheDefaultRun
        hardware_test.go:43: storage_integration_hardware_test.go is a harness file and does not open with the integration_hardware build constraint, so the default run would compile it

The call naming the hardware removed, with the constraint left intact:

    --- FAIL: TestEveryHardwareTestNamesItsHardware
        hardware_test.go:79: TestSequentialWriteOnRealStorage in storage_integration_hardware_test.go does not name the hardware it requires, so a reader who cannot run it is told nothing

`Needs` made to accept a test that names nothing:

    --- FAIL: TestNeedsRefusesATestThatNamesNothing
        hardware_test.go:149: Needs accepted a test that names no hardware

The second of those is the one that reaches a hardware test nobody has written
yet: it reads the harness source rather than running it, because the harness is
not compiled into the default run and that test is.

## What is not covered

Nobody other than the author has read this change. The evidence above stands in
place of a second reader rather than alongside one.

The disclosure line is not visible in a bare default run. `Disclosure()` is
printed by the harness package before its tests, and `go test` shows a passing
package's output only under `-v`:

    go test -count=1 ./... | grep -c integration-hardware
    0
    go test -count=1 -v ./internal/hardware | head -1
    the integration-hardware harness was not asked for and nothing in it ran.

That is a property of the tool rather than of this code, and closing it needs a
run command that prints what it examined, which is what #29 and #13 build. #30
stays open on that clause.

What a skip says when the harness WAS asked for and the hardware is not there
is not decided here. That is #31, and `Needs` is where it goes; the function
says so in its own comment.

The first test writes to a temporary directory of its own and needs no
elevation, so the harness does not itself breach record `0007` for anybody who
runs it. Nothing here asks for elevation and nothing here would work around a
prompt if it did.

The suite ran on one platform. Record `0012` names three that get a suite run
and #57 is what makes them all run.

Contributes to #30
