### PR TITLE
Fix the shape of an experiment record

### DIFF
--- a/docs/decisions/0008-the-experiment-record.md
+++ b/docs/decisions/0008-the-experiment-record.md
@@ -1,0 +1,169 @@
+# 0008. What an experiment record looks like
+
+## What was decided
+
+Record `0003` says what an experiment record has to mean. This record says what
+it has to look like, because a rule a machine cannot read is an explanation of a
+rule rather than a rule.
+
+`EXPERIMENT.md` opens with a small header of fixed fields and continues as
+prose. The header is what the runner reads. The prose is what a person reads,
+and nothing tries to parse it.
+
+### The header
+
+The header is the run of lines from the first byte of the file to the first
+blank line. Every line in it is a field, written as a name, a colon, a space and
+a value, with the name at column zero:
+
+    Slug: sequential-write-on-spinning-disk
+    State: asking
+    Question-Written: 2026-08-09
+
+Four field names are fixed here.
+
+`Slug` repeats the name of the directory the record sits in, so a reader holding
+a quoted slug can walk back to the experiment and a reader holding the record
+can tell which directory it belongs in. What a slug may be in the first place is
+not decided here; issue #59 fixes that shape and supersedes this record when it
+does.
+
+`State` is one of the three record `0003` names, written exactly as that record
+writes them: `asking`, `answered`, `abandoned`.
+
+`Question-Written` is the date the question was written, as `YYYY-MM-DD`. It is
+written in the commit that creates the directory and it does not move
+afterwards, because it is what the listing sorts by and a date that can be
+edited sorts a stalled experiment wherever its author prefers.
+
+`Answer-Written` is the date the answer was written, in the same shape. It is
+absent until there is an answer and it is added in the same change as the
+answer.
+
+Order does not matter and a name appears at most once. A name this record does
+not fix is allowed to appear: a field added by a later record is unknown to
+every checker built before it, and a format that refused an unrecognised name
+could only ever grow by breaking the checkers already in the tree.
+
+### The prose
+
+Headings at level two, in this order:
+
+    ## Question
+    ## Method
+    ## Answer
+
+Text may sit between the header and the first heading, and nothing reads it. A
+title, a note to whoever picks the work up, or nothing at all. It is named here
+so that a checker built against this record treats it as prose rather than as a
+malformed section.
+
+`## Question` carries one question, written as a question. One question and not
+a topic, because a directory holding three questions has no state that is true
+of all of them, and a record whose question is a topic can never be shown to
+have missed its answer.
+
+`## Method` says what was done, in enough detail that somebody else could do it
+again or say why they cannot.
+
+`## Answer` exists in every record from the day it is created, and it is empty
+until there is an answer. That is the shape rather than an accident of the
+template. Writing an answer is then filling in something that is visibly
+missing, rather than remembering to add a heading whose absence nobody sees.
+
+A promoted experiment also carries `## Promotion`, which record `0005` fixes the
+contents of. It is added by the change that hands the work over and it is absent
+from every other record.
+
+### What the format is not
+
+It is not a database. It is text somebody has to want to read, and a header of
+twenty fields would be a form to fill in rather than a record to write. The
+machine-readable part is kept to what the checks genuinely need, and a thing
+that can live in the prose lives there.
+
+A template lives at `docs/experiment-template.md` and carries the shape above
+with nothing filled in. The template is a convenience and not the authority.
+This record is the authority, and the runner parses the template in its own
+suite so that the two cannot quietly disagree.
+
+Nothing refuses a record over any of this at the commit this record lands on.
+The runner can read the header and the sections, and that is the whole of it.
+The refusals arrive with the issues that argue them: a record that never wrote
+its question, a record claiming an answer it does not carry, a header that
+disagrees with itself, and a slug that is not a legal slug. Writing that gap
+down here is cheaper than a reader inferring from a green run that the format is
+enforced.
+
+## What it applies to
+
+Every `EXPERIMENT.md` under `experiments/`, from the commit this record lands
+on, and every check that reads one.
+
+It applies to the template, which carries this shape and is checked against the
+runner rather than trusted.
+
+How this format changes afterwards is record `0013` and not this record. A field
+added later is optional and a check over it refuses only what is present, which
+is why the four names above are the whole of what a later checker may assume is
+there.
+
+It does not apply to the decision records in `docs/decisions/`. Those carry the
+four sections record `0000` fixes, they hold no state, and they change by
+superseding.
+
+It does not apply to anything else an experiment directory holds. Code, data
+files and notes beside the record are the experiment's own business.
+
+## What else was considered
+
+A header fenced as YAML front matter between `---` lines.
+
+A larger header, carrying the question, the method and the answer as fields
+rather than as prose.
+
+No header at all, with the checker reading the level-two headings and inferring
+the state from which of them carry text.
+
+A separate machine-readable file beside the record, holding the fields, with the
+record left as pure prose.
+
+Refusing a field name this record does not fix.
+
+## What each rejected option would have cost
+
+YAML front matter costs a parser and a dependency, on a runner whose language
+was chosen partly for carrying almost none. It also buys nothing the format
+needs: the values here are a slug, a word from a set of three and two dates, and
+none of them wants nesting, lists, quoting rules or the several ways YAML has of
+writing a date. The cost that would land last is the worst of it, because a YAML
+parser accepts documents this format has no meaning for, so the checker would
+have to refuse valid YAML and explain why.
+
+A larger header costs the record its readability, which is the thing it exists
+for. A question written into a field is a question written to fit on one line,
+and the method is where the detail that makes an experiment reproducible lives.
+It would also put the answer inside the part a machine reads, which invites a
+check over what the answer says, and no reading of a tree can judge that.
+
+No header costs the state. A record read as answered because its answer section
+has text can be answered by typing anything under the heading, and there would
+be nothing for a check to compare the claim against, since the claim and the
+evidence would be the same bytes. Record `0003` makes exactly that point: naming
+the state separately from the answer is what makes "claims answered, carries no
+answer" a thing a machine can see.
+
+A separate fields file costs the one-file rule and buys nothing. An experiment
+would carry two files that have to agree, a reader would have to open both to
+know what they are looking at, and every rule about the record would have to say
+which of the two it meant. It also puts the state somewhere a person editing the
+prose does not see, which is how a record ends up claiming `asking` under a
+finished answer.
+
+Refusing an unfixed field name costs the format its ability to grow. Record
+`0013` makes a new field optional so that records written before it stay legal;
+refusing unknown names would break the same rule from the other side, because
+every checker built before the new field would refuse every record written after
+it. The cost of allowing them is that a misspelled field name is read as a new
+field and passes, and that is a real cost, paid because the alternative makes
+the format un-growable.

