### PR TITLE
Write CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,184 @@
+# Contributing
+
+This board is for questions that will probably fail. Everything here is public
+from the first commit, a failed experiment included, and the one rule that keeps
+that from producing a graveyard is that every experiment states its question
+before it starts and its answer when it stops. The answer may be no. An
+experiment with no written answer is not finished, it is abandoned, and the
+difference is meant to be visible.
+
+## Before you push
+
+Run these, in this order, from the root of a checkout:
+
+```
+go build ./...
+go vet ./...
+gofmt -l .
+go test ./...
+```
+
+`gofmt -l` prints the files it would change and exits zero either way, so read
+its output rather than its exit code. No output is the passing result.
+
+That is what the gate runs on the server, so running it here means running the
+same thing rather than something that resembles it. What the checks are and what
+each one covers is not listed in this document. The run says what it examined,
+and a list written down here drifts against the thing it describes:
+
+```
+go run ./cmd/lab check .
+```
+
+The exit codes that command can return are a contract, in
+[docs/decisions/0011-the-exit-codes.md](docs/decisions/0011-the-exit-codes.md),
+and anything keyed on one of them is reading that record whether or not anybody
+said so.
+
+Nothing runs any of this for you on the way out. A fresh clone installs no git
+hook, so the commands above are yours to run. If you skip them, the first thing
+that notices is the pull request, and by then the failure is on the board rather
+than in your terminal.
+
+## Signing your work
+
+Every commit carries a `Signed-off-by` trailer matching its author. That trailer
+is you asserting the Developer Certificate of Origin, whose text is in
+[DCO](DCO) at the root of this repository. Read it once. It is short, and it is
+what you are asserting.
+
+`git commit` takes `-s` and writes the trailer for you from your configured name
+and address. A branch whose commits predate the habit takes
+`git rebase --signoff` against the base you branched from. A commit whose
+trailer does not match its author does not count, so if you change your git
+identity mid-branch, check the trailers before you push.
+
+## Starting an experiment
+
+The question is written first. Not sketched, not held in your head while you get
+something working, written.
+
+Create `experiments/<slug>/` and `experiments/<slug>/EXPERIMENT.md` in one
+commit, with the record in state `asking` and the question in it. One directory
+holds one experiment and one question. A directory holding three questions has
+no state that is true of all of them, and a record whose question is a topic
+rather than a question can never be shown to have missed its answer.
+
+The layout is fixed in
+[docs/decisions/0002-repository-layout.md](docs/decisions/0002-repository-layout.md)
+and the states are fixed in
+[docs/decisions/0003-the-experiment-lifecycle.md](docs/decisions/0003-the-experiment-lifecycle.md).
+There are three states and no others: `asking`, `answered`, `abandoned`.
+
+## Stopping one
+
+Two honest ways to stop, and both of them are finished work.
+
+Write the answer and move the record to `answered`. No is an answer. So is
+finding out that the question was the wrong question, which is often the most
+useful thing an experiment produces. An answered experiment is finished
+whichever way it went, and nothing on this board treats a no as a lesser
+outcome. Anyone who ever feels a check here pushing them towards a more
+flattering answer should report that as a defect in the check.
+
+Or move the record to `abandoned` and write one sentence saying what stopped the
+work. That is a lower bar than an answer on purpose. Moving here is always
+available and always cheaper than the alternative, which is leaving a record in
+`asking` while nothing happens. Anybody reading the tree may do it, not only
+whoever started the work, and an abandoned experiment somebody picks up again
+goes back to `asking`.
+
+The record is permanent either way. It is not deleted and it is not rewritten to
+hide what it said; what it gains over time is lines added to it, never lines
+replaced. The code is not permanent: once there is an answer, the prototype can
+be removed in a later commit, and the record gains one line naming the commit
+that removed it, with the full hash. That is
+[docs/decisions/0004-what-happens-to-the-code.md](docs/decisions/0004-what-happens-to-the-code.md).
+
+## What may never be committed
+
+Git history does not forget, so this is about what is committed at all rather
+than about what is in the current checkout. The reasoning is in
+[docs/decisions/0006-everything-here-is-public.md](docs/decisions/0006-everything-here-is-public.md).
+
+- No credential, token, key or secret of any kind, including expired and rotated
+  ones. An expired credential still reveals its format, its issuer and often the
+  account it belonged to.
+- No personal data of any kind, whether it is yours or somebody else's. Names,
+  addresses, e-mail addresses, device identifiers and account identifiers are
+  all covered.
+- No copy of a real media library, real account data, or real logs from a
+  running server, whoever runs it.
+- No file whose licence forbids it being here.
+
+Where an experiment needs real data to answer its question, the data stays on
+the host it is already on. It does not enter the tree as a fixture, as a sample,
+as an attachment, redacted, or in a screenshot. Redaction is named because it is
+the failure that feels safe: a partially masked identifier is still an
+identifier, and a screenshot of a list is a copy of the list. What may be
+written down is the measurement and the command that produced it.
+
+Nothing in this repository refuses a violation of that list today. What stands
+behind it is you reading before you commit and somebody reading the change, and
+that is written here plainly so that nobody mistakes the list for a gate. A
+mistake here is handled as an exposure rather than as a revert, which means
+rotating what leaked and saying so.
+
+## Headless and unelevated
+
+Every test in the default run completes with no graphical session and as an
+ordinary user. Both halves bind from the first test, not from the milestone that
+builds the mechanism that enforces them, and the reasoning is in
+[docs/decisions/0007-headless-by-birth.md](docs/decisions/0007-headless-by-birth.md).
+
+Learn this before you write a test rather than from a red board afterwards. A
+test that needs a display runs on one machine, and a suite that runs on one
+machine stops being evidence the first time that machine is unavailable. A test
+that needs administrator rights is worse, because the operating system answers
+by asking a question only an administrator can answer, on somebody else's
+machine, where nobody is watching, and that is indistinguishable from a hang.
+
+A test that genuinely cannot meet both halves does not get an exception and it
+does not skip itself inside the default run. It goes to the integration-hardware
+harness under `internal/hardware/`, which is a separate thing with its own name.
+Its tests are behind a build constraint, so the default run does not compile
+them, and they are asked for explicitly:
+
+```
+LAB_INTEGRATION_HARDWARE=1 go test -tags integration_hardware ./internal/hardware
+```
+
+Every test there names the hardware it requires, in words somebody can act on,
+and the default run holds them to that by reading the harness source. A
+measurement that harness produces is a measurement about the machine it ran on.
+It is never reported as the default suite's result.
+
+## What this board does not take
+
+Three things, and an idea that needs any of them is a product idea that belongs
+on a product board rather than here.
+
+Nothing a user is asked to install. This board ships a runner for people working
+in this repository and nothing that ends up on anybody else's machine as a
+product.
+
+Nothing the site advertises. An experiment is allowed to fail, and something
+that has been announced cannot fail quietly, which removes the only thing this
+board offers.
+
+Nothing another board is allowed to depend on. Work that leaves here does so by
+promotion, which is a hand-over recorded on both sides and never a dependency
+edge pointing back at an experiment. That route is
+[docs/decisions/0005-how-a-result-leaves.md](docs/decisions/0005-how-a-result-leaves.md).
+Nothing in this repository ever writes to another one.
+
+## Everything else
+
+Planning happens on the issue tracker first, and every decision that shapes the
+architecture is argued there before the code that depends on it exists. What
+survives the argument is written down in
+[docs/decisions/](docs/decisions/), in the shape
+[docs/decisions/0000-how-decisions-are-recorded.md](docs/decisions/0000-how-decisions-are-recorded.md)
+sets out. A record is replaced by a later record rather than edited, so the
+directory stays a history of what was argued instead of a description of what is
+currently there.


