### PR TITLE
Refuse a record that claims an answer it does not carry

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -53,6 +53,28 @@ const (
 	// that no longer exists.
 	RecordNamesAPathThatDoesNotResolve = "record-names-a-path-that-does-not-resolve"
 
+	// RecordStateIsNotOneOfTheThree refuses a record whose state is not one
+	// of the three record 0003 names, which includes a state that is
+	// misspelled, a state written with no value, and no state field at all.
+	// Every other rule about a record's state is conditional on the state,
+	// so a record with no readable state is a record none of them applies
+	// to, and a rule that a typo disables is not a rule.
+	RecordStateIsNotOneOfTheThree = "record-state-is-not-one-of-the-three"
+
+	// RecordClaimsAnAnswerItDoesNotCarry refuses a record in state
+	// answered whose answer section is empty. It does not make anybody
+	// answer. What it makes impossible is claiming to have answered while
+	// having written nothing, which turns a silent half-finished directory
+	// into either a real answer or an honest abandoned.
+	RecordClaimsAnAnswerItDoesNotCarry = "record-claims-an-answer-it-does-not-carry"
+
+	// AbandonedRecordDoesNotSayWhatStoppedTheWork refuses a record in state
+	// abandoned that says nothing about what stopped the work. Abandoning
+	// is allowed here and that is the point of the state existing, but
+	// abandoning without a sentence is the same silence this board is built
+	// to make visible.
+	AbandonedRecordDoesNotSayWhatStoppedTheWork = "abandoned-record-does-not-say-what-stopped-the-work"
+
 	// ExperimentHasNoRecord refuses a directory under experiments/ that
 	// carries no record a reader can open. It catches somebody dropping code
 	// in and meaning to write the record later, and it fires on the change
@@ -232,6 +254,7 @@ func Walk(root string) (Result, error) {
 		res.Records++
 		res.Refusals = append(res.Refusals, refuseBytes(record, data)...)
 		res.Refusals = append(res.Refusals, refusePaths(root, record, data)...)
+		res.Refusals = append(res.Refusals, refuseState(record, data)...)
 	}
 
 	return res, nil
@@ -260,6 +283,93 @@ func refusePaths(root, path string, data []byte) []Refusal {
 	}
 
 	return refusals
+}
+
+// refuseState holds a record to what its own state says about it. Record 0003
+// fixes the three states and what each one requires; this is the half of that
+// a machine can see.
+//
+// What it buys is smaller than it looks and the difference is worth keeping
+// straight. It does not make anybody finish an experiment or write an honest
+// answer. It makes a record that contradicts itself refusable, which converts
+// a silent half-finished directory into either a real answer or an honest
+// abandoned. A record saying "no, this does not work" and a record saying it
+// while its author knows otherwise are the same bytes, and review is the only
+// thing that catches the second.
+//
+// WHERE THIS DOES NOT REACH. A record whose bytes do not parse as a record is
+// not judged here at all. Nothing can read the state of something that has no
+// header, and inventing a state refusal for it would name the wrong repair:
+// whoever hits it has a file that is not a record rather than a record with a
+// bad state. So a record with no header passes every rule below, which is a
+// hole, and it is issue #16's rather than this one's. Read a green run
+// accordingly.
+func refuseState(path string, data []byte) []Refusal {
+	rec, err := ParseRecord(data)
+	if err != nil {
+		return nil
+	}
+
+	state, present := rec.Field(FieldState)
+	switch {
+	case !present:
+		return []Refusal{{
+			Property: RecordStateIsNotOneOfTheThree,
+			Subject:  path,
+			Detail:   fmt.Sprintf("it declares no %s field, so no rule about a state applies to it. record 0003 names %s", FieldState, statesInWords()),
+		}}
+	case state == "":
+		return []Refusal{{
+			Property: RecordStateIsNotOneOfTheThree,
+			Subject:  path,
+			Detail:   fmt.Sprintf("its %s field is there and empty, which is not one of %s", FieldState, statesInWords()),
+		}}
+	case state != StateAsking && state != StateAnswered && state != StateAbandoned:
+		return []Refusal{{
+			Property: RecordStateIsNotOneOfTheThree,
+			Subject:  path,
+			Detail:   fmt.Sprintf("its %s is %q, and record 0003 names %s", FieldState, state, statesInWords()),
+		}}
+	}
+
+	// The answer section carries both. For an answered record it is the
+	// answer; for an abandoned one it is the sentence saying what stopped
+	// the work, which record 0003 makes a lower bar than an answer on
+	// purpose. They are two properties rather than one because the repairs
+	// are different: an answered record with nothing under the heading is
+	// either finished or mislabelled, and an abandoned one is one sentence
+	// away from being honest.
+	answer, _ := rec.Section(SectionAnswer)
+	if strings.TrimSpace(answer) != "" {
+		return nil
+	}
+
+	switch state {
+	case StateAnswered:
+		return []Refusal{{
+			Property: RecordClaimsAnAnswerItDoesNotCarry,
+			Subject:  path,
+			Detail:   fmt.Sprintf("it says %s and its %s section is empty, so it claims an answer it does not carry", StateAnswered, SectionAnswer),
+		}}
+	case StateAbandoned:
+		return []Refusal{{
+			Property: AbandonedRecordDoesNotSayWhatStoppedTheWork,
+			Subject:  path,
+			Detail:   fmt.Sprintf("it says %s and its %s section is empty, so it does not say what stopped the work", StateAbandoned, SectionAnswer),
+		}}
+	}
+
+	// asking, with an empty answer section, is the ordinary state of an
+	// experiment that is running. Record 0008 asks for that heading to be
+	// there and empty from the day the record is created.
+	return nil
+}
+
+// statesInWords is the three states in one string, so that a message naming
+// them is derived from the constants rather than from a list somebody typed
+// into a format string and has to keep true.
+func statesInWords() string {
+	return strings.Join([]string{StateAsking, StateAnswered, StateAbandoned}, ", ")
 }
 
 // refuseBytes holds a record to being the text every later check assumes it