--- a/docs/experiment-template.md
+++ b/docs/experiment-template.md
@@ -1,0 +1,30 @@
+Slug: the-slug-of-this-experiment
+State: asking
+Question-Written: 2026-01-01
+
+Copy this file to `experiments/<slug>/EXPERIMENT.md` and replace every value in
+the header above. The slug is the name of the directory this record sits in. The
+state is `asking` on the day that directory is created. The question date is the
+day the question below was written, as `YYYY-MM-DD`, and it does not move
+afterwards, because the listing sorts by it. Add `Answer-Written` in the same
+change that writes the answer.
+
+The format is `docs/decisions/0008-the-experiment-record.md`. This file is a
+convenience and that record is the authority.
+
+## Question
+
+One question, written as a question, so that a reader who was not there can tell
+whether it has been answered. A topic is not a question: an experiment whose
+record says "media transcoding" can never be shown to have missed its answer.
+
+## Method
+
+What was done, in enough detail that somebody else could do it again or say why
+they cannot. The commands, the machine where it matters, and what was measured.
+
+What may never be committed alongside this record, and what happens where a
+question can only be answered against real data, is
+`docs/decisions/0006-everything-here-is-public.md`.
+
+## Answer

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -53,6 +53,28 @@ const (
 	// that no longer exists.
 	RecordNamesAPathThatDoesNotResolve = "record-names-a-path-that-does-not-resolve"
 
+	// RecordStateIsNotOneOfTheThree refuses a record whose state is not one
+	// of the three record 0003 names, which includes a state that is
+	// misspelled, a state written with no value, and no state field at all.
+	// Every other rule about a record's state is conditional on the state,
+	// so a record with no readable state is a record none of them applies
+	// to, and a rule that a typo disables is not a rule.
+	RecordStateIsNotOneOfTheThree = "record-state-is-not-one-of-the-three"
+
+	// RecordClaimsAnAnswerItDoesNotCarry refuses a record in state
+	// answered whose answer section is empty. It does not make anybody
+	// answer. What it makes impossible is claiming to have answered while
+	// having written nothing, which turns a silent half-finished directory
+	// into either a real answer or an honest abandoned.
+	RecordClaimsAnAnswerItDoesNotCarry = "record-claims-an-answer-it-does-not-carry"
+
+	// AbandonedRecordDoesNotSayWhatStoppedTheWork refuses a record in state
+	// abandoned that says nothing about what stopped the work. Abandoning
+	// is allowed here and that is the point of the state existing, but
+	// abandoning without a sentence is the same silence this board is built
+	// to make visible.
+	AbandonedRecordDoesNotSayWhatStoppedTheWork = "abandoned-record-does-not-say-what-stopped-the-work"
+
 	// ExperimentHasNoRecord refuses a directory under experiments/ that
 	// carries no record a reader can open. It catches somebody dropping code
 	// in and meaning to write the record later, and it fires on the change
@@ -232,6 +254,7 @@ func Walk(root string) (Result, error) {
 		res.Records++
 		res.Refusals = append(res.Refusals, refuseBytes(record, data)...)
 		res.Refusals = append(res.Refusals, refusePaths(root, record, data)...)
+		res.Refusals = append(res.Refusals, refuseState(record, data)...)
 	}
 
 	return res, nil
@@ -260,6 +283,93 @@ func refusePaths(root, path string, data []byte) []Refusal {
 	}
 
 	return refusals
+}
+
+// refuseState holds a record to what its own state says about it. Record 0003
+// fixes the three states and what each one requires; this is the half of that
+// a machine can see.
+//
+// What it buys is smaller than it looks and the difference is worth keeping
+// straight. It does not make anybody finish an experiment or write an honest
+// answer. It makes a record that contradicts itself refusable, which converts
+// a silent half-finished directory into either a real answer or an honest
+// abandoned. A record saying "no, this does not work" and a record saying it
+// while its author knows otherwise are the same bytes, and review is the only
+// thing that catches the second.
+//
+// WHERE THIS DOES NOT REACH. A record whose bytes do not parse as a record is
+// not judged here at all. Nothing can read the state of something that has no
+// header, and inventing a state refusal for it would name the wrong repair:
+// whoever hits it has a file that is not a record rather than a record with a
+// bad state. So a record with no header passes every rule below, which is a
+// hole, and it is issue #16's rather than this one's. Read a green run
+// accordingly.
+func refuseState(path string, data []byte) []Refusal {
+	rec, err := ParseRecord(data)
+	if err != nil {
+		return nil
+	}
+
+	state, present := rec.Field(FieldState)
+	switch {
+	case !present:
+		return []Refusal{{
+			Property: RecordStateIsNotOneOfTheThree,
+			Subject:  path,
+			Detail:   fmt.Sprintf("it declares no %s field, so no rule about a state applies to it. record 0003 names %s", FieldState, statesInWords()),
+		}}
+	case state == "":
+		return []Refusal{{
+			Property: RecordStateIsNotOneOfTheThree,
+			Subject:  path,
+			Detail:   fmt.Sprintf("its %s field is there and empty, which is not one of %s", FieldState, statesInWords()),
+		}}
+	case state != StateAsking && state != StateAnswered && state != StateAbandoned:
+		return []Refusal{{
+			Property: RecordStateIsNotOneOfTheThree,
+			Subject:  path,
+			Detail:   fmt.Sprintf("its %s is %q, and record 0003 names %s", FieldState, state, statesInWords()),
+		}}
+	}
+
+	// The answer section carries both. For an answered record it is the
+	// answer; for an abandoned one it is the sentence saying what stopped
+	// the work, which record 0003 makes a lower bar than an answer on
+	// purpose. They are two properties rather than one because the repairs
+	// are different: an answered record with nothing under the heading is
+	// either finished or mislabelled, and an abandoned one is one sentence
+	// away from being honest.
+	answer, _ := rec.Section(SectionAnswer)
+	if strings.TrimSpace(answer) != "" {
+		return nil
+	}
+
+	switch state {
+	case StateAnswered:
+		return []Refusal{{
+			Property: RecordClaimsAnAnswerItDoesNotCarry,
+			Subject:  path,
+			Detail:   fmt.Sprintf("it says %s and its %s section is empty, so it claims an answer it does not carry", StateAnswered, SectionAnswer),
+		}}
+	case StateAbandoned:
+		return []Refusal{{
+			Property: AbandonedRecordDoesNotSayWhatStoppedTheWork,
+			Subject:  path,
+			Detail:   fmt.Sprintf("it says %s and its %s section is empty, so it does not say what stopped the work", StateAbandoned, SectionAnswer),
+		}}
+	}
+
+	// asking, with an empty answer section, is the ordinary state of an
+	// experiment that is running. Record 0008 asks for that heading to be
+	// there and empty from the day the record is created.
+	return nil
+}
+
+// statesInWords is the three states in one string, so that a message naming
+// them is derived from the constants rather than from a list somebody typed
+// into a format string and has to keep true.
+func statesInWords() string {
+	return strings.Join([]string{StateAsking, StateAnswered, StateAbandoned}, ", ")
 }
 
 // refuseBytes holds a record to being the text every later check assumes it