### PR DESCRIPTION
Closes #9.

`CONTRIBUTING.md` at the root, and nothing else moves.

## What it carries

Each bullet the issue asks for, in the order a contributor meets them rather
than the order they were listed.

The commands that have to pass before a push, in the order they run, in one
block. `gofmt -l` is called out separately because it exits zero whether or not
it found something, so a reader keyed on the exit code would learn nothing from
it.

Signing. The trailer, what it asserts, a pointer to `DCO`, the flag that writes
it, and the flag that repairs a branch that predates the habit. Also the case
that costs people an afternoon: a trailer that does not match its author does
not count, so changing git identity mid-branch means checking the trailers.

Starting an experiment. The question is written first, and the directory and its
record are created in one commit with the record in `asking`.

Stopping one, both honest ways. Answered with the answer written, where no is an
answer, or abandoned with one sentence saying what stopped the work. The
permanence of the record and the impermanence of the code, which are two
different rules that are easy to read as one.

What may never be committed, from record 0006, including the sentence that
nothing in this repository refuses a violation of that list today. That
disclosure is in the document rather than only in the record, because the
document is what somebody reads before their first commit.

Headless and unelevated, from record 0007, with the reason stated in terms of
what goes wrong rather than as a rule, and the harness a test that cannot meet
it goes to instead, with the command that asks for it.