--- a/internal/check/state_test.go
+++ b/internal/check/state_test.go
@@ -1,0 +1,94 @@
+package check
+
+import (
+	"strings"
+	"testing"
+)
+
+// The three state refusals are proved by cases under testdata/cases, and the
+// harness compares sets of property identifiers. That is the whole of what a
+// case can prove, and it is not enough here, because the state property is
+// refused at three sites and a fixture for one of them satisfies the standing
+// requirement for all three.
+//
+// The three sites are not interchangeable. A record with no state field, a
+// record whose state field is there and empty, and a record whose state is
+// misspelled are three different repairs, and the message is the only thing
+// that separates them. So the message is what these tests hold, at the
+// function rather than through the walk, and the case harness holds that the
+// property is refused at all.
+//
+// This is the bound in harness_test.go acted on rather than restated. Deleting
+// the empty-state arm leaves every case green, because an empty value falls
+// through to the arm below and refuses the same property under a different
+// message. Measured, not supposed.
+
+// TestEachStateSiteNamesItsOwnRepair holds the three apart.
+func TestEachStateSiteNamesItsOwnRepair(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		record string
+		wants  string
+	}{
+		{
+			name:   "no state field at all",
+			record: "Slug: one\nQuestion-Written: 2026-01-01\n\n## Answer\n",
+			wants:  "declares no State field",
+		},
+		{
+			name:   "a state field with nothing after the colon",
+			record: "Slug: one\nState:\n\n## Answer\n",
+			wants:  "is there and empty",
+		},
+		{
+			name:   "a state that is misspelled",
+			record: "Slug: one\nState: answerd\n\n## Answer\n",
+			wants:  `is "answerd"`,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			refusals := refuseState("experiments/one/EXPERIMENT.md", []byte(c.record))
+			if len(refusals) != 1 {
+				t.Fatalf("got %d refusals, want exactly 1: %v", len(refusals), refusals)
+			}
+			if refusals[0].Property != RecordStateIsNotOneOfTheThree {
+				t.Fatalf("refused %s, want %s", refusals[0].Property, RecordStateIsNotOneOfTheThree)
+			}
+			if !strings.Contains(refusals[0].Detail, c.wants) {
+				t.Errorf("the message is %q and does not say %q, so it names the wrong repair", refusals[0].Detail, c.wants)
+			}
+			// Every one of the three names the three states, because a
+			// reader hitting this needs to know what the legal values are
+			// without opening a decision record.
+			if !strings.Contains(refusals[0].Detail, statesInWords()) {
+				t.Errorf("the message is %q and does not name the three states", refusals[0].Detail)
+			}
+		})
+	}
+}
+
+// TestAStateThatIsLegalRefusesNothingOnItsOwn is the near neighbour of the
+// three above, at the same level. Without it, a site that refused every state
+// would pass the test above.
+func TestAStateThatIsLegalRefusesNothingOnItsOwn(t *testing.T) {
+	for _, state := range []string{StateAsking, StateAnswered, StateAbandoned} {
+		t.Run(state, func(t *testing.T) {
+			record := "Slug: one\nState: " + state + "\n\n## Answer\n\nSomething is written here.\n"
+			if refusals := refuseState("experiments/one/EXPERIMENT.md", []byte(record)); len(refusals) != 0 {
+				t.Errorf("a record in state %s with an answer refused %v", state, refusals)
+			}
+		})
+	}
+}
+
+// TestARecordWithNoHeaderIsNotJudgedHere holds the hole open deliberately.
+// Nothing can read the state of something that has no header, and inventing a
+// state refusal for it would name the wrong repair: whoever hits it has a file
+// that is not a record rather than a record with a bad state. Issue #16 is
+// where that gap closes, and this test is what stops it being closed here by
+// accident.
+func TestARecordWithNoHeaderIsNotJudgedHere(t *testing.T) {
+	if refusals := refuseState("experiments/one/EXPERIMENT.md", []byte("# One\n\nThe question.\n")); len(refusals) != 0 {
+		t.Errorf("a file with no header was judged on its state and refused %v", refusals)
+	}
+}