--- a/internal/check/record.go
+++ b/internal/check/record.go
@@ -1,0 +1,213 @@
+package check
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// The header field names record 0008 fixes. They are named once here and
+// nowhere else, so a check reading a field and a template writing one are the
+// same string or they are not equal.
+const (
+	// FieldSlug repeats the name of the directory the record sits in, so a
+	// reader holding a quoted slug can walk back to the experiment.
+	FieldSlug = "Slug"
+
+	// FieldState is the record's state, one of the three below.
+	FieldState = "State"
+
+	// FieldQuestionWritten is the date the question was written. It is what
+	// the listing sorts by, which is why record 0008 says it does not move
+	// after the commit that creates the directory.
+	FieldQuestionWritten = "Question-Written"
+
+	// FieldAnswerWritten is the date the answer was written. It is absent
+	// until there is an answer.
+	FieldAnswerWritten = "Answer-Written"
+)
+
+// The three states record 0003 fixes, written exactly as that record writes
+// them.
+const (
+	StateAsking    = "asking"
+	StateAnswered  = "answered"
+	StateAbandoned = "abandoned"
+)
+
+// The level-two headings record 0008 fixes. Promotion is absent from every
+// record that has not been handed over, which record 0005 sets out.
+const (
+	SectionQuestion  = "Question"
+	SectionMethod    = "Method"
+	SectionAnswer    = "Answer"
+	SectionPromotion = "Promotion"
+)
+
+// fieldName is what a header field name may be. A name at column zero, a
+// letter first, then letters, digits and hyphens. The pattern is here rather
+// than in a sentence somewhere because it is what decides whether a line is a
+// malformed field or something that is not a field at all, and those produce
+// different messages.
+var fieldName = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9-]*$`)
+
+// A Field is one header line, as it was written.
+type Field struct {
+	// Name is the field name, without the colon.
+	Name string
+
+	// Value is what followed the colon, with the surrounding spaces
+	// removed. A field written with nothing after the colon has an empty
+	// value and is still present, because declaring a field and leaving it
+	// blank is a different statement from not declaring it.
+	Value string
+
+	// Line is the one-based line the field was written on, so a message
+	// about it can send a reader to the right place.
+	Line int
+}
+
+// A Section is one level-two heading and the text under it, up to the next
+// level-two heading or the end of the file.
+type Section struct {
+	// Heading is the text of the heading, without the two hashes.
+	Heading string
+
+	// Body is the text under it, with the surrounding blank lines removed.
+	// An empty body is what an unanswered record's answer section has, and
+	// that is the shape rather than an omission.
+	Body string
+
+	// Line is the one-based line the heading was written on.
+	Line int
+}
+
+// A Record is an EXPERIMENT.md read into the two halves record 0008 divides it
+// into: the header, which the runner reads, and the sections, which a person
+// reads. Nothing here judges what any of it says.
+type Record struct {
+	// Fields are the header fields, in the order they were written.
+	Fields []Field
+
+	// Sections are the level-two sections, in the order they were written.
+	Sections []Section
+
+	// HeaderLines is how many lines the header occupied, so a caller can
+	// tell a record whose header is the whole file from one that carries
+	// prose as well.
+	HeaderLines int
+}
+
+// Field returns the value of a header field and whether it was present. The
+// two are separate answers: a field written with an empty value and a field
+// nobody wrote are the same string and different statements, and record 0013
+// makes the difference load-bearing, because absence is never a refusal and an
+// empty declaration may be.
+func (r Record) Field(name string) (string, bool) {
+	for _, field := range r.Fields {
+		if field.Name == name {
+			return field.Value, true
+		}
+	}
+	return "", false
+}
+
+// Section returns the body of a section and whether the heading was there. The
+// same split as Field, and for the same reason: a record with no answer
+// section and a record whose answer section is empty are different things, and
+// record 0008 asks for the second one from the day a record is created.
+func (r Record) Section(heading string) (string, bool) {
+	for _, section := range r.Sections {
+		if section.Heading == heading {
+			return section.Body, true
+		}
+	}
+	return "", false
+}
+
+// ParseRecord reads the bytes of an EXPERIMENT.md into a Record.
+//
+// It returns an error only where the bytes are not a record at all: no header,
+// a header line that is not a field, or one name written twice. Everything a
+// field or a section says is somebody else's judgement, and this returns it
+// unread. In particular an absent field is never an error here, because record
+// 0013 makes absence legal for every field added after it and a parser that
+// refused one would be the same rule from the other side.
+//
+// WHAT THIS DOES NOT DO. Nothing in the runner calls this yet. It is reached
+// by this package's own tests and by the test that parses the shipped
+// template, and no walk refuses a record over anything it reports. The
+// refusals arrive with the issues that argue them, and a green run today says
+// the records were read rather than that they were judged.
+func ParseRecord(data []byte) (Record, error) {
+	var rec Record
+
+	// A record that arrived through a translating checkout ends its lines
+	// with a carriage return, and this reads it as the same record. The
+	// tree stores text with LF and .gitattributes holds every checkout to
+	// it, so such a record arrived some other way. Reading it as a state
+	// whose value ends in an invisible byte would send whoever hits it to
+	// the wrong repair, and refusing it is a decision about the bytes of a
+	// record, which refuseBytes owns rather than this.
+	//
+	// There is no separate step for it. Every value and every heading below
+	// is trimmed of surrounding whitespace, and a carriage return is
+	// whitespace, so the tolerance falls out of the trimming rather than
+	// out of a line somebody could delete without the suite noticing.
+	// TestParseRecordToleratesCarriageReturns is what holds it.
+	lines := strings.Split(string(data), "\n")
+
+	if len(bytes.TrimSpace(data)) == 0 {
+		return rec, fmt.Errorf("the file is empty, so it carries no header")
+	}
+	if strings.TrimSpace(lines[0]) == "" {
+		return rec, fmt.Errorf("line 1 is blank, so the file opens with no header")
+	}
+
+	seen := make(map[string]int)
+	end := len(lines)
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			end = i
+			break
+		}
+		name, value, found := strings.Cut(line, ":")
+		if !found || !fieldName.MatchString(name) {
+			return rec, fmt.Errorf("line %d is %q, which is not a header field written as a name, a colon and a value", i+1, line)
+		}
+		if first, repeated := seen[name]; repeated {
+			return rec, fmt.Errorf("line %d writes %s a second time, first written on line %d, so a check reading that field would have to choose", i+1, name, first)
+		}
+		seen[name] = i + 1
+		rec.Fields = append(rec.Fields, Field{Name: name, Value: strings.TrimSpace(value), Line: i + 1})
+	}
+	rec.HeaderLines = end
+
+	headings := make(map[string]int)
+	for i := end; i < len(lines); i++ {
+		heading, isHeading := strings.CutPrefix(lines[i], "## ")
+		if !isHeading {
+			continue
+		}
+		heading = strings.TrimSpace(heading)
+		if first, repeated := headings[heading]; repeated {
+			return rec, fmt.Errorf("line %d writes the %s section a second time, first written on line %d, so a check reading that section would have to choose", i+1, heading, first)
+		}
+		headings[heading] = i + 1
+
+		body := i + 1
+		for ; body < len(lines); body++ {
+			if strings.HasPrefix(lines[body], "## ") {
+				break
+			}
+		}
+		rec.Sections = append(rec.Sections, Section{
+			Heading: heading,
+			Body:    strings.TrimSpace(strings.Join(lines[i+1:body], "\n")),
+			Line:    i + 1,
+		})
+	}
+
+	return rec, nil
+}

--- a/internal/check/record_test.go
+++ b/internal/check/record_test.go
@@ -1,0 +1,220 @@
+package check
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// templatePath is the template record 0008 says carries the shape. Decision
+// record 0002 puts it under docs/, so the path climbs out of internal/check.
+const templatePath = "../../docs/experiment-template.md"
+
+// TestTheTemplateParses is the standing agreement between the format and the
+// file a contributor copies. A template is a convenience and the record is the
+// authority, so the way the two are kept from disagreeing is that the runner
+// reads the template in its own suite rather than a person reading both.
+func TestTheTemplateParses(t *testing.T) {
+	data, err := os.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf("cannot read %s: %v", templatePath, err)
+	}
+
+	rec, err := ParseRecord(data)
+	if err != nil {
+		t.Fatalf("the template does not parse: %v", err)
+	}
+
+	for _, name := range []string{FieldSlug, FieldState, FieldQuestionWritten} {
+		if _, present := rec.Field(name); !present {
+			t.Errorf("the template carries no %s field", name)
+		}
+	}
+
+	// Answer-Written is absent on purpose. A template that carried it would
+	// teach every new experiment to declare an answer date on the day the
+	// question was written.
+	if _, present := rec.Field(FieldAnswerWritten); present {
+		t.Errorf("the template carries %s, which belongs in the change that writes the answer", FieldAnswerWritten)
+	}
+
+	if state, _ := rec.Field(FieldState); state != StateAsking {
+		t.Errorf("the template opens in state %q, want %q", state, StateAsking)
+	}
+
+	for _, heading := range []string{SectionQuestion, SectionMethod, SectionAnswer} {
+		if _, present := rec.Section(heading); !present {
+			t.Errorf("the template carries no %s section", heading)
+		}
+	}
+
+	// The empty answer section is the shape rather than an oversight. Record
+	// 0008 asks for it from the day a record is created, so that writing an
+	// answer is filling in something visibly missing.
+	if body, present := rec.Section(SectionAnswer); present && body != "" {
+		t.Errorf("the template's %s section carries %q, and it is meant to be empty", SectionAnswer, body)
+	}
+
+	if _, present := rec.Section(SectionPromotion); present {
+		t.Errorf("the template carries a %s section, which record 0005 adds when work is handed over", SectionPromotion)
+	}
+}
+
+// TestParseRecordReadsAHeaderAndItsSections is the ordinary case, written out
+// in full rather than assembled, so that what the parser was given is the thing
+// a reader of this test sees.
+func TestParseRecordReadsAHeaderAndItsSections(t *testing.T) {
+	rec, err := ParseRecord([]byte(`Slug: one
+State: answered
+Question-Written: 2026-01-01
+Answer-Written: 2026-02-02
+
+A title nobody parses.
+
+## Question
+
+Does it?
+
+## Method
+
+It was measured.
+
+## Answer
+
+No, and that is a finished piece of work.
+`))
+	if err != nil {
+		t.Fatalf("this record does not parse: %v", err)
+	}
+
+	for _, want := range []struct{ name, value string }{
+		{FieldSlug, "one"},
+		{FieldState, StateAnswered},
+		{FieldQuestionWritten, "2026-01-01"},
+		{FieldAnswerWritten, "2026-02-02"},
+	} {
+		got, present := rec.Field(want.name)
+		if !present {
+			t.Errorf("%s is absent", want.name)
+			continue
+		}
+		if got != want.value {
+			t.Errorf("%s is %q, want %q", want.name, got, want.value)
+		}
+	}
+
+	if rec.HeaderLines != 4 {
+		t.Errorf("the header is %d lines, want 4", rec.HeaderLines)
+	}
+
+	// The text between the header and the first heading is prose and is not a
+	// section. Reading it as one is how a title becomes a malformed section.
+	if len(rec.Sections) != 3 {
+		t.Fatalf("the record has %d sections, want 3", len(rec.Sections))
+	}
+	for i, want := range []string{SectionQuestion, SectionMethod, SectionAnswer} {
+		if rec.Sections[i].Heading != want {
+			t.Errorf("section %d is %q, want %q", i, rec.Sections[i].Heading, want)
+		}
+	}
+
+	if body, _ := rec.Section(SectionAnswer); body != "No, and that is a finished piece of work." {
+		t.Errorf("the answer section is %q", body)
+	}
+}
+
+// TestParseRecordSeparatesAnAbsentFieldFromAnEmptyOne holds the split the rest
+// of this format rests on. Record 0013 makes an absent field legal for ever and
+// leaves a field declared empty refusable, so a parser that reported the two
+// alike would remove the only thing a later check has to go on.
+func TestParseRecordSeparatesAnAbsentFieldFromAnEmptyOne(t *testing.T) {
+	rec, err := ParseRecord([]byte("Slug: one\nState:\n\n## Answer\n"))
+	if err != nil {
+		t.Fatalf("this record does not parse: %v", err)
+	}
+
+	value, present := rec.Field(FieldState)
+	if !present {
+		t.Errorf("%s was written with an empty value and reads as absent", FieldState)
+	}
+	if value != "" {
+		t.Errorf("%s is %q, want the empty string", FieldState, value)
+	}
+
+	if _, present := rec.Field(FieldQuestionWritten); present {
+		t.Errorf("%s was never written and reads as present", FieldQuestionWritten)
+	}
+
+	body, present := rec.Section(SectionAnswer)
+	if !present {
+		t.Errorf("the %s heading is there and reads as absent", SectionAnswer)
+	}
+	if body != "" {
+		t.Errorf("the %s section is %q, want the empty string", SectionAnswer, body)
+	}
+}
+
+// TestParseRecordToleratesCarriageReturns fixes what a record that arrived
+// through a translating checkout parses to. The tree stores text with LF and
+// .gitattributes holds every checkout to it, so this is a record that arrived
+// some other way. Reading it as a state whose value ends in an invisible byte
+// would send whoever hits it to the wrong repair.
+//
+// The bytes are escape sequences in this source rather than literal carriage
+// returns, so nothing between here and git can remove the byte the test exists
+// for.
+func TestParseRecordToleratesCarriageReturns(t *testing.T) {
+	rec, err := ParseRecord([]byte("Slug: one\r\nState: asking\r\n\r\n## Answer\r\n"))
+	if err != nil {
+		t.Fatalf("this record does not parse: %v", err)
+	}
+	if state, _ := rec.Field(FieldState); state != StateAsking {
+		t.Errorf("state is %q, want %q", state, StateAsking)
+	}
+	if _, present := rec.Section(SectionAnswer); !present {
+		t.Errorf("the %s heading was not read", SectionAnswer)
+	}
+}
+
+// TestParseRecordRefusesBytesThatAreNotARecord covers the whole of what this
+// parser returns an error for. Each case is a structural statement about the
+// bytes and none of them is a field being absent, which record 0013 makes legal
+// for ever.
+func TestParseRecordRefusesBytesThatAreNotARecord(t *testing.T) {
+	for _, c := range []struct {
+		name, input, wants string
+	}{
+		{"an empty file", "", "empty"},
+		{"only whitespace", "   \n\n", "empty"},
+		{"opening with a blank line", "\nSlug: one\n", "line 1 is blank"},
+		{"a header line that is not a field", "Slug: one\nnot a field at all\n\n## Answer\n", "line 2"},
+		{"a field name with a space in it", "Slug: one\nAnswer Written: 2026-01-01\n", "line 2"},
+		{"one field name written twice", "Slug: one\nSlug: two\n", "a second time"},
+		{"one heading written twice", "Slug: one\n\n## Answer\n\n## Answer\n", "a second time"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := ParseRecord([]byte(c.input))
+			if err == nil {
+				t.Fatalf("this parsed and should not have")
+			}
+			if !strings.Contains(err.Error(), c.wants) {
+				t.Errorf("the message is %q and does not say %q, so a reader is not sent to the repair", err, c.wants)
+			}
+		})
+	}
+}
+
+// TestParseRecordAcceptsAFieldNameTheFormatDoesNotFix holds the direction
+// record 0013 is read from here. A field added by a later record is unknown to
+// every checker built before it, so refusing an unrecognised name would break
+// the same rule from the other side. The cost is that a misspelled name is read
+// as a new field, and it is paid rather than overlooked.
+func TestParseRecordAcceptsAFieldNameTheFormatDoesNotFix(t *testing.T) {
+	rec, err := ParseRecord([]byte("Slug: one\nTouches-Real-Data: no\n\n## Answer\n"))
+	if err != nil {
+		t.Fatalf("a record carrying a field this format does not fix was refused: %v", err)
+	}
+	if value, present := rec.Field("Touches-Real-Data"); !present || value != "no" {
+		t.Errorf("the unfixed field reads as %q, present=%v", value, present)
+	}
+}

--- a/internal/check/state_test.go
+++ b/internal/check/state_test.go
@@ -1,0 +1,94 @@
+package check
+
+import (
+	"strings"
+	"testing"
+)
+
+// The three state refusals are proved by cases under testdata/cases, and the
+// harness compares sets of property identifiers. That is the whole of what a
+// case can prove, and it is not enough here, because the state property is
+// refused at three sites and a fixture for one of them satisfies the standing
+// requirement for all three.
+//
+// The three sites are not interchangeable. A record with no state field, a
+// record whose state field is there and empty, and a record whose state is
+// misspelled are three different repairs, and the message is the only thing
+// that separates them. So the message is what these tests hold, at the
+// function rather than through the walk, and the case harness holds that the
+// property is refused at all.
+//
+// This is the bound in harness_test.go acted on rather than restated. Deleting
+// the empty-state arm leaves every case green, because an empty value falls
+// through to the arm below and refuses the same property under a different
+// message. Measured, not supposed.
+
+// TestEachStateSiteNamesItsOwnRepair holds the three apart.
+func TestEachStateSiteNamesItsOwnRepair(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		record string
+		wants  string
+	}{
+		{
+			name:   "no state field at all",
+			record: "Slug: one\nQuestion-Written: 2026-01-01\n\n## Answer\n",
+			wants:  "declares no State field",
+		},
+		{
+			name:   "a state field with nothing after the colon",
+			record: "Slug: one\nState:\n\n## Answer\n",
+			wants:  "is there and empty",
+		},
+		{
+			name:   "a state that is misspelled",
+			record: "Slug: one\nState: answerd\n\n## Answer\n",
+			wants:  `is "answerd"`,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			refusals := refuseState("experiments/one/EXPERIMENT.md", []byte(c.record))
+			if len(refusals) != 1 {
+				t.Fatalf("got %d refusals, want exactly 1: %v", len(refusals), refusals)
+			}
+			if refusals[0].Property != RecordStateIsNotOneOfTheThree {
+				t.Fatalf("refused %s, want %s", refusals[0].Property, RecordStateIsNotOneOfTheThree)
+			}
+			if !strings.Contains(refusals[0].Detail, c.wants) {
+				t.Errorf("the message is %q and does not say %q, so it names the wrong repair", refusals[0].Detail, c.wants)
+			}
+			// Every one of the three names the three states, because a
+			// reader hitting this needs to know what the legal values are
+			// without opening a decision record.
+			if !strings.Contains(refusals[0].Detail, statesInWords()) {
+				t.Errorf("the message is %q and does not name the three states", refusals[0].Detail)
+			}
+		})
+	}
+}
+
+// TestAStateThatIsLegalRefusesNothingOnItsOwn is the near neighbour of the
+// three above, at the same level. Without it, a site that refused every state
+// would pass the test above.
+func TestAStateThatIsLegalRefusesNothingOnItsOwn(t *testing.T) {
+	for _, state := range []string{StateAsking, StateAnswered, StateAbandoned} {
+		t.Run(state, func(t *testing.T) {
+			record := "Slug: one\nState: " + state + "\n\n## Answer\n\nSomething is written here.\n"
+			if refusals := refuseState("experiments/one/EXPERIMENT.md", []byte(record)); len(refusals) != 0 {
+				t.Errorf("a record in state %s with an answer refused %v", state, refusals)
+			}
+		})
+	}
+}
+
+// TestARecordWithNoHeaderIsNotJudgedHere holds the hole open deliberately.
+// Nothing can read the state of something that has no header, and inventing a
+// state refusal for it would name the wrong repair: whoever hits it has a file
+// that is not a record rather than a record with a bad state. Issue #16 is
+// where that gap closes, and this test is what stops it being closed here by
+// accident.
+func TestARecordWithNoHeaderIsNotJudgedHere(t *testing.T) {
+	if refusals := refuseState("experiments/one/EXPERIMENT.md", []byte("# One\n\nThe question.\n")); len(refusals) != 0 {
+		t.Errorf("a file with no header was judged on its state and refused %v", refusals)
+	}
+}

--- a/testdata/cases/record-abandoned-with-a-reason/expected
+++ b/testdata/cases/record-abandoned-with-a-reason/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-abandoned-with-a-reason/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-abandoned-with-a-reason/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,15 @@
+Slug: one
+State: abandoned
+Question-Written: 2026-01-01
+
+## Question
+
+Does the walk read a record whose work stopped without an answer?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer
+
+The machine this needed was returned before anything was measured.

--- a/testdata/cases/record-abandoned-with-no-reason/expected
+++ b/testdata/cases/record-abandoned-with-no-reason/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-abandoned-with-no-reason/expected-refusals
+++ b/testdata/cases/record-abandoned-with-no-reason/expected-refusals
@@ -1,0 +1,1 @@
+abandoned-record-does-not-say-what-stopped-the-work

--- a/testdata/cases/record-abandoned-with-no-reason/near-neighbour
+++ b/testdata/cases/record-abandoned-with-no-reason/near-neighbour
@@ -1,0 +1,1 @@
+record-abandoned-with-a-reason

--- a/testdata/cases/record-abandoned-with-no-reason/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-abandoned-with-no-reason/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,13 @@
+Slug: one
+State: abandoned
+Question-Written: 2026-01-01
+
+## Question
+
+Does the walk read a record whose work stopped without an answer?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer

--- a/testdata/cases/record-answered-with-an-answer/expected
+++ b/testdata/cases/record-answered-with-an-answer/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-answered-with-an-answer/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-answered-with-an-answer/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,16 @@
+Slug: one
+State: answered
+Question-Written: 2026-01-01
+Answer-Written: 2026-02-02
+
+## Question
+
+Does the walk read a record that stopped with an answer?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer
+
+No, and that is a finished piece of work.

--- a/testdata/cases/record-answered-with-no-answer/expected
+++ b/testdata/cases/record-answered-with-no-answer/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-answered-with-no-answer/expected-refusals
+++ b/testdata/cases/record-answered-with-no-answer/expected-refusals
@@ -1,0 +1,1 @@
+record-claims-an-answer-it-does-not-carry

--- a/testdata/cases/record-answered-with-no-answer/near-neighbour
+++ b/testdata/cases/record-answered-with-no-answer/near-neighbour
@@ -1,0 +1,1 @@
+record-answered-with-an-answer

--- a/testdata/cases/record-answered-with-no-answer/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-answered-with-no-answer/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,14 @@
+Slug: one
+State: answered
+Question-Written: 2026-01-01
+Answer-Written: 2026-02-02
+
+## Question
+
+Does the walk read a record that stopped with an answer?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer

--- a/testdata/cases/record-in-asking/expected
+++ b/testdata/cases/record-in-asking/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-in-asking/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-in-asking/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,13 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+
+## Question
+
+Does the walk read a record that is still running?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer

--- a/testdata/cases/record-with-a-misspelled-state/expected
+++ b/testdata/cases/record-with-a-misspelled-state/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-with-a-misspelled-state/expected-refusals
+++ b/testdata/cases/record-with-a-misspelled-state/expected-refusals
@@ -1,0 +1,1 @@
+record-state-is-not-one-of-the-three

--- a/testdata/cases/record-with-a-misspelled-state/near-neighbour
+++ b/testdata/cases/record-with-a-misspelled-state/near-neighbour
@@ -1,0 +1,1 @@
+record-answered-with-an-answer

--- a/testdata/cases/record-with-a-misspelled-state/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-with-a-misspelled-state/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,16 @@
+Slug: one
+State: answerd
+Question-Written: 2026-01-01
+Answer-Written: 2026-02-02
+
+## Question
+
+Does the walk read a record that stopped with an answer?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer
+
+No, and that is a finished piece of work.

--- a/testdata/cases/record-with-an-empty-state/expected
+++ b/testdata/cases/record-with-an-empty-state/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-with-an-empty-state/expected-refusals
+++ b/testdata/cases/record-with-an-empty-state/expected-refusals
@@ -1,0 +1,1 @@
+record-state-is-not-one-of-the-three

--- a/testdata/cases/record-with-an-empty-state/near-neighbour
+++ b/testdata/cases/record-with-an-empty-state/near-neighbour
@@ -1,0 +1,1 @@
+record-in-asking

--- a/testdata/cases/record-with-an-empty-state/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-with-an-empty-state/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,13 @@
+Slug: one
+State:
+Question-Written: 2026-01-01
+
+## Question
+
+Does the walk read a record that is still running?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer

--- a/testdata/cases/record-with-no-state-field/expected
+++ b/testdata/cases/record-with-no-state-field/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-with-no-state-field/expected-refusals
+++ b/testdata/cases/record-with-no-state-field/expected-refusals
@@ -1,0 +1,1 @@
+record-state-is-not-one-of-the-three

--- a/testdata/cases/record-with-no-state-field/near-neighbour
+++ b/testdata/cases/record-with-no-state-field/near-neighbour
@@ -1,0 +1,1 @@
+record-in-asking

--- a/testdata/cases/record-with-no-state-field/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-with-no-state-field/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,12 @@
+Slug: one
+Question-Written: 2026-01-01
+
+## Question
+
+Does the walk read a record that is still running?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer


### PR DESCRIPTION
Closes #15.

Four files, none of them edited: `docs/decisions/0008-the-experiment-record.md`,
`docs/experiment-template.md`, `internal/check/record.go` and its test.

## The format

A small header of fixed fields, then prose. The header is the run of lines from
the first byte to the first blank line, each written as a name, a colon and a
value at column zero. Four names are fixed: `Slug`, `State`, `Question-Written`
and `Answer-Written`, the last absent until there is an answer. Then `##
Question`, `## Method` and `## Answer`, with `## Promotion` on a record that has
been handed over.

