### PR TITLE
Run the suite on every platform the release ships

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,10 @@
 #
 # The platforms come from docs/decisions/0012-the-supported-platforms.md and
 # from nowhere else. That record names six entries for the build and three for
-# the suite; this workflow holds the build half of it. The suite runs on one
-# platform here, and issue #57 is where it grows to the three the record names.
+# the suite, and both halves are here. The three the suite runs on are the three
+# that differ in what a checkout is, which is the whole of what the runner
+# reads; the other three are compiled and produce no evidence beyond that the
+# source builds.
 #
 # Hardened the way every other workflow in this tree is, because the audit job
 # in zizmor.yml refuses a new one that departs from it: permissions are denied
@@ -89,15 +91,47 @@ jobs:
         run: go build ./...
 
   test:
-    # Named for the platform it runs on rather than `test`, because issue #57
-    # adds the other two entries record 0012 names and a bare `test` would have
-    # to be renamed to make room for them. A rename is a change to the gate, so
-    # the name that survives that change is the one to write now.
-    name: test (linux/amd64)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # One entry per platform record 0012 says the release ships a binary for and
+    # the suite runs on. Compiling for a platform is not the property that
+    # matters most here: the runner's whole job is reading a checkout, and what
+    # a checkout is differs between these three. Case folding, the path
+    # separator and what a line ending arrives as are the three properties
+    # record 0012 chose the list from, and each entry below differs from the
+    # baseline in at least one of them.
+    #
+    # The label is not the platform. `macos-latest` is an arm64 image, which is
+    # the `darwin/arm64` entry; the names below are written from the record's
+    # vocabulary rather than from the runner label, because the record is what a
+    # reader is holding when they ask whether every entry is covered.
+    #
+    # Record 0012 leaves open whether a hosted runner is offered for each of
+    # these and says the first workflow written against it settles that, since a
+    # run either arrives on the label or does not. This job is that workflow.
+    # The build matrix above never asked, because it cross-compiles.
+    name: test (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
     permissions:
       contents: read
+    strategy:
+      # Every platform runs. Stopping at the first failure would leave the other
+      # two unexamined, and a checker whose whole job is reading a checkout is
+      # the last thing to learn about on one platform at a time.
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: windows/amd64
+            runner: windows-latest
+          - platform: darwin/arm64
+            runner: macos-latest
+    defaults:
+      run:
+        # One shell for all three entries, so the counting step below is one
+        # script rather than three that have to be kept saying the same thing.
+        # Every image these entries run on carries bash.
+        shell: bash
     steps:
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -111,7 +145,33 @@ jobs:
           cache: false
 
       - name: Run the default suite
-        run: go test ./...
+        # The same suite on every entry. No platform gets a reduced set and no
+        # package is excluded here, because the platform whose difficult tests
+        # are left out is the platform the defect is on.
+        #
+        # -count=1 rather than the cache, so a green entry is a suite that ran
+        # on this machine rather than one whose stored output was replayed.
+        #
+        # The count is what separates a suite that ran everything and passed
+        # from one that executed nothing and reported success, which look
+        # identical from outside. Top-level results are counted: a subtest's
+        # line is indented, so the anchored pattern does not read it twice.
+        #
+        # The platform reaches the script through the environment rather than
+        # through an expression inside it, which is the pattern the other
+        # workflows here already carry.
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          go test -count=1 -v ./... 2>&1 | tee suite.log
+          executed=$(grep -cE '^--- (PASS|FAIL): ' suite.log || true)
+          skipped=$(grep -cE '^--- SKIP: ' suite.log || true)
+          echo "${PLATFORM}: executed ${executed} test(s), skipped ${skipped}"
+          if [ "$executed" -eq 0 ]; then
+            echo "::error::The suite reported success having executed no tests on ${PLATFORM}."
+            exit 1
+          fi
 
   vet:
     name: vet


### PR DESCRIPTION
Closes #57.

Stacked on #88, which adds the workflow this change edits. The base of this
pull request is `scaffolding/the-build-and-test-workflow`, so the diff here is
the suite matrix and nothing else.

## What this changes

The `test` job in `.github/workflows/build.yml` becomes a matrix over the three
platforms `docs/decisions/0012-the-supported-platforms.md` says the suite runs
on, and gains the executed-test count.

## The names

    test (linux/amd64)
    test (windows/amd64)
    test (darwin/arm64)

Written from the record's vocabulary rather than from the runner label, because
the record is what a reader is holding when they ask whether every entry is
covered, and `macos-latest` does not say `darwin/arm64` to anybody checking. The
label is carried beside it in the matrix. These are the strings the required set
refers to once #26 assembles it.

## The two properties

Every platform runs the same suite. `go test -count=1 -v ./...` on all three,
with no package excluded and no platform-conditional skip added. The tree has no
`t.Skip` reachable from the default run today, which is the state this keeps
rather than a claim it establishes:

    $ grep -rn "t.Skip" --include=*.go .
    ./internal/hardware/hardware.go:78:		t.Skipf("%s was not asked for. this test needs %s", Name, hardware)
    ./internal/hardware/hardware_test.go:29:		t.Skip("this run asked for the harness, so there is no default-run exclusion to check")

Both of those sit behind the harness request, and the printed skipped count is
what makes a change to that visible rather than silent.

Each run says what it examined. The step counts top-level results and fails when
the executed count is zero. `-count=1` is part of the same property: without it
a green entry could be a replay of stored output rather than a suite that ran on
that machine.

## Evidence that the count guard bites

The counting script, run unchanged on `windows/amd64`, which is one of the three
entries:

    $ go test -count=1 -v ./... 2>&1 | tee suite.log
    $ executed=$(grep -cE '^--- (PASS|FAIL): ' suite.log || true)
    $ skipped=$(grep -cE '^--- SKIP: ' suite.log || true)
    $ echo "windows/amd64: executed ${executed} test(s), skipped ${skipped}"
    windows/amd64: executed 15 test(s), skipped 0

The same script over a module that compiles and has no tests, which is the case
the guard exists for. `go test` is green there and the step is not:

    ?   	notests	[no test files]
    PLATFORM: executed 0 test(s), skipped 0
    ::error::The suite reported success having executed no tests on PLATFORM.
    exit=1

## What this settles that the record left open

Record 0012 says whether a hosted runner is offered for each of the three suite
entries is a question the first workflow written against it settles, since a run
either arrives on the label or does not. The build matrix in #88 never asked,
because it cross-compiles. This job asks. Whether all three arrive is read off
the checks on this pull request, not asserted here.

## Means

The same workflow file and the same YAML, because this is a change to an
existing gate rather than a new artefact. The counting step is bash on all three
entries, declared once at the job rather than written three times in three
dialects, so the property the three runs share is one script a reader compares
against one sentence.

## Limits

The count is of top-level tests. A subtest's result line is indented, so it is
not counted twice, and a package whose tests all became subtests of one parent
would report a smaller number without anything being wrong. What the guard
refuses is zero, and zero is the case that is indistinguishable from a healthy
run.

Nobody else has read this change. The evidence above stands in place of a second
reader rather than alongside one.

## What the run on this pull request said

All three entries arrived on their labels, which is the question record 0012
left for the first workflow written against it. Each printed its count:

    darwin/arm64: executed 15 test(s), skipped 0
    linux/amd64: executed 15 test(s), skipped 0
    windows/amd64: executed 15 test(s), skipped 0

Read from the job logs of run 31301451314. The same number on all three is what
"no platform runs a reduced set" looks like from outside, and it is a
measurement rather than a claim only because each job prints it.