--- a/testdata/cases/record-abandoned-with-a-reason/expected
+++ b/testdata/cases/record-abandoned-with-a-reason/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-abandoned-with-a-reason/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-abandoned-with-a-reason/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,15 @@
+Slug: one
+State: abandoned
+Question-Written: 2026-01-01
+
+## Question
+
+Does the walk read a record whose work stopped without an answer?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer
+
+The machine this needed was returned before anything was measured.

--- a/testdata/cases/record-abandoned-with-no-reason/expected
+++ b/testdata/cases/record-abandoned-with-no-reason/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-abandoned-with-no-reason/expected-refusals
+++ b/testdata/cases/record-abandoned-with-no-reason/expected-refusals
@@ -1,0 +1,1 @@
+abandoned-record-does-not-say-what-stopped-the-work

--- a/testdata/cases/record-abandoned-with-no-reason/near-neighbour
+++ b/testdata/cases/record-abandoned-with-no-reason/near-neighbour
@@ -1,0 +1,1 @@
+record-abandoned-with-a-reason

--- a/testdata/cases/record-abandoned-with-no-reason/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-abandoned-with-no-reason/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,13 @@
+Slug: one
+State: abandoned
+Question-Written: 2026-01-01
+
+## Question
+
+Does the walk read a record whose work stopped without an answer?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer

--- a/testdata/cases/record-answered-with-an-answer/expected
+++ b/testdata/cases/record-answered-with-an-answer/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-answered-with-an-answer/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-answered-with-an-answer/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,16 @@
+Slug: one
+State: answered
+Question-Written: 2026-01-01
+Answer-Written: 2026-02-02
+
+## Question
+
+Does the walk read a record that stopped with an answer?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer
+
+No, and that is a finished piece of work.

--- a/testdata/cases/record-answered-with-no-answer/expected
+++ b/testdata/cases/record-answered-with-no-answer/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-answered-with-no-answer/expected-refusals
+++ b/testdata/cases/record-answered-with-no-answer/expected-refusals
@@ -1,0 +1,1 @@
+record-claims-an-answer-it-does-not-carry

--- a/testdata/cases/record-answered-with-no-answer/near-neighbour
+++ b/testdata/cases/record-answered-with-no-answer/near-neighbour
@@ -1,0 +1,1 @@
+record-answered-with-an-answer