Two shape rules the issue asked to have argued now rather than later are in the
record. One question and not a topic, because a directory holding three
questions has no state that is true of all of them. And the answer section
exists in every record from the day it is created, empty, so writing an answer
is filling in something visibly missing rather than remembering a heading whose
absence nobody sees.

One thing the record decides that the issue did not raise. A field name the
format does not fix is accepted rather than refused. Record 0013 makes a field
added later optional so that records written before it stay legal; refusing an
unrecognised name breaks the same rule from the other side, because every
checker built before a new field would refuse every record written after it. The
cost is that a misspelled name reads as a new field and passes, and it is named
in the record's fourth section rather than left to be discovered.

## The template is not the authority

`docs/experiment-template.md` carries the shape with placeholder values. The
record is the authority and the template is a convenience, and what keeps the
two from drifting is that the suite parses the template rather than a person
reading both. `TestTheTemplateParses` asserts the fields it must carry, the
field it must not carry, that it opens in `asking`, that the three sections are
there, and that the answer section is empty.

## What the parser refuses, and what it does not

It returns an error only where the bytes are not a record at all: no header, a
header line that is not a field, one field name written twice, one heading
written twice. Each of those is a structural statement about the bytes.

An absent field is never an error. That is record 0013 read directly, and it is
why `Field` and `Section` each return a value and a presence separately: a field
written with an empty value and a field nobody wrote are the same string and
different statements, and the second is the one a later check may refuse.

