### PR TITLE
Add the build and test workflow and fix its check names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,168 @@
+# Build and test the runner.
+#
+# The check names below are the thing to be careful with. They are what the
+# required set on the default branch refers to later, and a job renamed in
+# passing removes itself from that set while the tab still looks green. Every
+# job here carries an explicit `name:`, so the reported name comes from this
+# file rather than from whatever the job id happens to be, and changing one is a
+# change to the gate rather than tidying.
+#
+# The platforms come from docs/decisions/0012-the-supported-platforms.md and
+# from nowhere else. That record names six entries for the build and three for
+# the suite; this workflow holds the build half of it. The suite runs on one
+# platform here, and issue #57 is where it grows to the three the record names.
+#
+# Hardened the way every other workflow in this tree is, because the audit job
+# in zizmor.yml refuses a new one that departs from it: permissions are denied
+# at the top and granted per job, every action is pinned to a commit with its
+# version in a comment, and checkout does not persist credentials.
+name: Build and test
+
+on:
+  pull_request:
+    branches: ["**"]
+  push:
+    branches: [main]
+
+# Explicit deny-all at workflow level; each job grants only what it needs.
+permissions: {}
+
+# Cancel a superseded run on the same ref. Nothing here publishes, so a run that
+# has been overtaken is safe to drop.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    # One entry per platform the release targets. Cross-compiled from one runner
+    # rather than one runner per platform: what this job answers is whether the
+    # source compiles for that target, and the compiler answers that from
+    # anywhere. Whether a hosted runner exists for each label is the question
+    # record 0012 leaves to the first workflow written against it, and the suite
+    # is where it gets settled, not here.
+    name: build (${{ matrix.goos }}/${{ matrix.goarch }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    strategy:
+      # Every entry runs. Stopping the matrix at the first failure would report
+      # one broken platform and leave the others unexamined, which reads as
+      # though only one is broken.
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+          - goos: windows
+            goarch: arm64
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          # The toolchain comes from go.mod, so the version this job uses moves
+          # when the module says so and never separately.
+          go-version-file: go.mod
+          # This module has no dependencies and therefore no go.sum for a cache
+          # key to be built from. Asking for a cache anyway makes the step
+          # depend on a file that is not there.
+          cache: false
+
+      - name: Build for ${{ matrix.goos }}/${{ matrix.goarch }}
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: go build ./...
+
+  test:
+    # Named for the platform it runs on rather than `test`, because issue #57
+    # adds the other two entries record 0012 names and a bare `test` would have
+    # to be renamed to make room for them. A rename is a change to the gate, so
+    # the name that survives that change is the one to write now.
+    name: test (linux/amd64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Run the default suite
+        run: go test ./...
+
+  vet:
+    name: vet
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Vet the runner
+        run: go vet ./...
+
+  format:
+    name: format
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Check formatting
+        # gofmt -l prints the files it would change and exits zero either way,
+        # so the job has to read the output to fail. Printing the names first
+        # means a red run says which files rather than only that some file was
+        # wrong.
+        run: |
+          set -euo pipefail
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "$unformatted"
+            echo "::error::These files are not gofmt-formatted. Run 'gofmt -w .'."
+            exit 1
+          fi
+          echo "Every Go file in this tree is gofmt-formatted."


### PR DESCRIPTION
Closes #13.

## What this changes

`.github/workflows/build.yml` is new and nothing else moves. It builds the
runner for every platform `docs/decisions/0012-the-supported-platforms.md`
names, vets it, runs the default suite, and checks formatting.

## The check names

Four jobs, each with an explicit `name:` rather than an inherited job id:

    build (linux/amd64)
    build (linux/arm64)
    build (darwin/amd64)
    build (darwin/arm64)
    build (windows/amd64)
    build (windows/arm64)
    test (linux/amd64)
    vet
    format

Those strings are what the required set on the default branch refers to once
#26 assembles it, so a rename afterwards is a change to the gate. The suite
entry carries its platform in its name already. Record 0012 gives the suite
three platforms and #57 adds the other two, and naming this one `test` today
would make that addition a rename of a gate instead of an addition beside it.

## The platform list

Six build entries, taken from record 0012 and from nothing else. They are
cross-compiled from one runner because what the build job answers is whether
the source compiles for a target, and the compiler answers that from anywhere.
Record 0012 leaves open whether a hosted runner is offered for each label and
says the first workflow written against it is where that gets settled. This
workflow does not settle it: cross-compilation never asks for those labels. It
is the suite in #57 that asks, and that is where the answer will arrive.

## Hardening

Actions pinned to a commit with the version in a comment, `permissions: {}` at
the top with `contents: read` granted per job, and `persist-credentials: false`
on every checkout. That is the pattern the other workflows in this tree already
carry and what the audit job refuses a departure from. `cache: false` on
`setup-go`: this module has no dependencies and therefore no `go.sum` for a
cache key to be built from.

## Means

YAML in a GitHub Actions workflow, because the thing being built is a set of
checks that run on this repository's pull requests and the platform reads no
other format. The logic inside the steps is the toolchain's own verbs rather
than a script, so the only thing this file adds is the wiring.

## Evidence

Run at `a4e9805559009f9ecc761e37d2dbbc5a0ee4c89f`, which is the head of this
branch.

    $ for t in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do
        GOOS=${t%/*} GOARCH=${t#*/} go build ./... && echo "ok   $t"
      done
    ok   linux/amd64
    ok   linux/arm64
    ok   darwin/amd64
    ok   darwin/arm64
    ok   windows/amd64
    ok   windows/arm64

    $ go vet ./...
    (no output)

    $ gofmt -l .
    (no output)

    $ go test ./...
    ok  	github.com/Flowfin/lab/cmd/lab
    ok  	github.com/Flowfin/lab/internal/check
    ok  	github.com/Flowfin/lab/internal/hardware

That is the local half. The half that matters for the Done-when is the run on
this pull request, because a workflow that passes nowhere but a laptop is not a
gate. Whether the audit job accepts this file, and whether every job above
reports under the name written into it, is read off this pull request rather
than asserted here.

## What this does not do

It does not make any of these checks required. #26 assembles the required set,
and putting the setting in two places would leave a reader trusting the one
nobody edits.

It does not run the suite anywhere but `linux/amd64`. Record 0012 asks for
three and #57 is the issue that adds the other two, along with the executed
test count that separates a suite which ran everything from one that ran
nothing.

Nobody else has read this change. The evidence above stands in place of a
second reader rather than alongside one.