--- a/testdata/cases/record-answered-with-no-answer/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-answered-with-no-answer/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,14 @@
+Slug: one
+State: answered
+Question-Written: 2026-01-01
+Answer-Written: 2026-02-02
+
+## Question
+
+Does the walk read a record that stopped with an answer?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer

--- a/testdata/cases/record-in-asking/expected
+++ b/testdata/cases/record-in-asking/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-in-asking/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-in-asking/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,13 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+
+## Question
+
+Does the walk read a record that is still running?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer

--- a/testdata/cases/record-with-a-misspelled-state/expected
+++ b/testdata/cases/record-with-a-misspelled-state/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-with-a-misspelled-state/expected-refusals
+++ b/testdata/cases/record-with-a-misspelled-state/expected-refusals
@@ -1,0 +1,1 @@
+record-state-is-not-one-of-the-three

--- a/testdata/cases/record-with-a-misspelled-state/near-neighbour
+++ b/testdata/cases/record-with-a-misspelled-state/near-neighbour
@@ -1,0 +1,1 @@
+record-answered-with-an-answer

--- a/testdata/cases/record-with-a-misspelled-state/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-with-a-misspelled-state/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,16 @@
+Slug: one
+State: answerd
+Question-Written: 2026-01-01
+Answer-Written: 2026-02-02
+
+## Question
+
+Does the walk read a record that stopped with an answer?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer
+
+No, and that is a finished piece of work.

--- a/testdata/cases/record-with-an-empty-state/expected
+++ b/testdata/cases/record-with-an-empty-state/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-with-an-empty-state/expected-refusals
+++ b/testdata/cases/record-with-an-empty-state/expected-refusals
@@ -1,0 +1,1 @@
+record-state-is-not-one-of-the-three

--- a/testdata/cases/record-with-an-empty-state/near-neighbour
+++ b/testdata/cases/record-with-an-empty-state/near-neighbour
@@ -1,0 +1,1 @@
+record-in-asking

--- a/testdata/cases/record-with-an-empty-state/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-with-an-empty-state/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,13 @@
+Slug: one
+State:
+Question-Written: 2026-01-01
+
+## Question
+
+Does the walk read a record that is still running?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer

--- a/testdata/cases/record-with-no-state-field/expected
+++ b/testdata/cases/record-with-no-state-field/expected
@@ -1,0 +1,3 @@
+directories 1
+records 1
+experiments present

--- a/testdata/cases/record-with-no-state-field/expected-refusals
+++ b/testdata/cases/record-with-no-state-field/expected-refusals
@@ -1,0 +1,1 @@
+record-state-is-not-one-of-the-three

--- a/testdata/cases/record-with-no-state-field/near-neighbour
+++ b/testdata/cases/record-with-no-state-field/near-neighbour
@@ -1,0 +1,1 @@
+record-in-asking

--- a/testdata/cases/record-with-no-state-field/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-with-no-state-field/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,12 @@
+Slug: one
+Question-Written: 2026-01-01
+
+## Question
+
+Does the walk read a record that is still running?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer


### PR DESCRIPTION
Closes #17.

Stacked on #91, which lands the format and the parser this reads. The base of
this pull request is `records/the-shape-of-a-record`, so the diff here is the
three refusals and their fixtures.

## The three refusals

`record-state-is-not-one-of-the-three`, over a state that is misspelled, a
state field with nothing after the colon, and no state field at all. Without
it, a typo is a record that no state-dependent rule applies to, which is the
hole the other two would sit in.

`record-claims-an-answer-it-does-not-carry`, over a record in `answered` whose
answer section is empty.

`abandoned-record-does-not-say-what-stopped-the-work`, over a record in
`abandoned` whose answer section is empty. Two properties over one condition
rather than one property, because the repairs differ: an answered record with
nothing under the heading is either finished or mislabelled, and an abandoned
one is a sentence away from being honest.

The abandoned sentence goes in the answer section. Record 0003 makes it a lower
bar than an answer on purpose, and record 0008 gives the record one slot for
what it stopped with, so putting it anywhere else would be a second heading for
the same job.

## What this buys, stated narrowly