## Means

Go, in `internal/check`, beside the walk that will call it. It adds no
dependency: the parser is `strings` and one small pattern from `regexp`, both
already in the tree. A parsed format that needed a library would be the argument
against YAML front matter made twice, and record 0008's fourth section is where
that argument is written.

## Evidence

Run at `6b2cade27599da4aadf9d9080a4e031bea4ad43f`, the head of this branch.

    $ gofmt -l . ; go vet ./... ; go run ./cmd/lab check .
    examined .
    no experiments directory in this tree
    0 experiment directories walked, 0 records read
    0 refused

    $ go test -count=1 ./...
    ok  	github.com/Flowfin/lab/cmd/lab	0.601s
    ok  	github.com/Flowfin/lab/internal/check	0.810s
    ok  	github.com/Flowfin/lab/internal/hardware	0.773s

The Done-when asks that the runner parse the template without error, which is
`TestTheTemplateParses` above. Each new guard was then deleted and the suite
watched, because a test that passes proves nothing about a guard that was never
load-bearing.

Removing the duplicate-field refusal:

    --- FAIL: TestParseRecordRefusesBytesThatAreNotARecord/one_field_name_written_twice

Adding a line of text under the template's `## Answer`:

    --- FAIL: TestTheTemplateParses
        record_test.go:55: the template's Answer section carries "It worked.", and it is meant to be empty