What this board does not take. Nothing a user installs, nothing the site
advertises, nothing another board may depend on.

## What it deliberately does not do

It does not list the checks. The run prints what it examined, and a list here
drifts against the thing it describes, so the document points at
`go run ./cmd/lab check .` and at the exit-code record instead of reproducing
either.

## Means

Markdown at the repository root, because the platform, every editor and every
plain-text reader render it, and it is what the DCO workflow's failure message
already points a contributor at. It adds no language, no runtime and no
dependency to the tree.

## Evidence

The Done-when asks that every command the document quotes runs successfully on a
fresh clone of the default branch. Run against a clone made for this, at
`37ef6f1816458de6a440756482ef96bb75cdced0`, which was the head of `main`:

    $ git clone --depth 1 --branch main https://github.com/Flowfin/lab freshclone
    $ cd freshclone && git rev-parse HEAD
    37ef6f1816458de6a440756482ef96bb75cdced0

    $ go build ./...
    exit=0

    $ go vet ./...
    exit=0

    $ gofmt -l .
    (no output) exit=0

    $ go test ./...
    ok  	github.com/Flowfin/lab/cmd/lab	0.827s
    ok  	github.com/Flowfin/lab/internal/check	1.076s
    ok  	github.com/Flowfin/lab/internal/hardware	0.810s

    $ go run ./cmd/lab check .
    examined .
    no experiments directory in this tree
    0 experiment directories walked, 0 records read
    0 refused
    exit=0

    $ LAB_INTEGRATION_HARDWARE=1 go test -tags integration_hardware ./internal/hardware
    ok  	github.com/Flowfin/lab/internal/hardware	1.080s
    exit=0

That clone was made on `windows/amd64`, which is one of the three platforms
record 0012 names for the suite. It is one platform and not three, and the
issue asks for a fresh clone rather than for a matrix.

`git commit -s` and `git rebase --signoff` appear in the prose as flags to
commands a contributor is already running, not as quoted commands of their own,
because neither does anything useful in a clean clone with nothing staged.

## Limits

Every link in the document resolves at this commit, and nothing here refuses one
that stops resolving later. #25 is where a check over the paths this
repository's own documents name is planned; until it lands, a dead link in this
file is caught by a reader.

Nobody else has read this change. The evidence above stands in place of a second
reader rather than alongside one.


## What ran on this pull request, and what did not

The build and test workflow is not on the default branch yet. It arrives with
#88, and a `pull_request` run reads the workflow files from the merge of base
and head, so no `build`, `test`, `vet` or `format` job exists for this branch to
report. What ran here is the DCO, Unicode, workflow-audit and dependency-review
set the checks tab shows.

So the suite evidence above is local and one-platform, and it stays that way
until the build workflow is on `main`. Once it is, a branch taken from `main`
gets the three-platform suite reporting on its own pull request, and this
change should be re-run there rather than trusted from here.