It does not make anybody answer. It makes claiming to have answered while
having written nothing impossible, which converts a silent half-finished
directory into either a real answer or an honest `abandoned`. A record saying
"no, this does not work" and a record saying it while its author knows
otherwise are the same bytes, and review is the only thing that catches the
second.

## Where it does not reach

A record whose bytes do not parse as a record is not judged on its state at
all. Nothing can read the state of something with no header, and a state
refusal there would name the wrong repair, because whoever hits it has a file
that is not a record rather than a record with a bad state. That is a hole, it
is #16's, and `TestARecordWithNoHeaderIsNotJudgedHere` holds it open so that
nothing closes it here by accident.

That is also why no existing fixture moved. The records under `testdata/cases`
that predate the format do not parse, so they are not judged and their refusal
sets are unchanged.

## Evidence

Run at `57fb801b6070b4053270cac8c53cbacf622a9c72`, the head of this branch.

    $ gofmt -l . ; go vet ./... ; go test -count=1 ./...
    ok  	github.com/Flowfin/lab/cmd/lab	0.661s
    ok  	github.com/Flowfin/lab/internal/check	1.020s
    ok  	github.com/Flowfin/lab/internal/hardware	0.942s

Eight new cases: three that refuse nothing and are the near neighbours, and
five that each refuse exactly one property. Each refusal was then deleted and
the suite watched.

Dropping the arm for a record with no state field:

    --- FAIL: TestCases/record-with-no-state-field
        expected refusal not produced: record-state-is-not-one-of-the-three

Making the answered arm unreachable:

    --- FAIL: TestCases/record-answered-with-no-answer
        expected refusal not produced: record-claims-an-answer-it-does-not-carry

Making the abandoned arm unreachable:

    --- FAIL: TestCases/record-abandoned-with-no-reason
        expected refusal not produced: abandoned-record-does-not-say-what-stopped-the-work

Making the unknown-state arm unreachable:

    --- FAIL: TestCases/record-with-a-misspelled-state
        expected refusal not produced: record-state-is-not-one-of-the-three

## The fifth deletion is the one worth reading

Deleting the empty-state arm left every case green. An empty value falls
through to the arm below and refuses the same property under a different
message, and the harness compares sets of property identifiers, so no case can
tell the two sites apart. That is the bound `harness_test.go` states, measured
here rather than supposed.

The three sites are not interchangeable: no state field, an empty state field
and a misspelled state are three different repairs, and the message is the only
thing that separates them. So `internal/check/state_test.go` holds the messages
apart at the function, and the cases hold that the property is refused at all.
With that test present the same deletion moves:

    --- FAIL: TestEachStateSiteNamesItsOwnRepair/a_state_field_with_nothing_after_the_colon
        the message is "its State is \"\", and record 0003 names asking, answered, abandoned"
        and does not say "is there and empty", so it names the wrong repair

Its near neighbour at the same level, which stops a site that refused every
state from passing:

    --- FAIL: TestAStateThatIsLegalRefusesNothingOnItsOwn/asking
        a record in state asking with an answer refused [... record-state-is-not-one-of-the-three]

And the hole, held open:

    --- FAIL: TestARecordWithNoHeaderIsNotJudgedHere
        a file with no header was judged on its state and refused [...]

## Means

Go, in the operator beside the walk that already reads these records, and
fixtures as files under `testdata/cases` in the layout `harness_test.go` fixes.
Nothing new: no property could be refused, no set compared and no message
asserted in a means this tree does not already carry.

## A note on the third-site tests

`state_test.go` is a new file rather than an addition to `check_test.go`, so
the shared harness file is untouched by this change.

Nobody else has read this change. The evidence above stands in place of a
second reader rather than alongside one.


## What ran on this pull request, and what did not

The build and test workflow is not on the default branch yet. It arrives with
#88, and a `pull_request` run reads the workflow files from the merge of base
and head, so no `build`, `test`, `vet` or `format` job exists for this branch to
report. What ran here is the DCO, Unicode, workflow-audit and dependency-review
set the checks tab shows.

So the suite evidence above is local and one-platform, and it stays that way
until the build workflow is on `main`. Once it is, a branch taken from `main`
gets the three-platform suite reporting on its own pull request, and this
change should be re-run there rather than trusted from here.