The third attempt is worth reporting because it failed. The parser first carried
an explicit step trimming a carriage return from the end of each line. Deleting
that step left the suite green, because every value and every heading is trimmed
of surrounding whitespace anyway and a carriage return is whitespace. A guard
that can be deleted without anything noticing is not a guard, so the step is
gone and the comment says where the tolerance actually comes from. Narrowing the
trim to spaces alone is what moves it now:

    --- FAIL: TestParseRecordToleratesCarriageReturns
        record_test.go:172: state is "asking\r", want "asking"

The carriage returns in that test are escape sequences in the Go source rather
than literal bytes, so nothing between the test and git can remove the byte it
exists for.

## What this does not do

Nothing in the walk calls the parser. No record is refused over its header, its
state, its dates or an empty answer under a claim of one, and a green run today
says the records were read rather than that they were judged. That sentence is
in the record and at the function as well as here, because it is the thing a
reader is most likely to assume the other way. The refusals arrive with the
issues that argue them: a record that never wrote its question, a record
claiming an answer it does not carry, a header that disagrees with itself, and a
slug that is not a legal slug.

The legal shape of a slug is not decided here. #59 fixes it and supersedes
record 0008 when it does, which the record says in its own first section.

Nobody else has read this change. The evidence above stands in place of a second
reader rather than alongside one.


## What ran on this pull request, and what did not

The build and test workflow is not on the default branch yet. It arrives with
#88, and a `pull_request` run reads the workflow files from the merge of base
and head, so no `build`, `test`, `vet` or `format` job exists for this branch to
report. What ran here is the DCO, Unicode, workflow-audit and dependency-review
set the checks tab shows.

So the suite evidence above is local and one-platform, and it stays that way
until the build workflow is on `main`. Once it is, a branch taken from `main`
gets the three-platform suite reporting on its own pull request, and this
change should be re-run there rather than trusted from here.
