### PR TITLE
A skipped hardware test says what was missing

### DIFF
--- a/cmd/lab/main.go
+++ b/cmd/lab/main.go
@@ -12,9 +12,15 @@ import (
 )
 
 // The exit codes. Decision record 0011 is the contract and this is the only
-// place the numbers appear, so a caller keyed on one of them is reading the
-// record whether or not anybody told it so. A fifth code supersedes that
-// record rather than being added here.
+// place the three the runner returns appear, so a caller keyed on one of them
+// is reading the record whether or not anybody told it so. A fifth code
+// supersedes that record rather than being added here.
+//
+// The fourth code the record fixes is not here. `3`, for a run that was asked
+// for something and delivered nothing, belongs to the integration-hardware
+// harness and is declared where its producer is, in internal/hardware. Record
+// 0011 refuses a code written into the runner as a branch nothing can reach,
+// and that is what one here would be.
 const (
 	// exitClean means the run completed and refused nothing. It does not
 	// mean the tree is good, only that nothing this runner judges was found

--- a/internal/hardware/hardware.go
+++ b/internal/hardware/hardware.go
@@ -23,11 +23,26 @@ package hardware
 import (
 	"fmt"
 	"os"
+	"sort"
+	"strings"
+	"sync"
 	"testing"
 )
 
 // Name is what this harness is called wherever it is referred to.
 const Name = "integration-hardware"
+
+// ExitAskedAndDeliveredNothing is what a run of this harness reports when it
+// was asked for and executed nothing. Decision record 0011 fixes the meaning:
+// being asked for coverage and producing none is a failure of the request even
+// though no assertion broke, and reporting it as zero would let a run that
+// exercised nothing pass for a run that found nothing.
+//
+// Record 0011 is the contract for this number and for the three the runner
+// returns. It lives here rather than beside those three because this is where
+// its producer is, and that record refuses a code written into the runner as a
+// branch nothing can reach.
+const ExitAskedAndDeliveredNothing = 3
 
 // BuildTag is the constraint its tests are behind. The default run does not
 // compile them, which is a stronger exclusion than skipping at run time: a
@@ -65,17 +80,151 @@ func Disclosure() string {
 // rather than trusting it: a failure saying a device was unavailable is
 // useful, and one saying an assertion failed is not.
 //
-// What happens when the harness was asked for and the hardware is not there
-// is not decided here. That is issue #31, which is about what a skip says,
-// and this function is where it will go.
+// It is also where a test is counted. The tally is taken at the end of the
+// test rather than here, because a test that reaches this line and skips two
+// lines later has not run, and a skip is the one result that is reported in
+// the same colour as a pass.
 func Needs(t *testing.T, hardware string) {
 	t.Helper()
 
 	if hardware == "" {
 		t.Fatal("this test names no hardware, so a reader cannot tell what it would take to run it")
 	}
+
+	name := t.Name()
+	t.Cleanup(func() {
+		if t.Skipped() {
+			runs.skipped(name, hardware)
+			return
+		}
+		runs.executed()
+	})
+
 	if !Asked() {
 		t.Skipf("%s was not asked for. this test needs %s", Name, hardware)
 	}
 	t.Logf("this test needs %s, and it ran on whatever machine that is", hardware)
+}
+
+// Absent stops a test because the hardware it named is not on this machine. It
+// takes the hardware again and how that was established, because a skip saying
+// only that something was missing sends the reader to the test to find out
+// what, and the reader is usually somebody deciding whether their machine
+// could run it.
+//
+// Every skip in this harness goes through Needs or through here, and both name
+// what was missing. The tally counts either as a test that did not run.
+func Absent(t *testing.T, hardware, how string) {
+	t.Helper()
+
+	if hardware == "" || how == "" {
+		t.Fatal("a skip has to name the hardware that was missing and how that was established, or it says nothing a reader can act on")
+	}
+	t.Skipf("this test needs %s, which is not on this machine: %s", hardware, how)
+}
+
+// runs is what the harness counted. A run where everything skipped and a run
+// where everything passed look the same from outside, and the count is the
+// only thing that separates them.
+var runs tally
+
+// tally holds what a harness run executed and what it did not.
+type tally struct {
+	mu      sync.Mutex
+	ran     int
+	missing map[string]string
+}
+
+func (t *tally) executed() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.ran++
+}
+
+func (t *tally) skipped(test, hardware string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.missing == nil {
+		t.missing = make(map[string]string)
+	}
+	t.missing[test] = hardware
+}
+
+func (t *tally) counts() (ran, skipped int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.ran, len(t.missing)
+}
+
+// Summary is the line a harness run prints when it was asked for. It says how
+// many of its tests ran and how many did not, and it names what each one that
+// did not was missing.
+//
+// A LINE ADMITTING SOMETHING WAS NOT VERIFIED SURVIVES EVERY LATER EDIT AND
+// GETS SHARPER IF IT CHANGES AT ALL. Rewriting a skip notice into a statement
+// that the case passed is worse than deleting the test, and this is where a
+// reader looks for it, so this is where that is written down.
+func Summary() string {
+	runs.mu.Lock()
+	defer runs.mu.Unlock()
+
+	var out strings.Builder
+	fmt.Fprintf(&out, "%s: %d of its tests ran and %d did not.\n", Name, runs.ran, len(runs.missing))
+
+	if len(runs.missing) == 0 {
+		if runs.ran == 0 {
+			out.WriteString("nothing in this harness was executed, so this run is evidence about nothing.\n")
+		}
+		return out.String()
+	}
+
+	names := make([]string, 0, len(runs.missing))
+	for name := range runs.missing {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		fmt.Fprintf(&out, "  did not run: %s, missing %s\n", name, runs.missing[name])
+	}
+	out.WriteString("what those tests would have covered was not verified on this machine.\n")
+	return out.String()
+}
+
+// Verdict is the exit code a finished harness run reports, given the code the
+// test binary produced, whether the harness was asked for, and how many of its
+// tests executed.
+//
+// It is a function rather than four lines inside TestMain because record 0011
+// requires every code the harness can return to be reached by a test in the
+// default run, and no default run can produce a harness run that skipped
+// everything. The alternative is landing the mapping untested and finding out
+// on the day a job should have gone red.
+//
+// WHAT A CALLER ACTUALLY SEES. This is the exit status of the test binary. go
+// test collapses every non-zero status from a package to 1 in its own exit
+// code, so a caller that needs the three apart runs the binary rather than the
+// go command:
+//
+//	go test -tags integration_hardware -c -o harness ./internal/hardware
+//	LAB_INTEGRATION_HARDWARE=1 ./harness
+//
+// Through go test, a harness that was asked for and skipped everything is red
+// rather than distinctly red, which is the honest half of the claim and is
+// written here rather than left to be discovered.
+func Verdict(code int, asked bool, ran int) int {
+	if code != 0 || !asked || ran > 0 {
+		return code
+	}
+	return ExitAskedAndDeliveredNothing
+}
+
+// Report is what a harness run prints and returns when it finishes: the
+// disclosure where it was not asked for, the summary where it was, and the
+// exit code either way.
+func Report(code int) (string, int) {
+	if !Asked() {
+		return Disclosure() + "\n", code
+	}
+	ran, _ := runs.counts()
+	return Summary(), Verdict(code, true, ran)
 }

--- a/internal/hardware/hardware_test.go
+++ b/internal/hardware/hardware_test.go
@@ -10,14 +10,20 @@ import (
 	"testing"
 )
 
-// TestMain prints the disclosure on every default run. That line is the whole
-// point of the harness being separate: a run that covered less than the whole
-// set must not be readable as one that covered it and found nothing.
+// TestMain says what the run covered, and it says it at the end rather than at
+// the start, because that is where a reader looks after the last line of
+// output. On a default run that is the disclosure: this harness was not asked
+// for and nothing in it ran. On a run that asked for it, it is the count of
+// how many of its tests executed and how many did not, and what each one that
+// did not was missing.
+//
+// The exit code comes from the same place. A run asked for and delivering
+// nothing reports its own code, because no assertion breaking is not the same
+// as coverage having been produced.
 func TestMain(m *testing.M) {
-	if !Asked() {
-		fmt.Println(Disclosure())
-	}
-	os.Exit(m.Run())
+	report, code := Report(m.Run())
+	fmt.Print(report)
+	os.Exit(code)
 }
 
 // TestTheHarnessIsNotInTheDefaultRun holds the exclusion rather than trusting

--- a/internal/hardware/summary_test.go
+++ b/internal/hardware/summary_test.go
@@ -1,0 +1,199 @@
+package hardware
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// These run in the default suite, where no hardware test is compiled at all.
+// That is deliberate rather than awkward: what they hold is the reporting and
+// the exit code of a harness run, and both have to be provable on a machine
+// with none of the hardware, which is every machine the default run happens
+// on.
+
+// withTally runs f against a tally this test controls, and puts the harness's
+// own back afterwards. The counters are package state because TestMain reads
+// them after the last test has finished, and there is nowhere else for them to
+// live.
+func withTally(t *testing.T, ran int, missing map[string]string, f func()) {
+	t.Helper()
+
+	saved := runs.ran
+	savedMissing := runs.missing
+	t.Cleanup(func() {
+		runs.ran = saved
+		runs.missing = savedMissing
+	})
+
+	runs.ran = ran
+	runs.missing = missing
+	f()
+}
+
+// TestVerdictReachesEveryCodeThisHarnessCanReturn is what record 0011 asks of
+// every code: a test in the default run that reaches it. No default run can
+// produce a harness run that skipped everything, so the mapping is a function
+// and this is what proves it before the day a job should go red.
+func TestVerdictReachesEveryCodeThisHarnessCanReturn(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		code  int
+		asked bool
+		ran   int
+		want  int
+	}{
+		{"asked for, tests ran, nothing failed", 0, true, 2, 0},
+		{"asked for, nothing ran", 0, true, 0, ExitAskedAndDeliveredNothing},
+		{"asked for, nothing ran, and something failed as well", 1, true, 0, 1},
+		{"asked for, tests ran, something failed", 1, true, 2, 1},
+		{"not asked for, so nothing ran and that is ordinary", 0, false, 0, 0},
+		{"not asked for, and the meta tests failed", 1, false, 0, 1},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Verdict(c.code, c.asked, c.ran); got != c.want {
+				t.Errorf("Verdict(%d, %v, %d) is %d, want %d", c.code, c.asked, c.ran, got, c.want)
+			}
+		})
+	}
+}
+
+// TestSummaryNamesEveryTestThatDidNotRunAndWhatItWasMissing is the whole point
+// of the summary. A skip is reported in the same colour as a pass, so a run
+// where everything skipped and a run where everything passed look the same
+// from outside unless the missing thing is named.
+func TestSummaryNamesEveryTestThatDidNotRunAndWhatItWasMissing(t *testing.T) {
+	withTally(t, 1, map[string]string{
+		"TestReadsFromTheDevice":  "a device on the serial port",
+		"TestWritesToRealStorage": "the storage device the temporary directory is on",
+	}, func() {
+		summary := Summary()
+
+		for _, wants := range []string{
+			"1 of its tests ran and 2 did not",
+			"TestReadsFromTheDevice, missing a device on the serial port",
+			"TestWritesToRealStorage, missing the storage device the temporary directory is on",
+			"was not verified on this machine",
+		} {
+			if !strings.Contains(summary, wants) {
+				t.Errorf("the summary does not say %q. it says:\n%s", wants, summary)
+			}
+		}
+	})
+}
+
+// TestSummarySaysWhenNothingRanAtAll holds the sharpest case. A harness that
+// executed nothing is evidence about nothing, and the line that says so is the
+// one somebody quoting a green run needs to have read.
+func TestSummarySaysWhenNothingRanAtAll(t *testing.T) {
+	withTally(t, 0, nil, func() {
+		summary := Summary()
+		if !strings.Contains(summary, "0 of its tests ran and 0 did not") {
+			t.Errorf("the summary does not carry the counts. it says:\n%s", summary)
+		}
+		if !strings.Contains(summary, "evidence about nothing") {
+			t.Errorf("the summary does not say that the run proves nothing. it says:\n%s", summary)
+		}
+	})
+}
+
+// TestSummaryOfARunThatCoveredEverythingClaimsNothingMore is the near
+// neighbour. Without it, a summary that always printed the admission would
+// pass the two tests above.
+func TestSummaryOfARunThatCoveredEverythingClaimsNothingMore(t *testing.T) {
+	withTally(t, 3, nil, func() {
+		summary := Summary()
+		if !strings.Contains(summary, "3 of its tests ran and 0 did not") {
+			t.Errorf("the summary does not carry the counts. it says:\n%s", summary)
+		}
+		if strings.Contains(summary, "not verified") || strings.Contains(summary, "evidence about nothing") {
+			t.Errorf("a run that covered everything printed an admission. it says:\n%s", summary)
+		}
+	})
+}
+
+// TestAbsentRefusesASkipThatNamesNothing holds the other half of a useful
+// skip. Naming the hardware without saying how its absence was established
+// tells a reader nothing they can act on, and naming neither is the state this
+// whole issue is against.
+func TestAbsentRefusesASkipThatNamesNothing(t *testing.T) {
+	for _, c := range []struct{ name, hardware, how string }{
+		{"neither", "", ""},
+		{"no hardware", "", "the port is not there"},
+		{"no reason", "a device on the serial port", ""},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			fake := &testing.T{}
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				Absent(fake, c.hardware, c.how)
+			}()
+			<-done
+
+			if !fake.Failed() {
+				t.Errorf("Absent accepted a skip naming %q and %q", c.hardware, c.how)
+			}
+		})
+	}
+}
+
+// TestEveryHardwareSkipNamesWhatWasMissing is what makes the rule reach a test
+// nobody has written yet. Needs and Absent both name the missing thing and
+// both are counted by the tally; a bare t.Skip in a harness file names nothing
+// and is invisible to the summary, which is the exact failure this is against.
+//
+// It reads the harness source rather than running it, because the harness is
+// not compiled into the default run and this test is.
+func TestEveryHardwareSkipNamesWhatWasMissing(t *testing.T) {
+	files := hardwareTestFiles(t)
+	if len(files) == 0 {
+		t.Fatalf("no file in this package is behind the %s constraint, which cannot be right while the harness exists", BuildTag)
+	}
+
+	fset := token.NewFileSet()
+	for _, name := range files {
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("cannot parse %s: %v", name, err)
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if sel.Sel.Name == "Skip" || sel.Sel.Name == "Skipf" || sel.Sel.Name == "SkipNow" {
+				t.Errorf("%s skips directly at %s. a skip here has to go through Needs or Absent, which name what was missing and are counted in the summary",
+					name, fset.Position(call.Pos()))
+			}
+			return true
+		})
+	}
+}
+
+// TestADefaultRunReportsTheDisclosureAndNoSummary holds the two routes apart.
+// The disclosure is what a run that was not asked for owes; a summary there
+// would report zero of zero tests as though the harness had been run.
+func TestADefaultRunReportsTheDisclosureAndNoSummary(t *testing.T) {
+	if Asked() {
+		t.Skipf("%s was asked for on this run, so there is no default-run report to check", Name)
+	}
+
+	report, code := Report(0)
+	if !strings.Contains(report, "was not asked for") {
+		t.Errorf("the default-run report does not disclose that the harness was not asked for. it says:\n%s", report)
+	}
+	if strings.Contains(report, "of its tests ran") {
+		t.Errorf("the default-run report carries a summary of a run that did not happen. it says:\n%s", report)
+	}
+	if code != 0 {
+		t.Errorf("a default run reports %d, want 0. not asking for the harness is ordinary", code)
+	}
+}


### PR DESCRIPTION
Closes #31.

## What changes

`Needs` now tallies the test, `Absent` is added as the route for hardware that
is not on the machine, a harness run prints what it covered, and a run that was
asked for and executed nothing reports its own exit code.

## Every skip names what was missing

Two routes and no third. `Needs` names the hardware and skips where the harness
was not asked for. `Absent` names the hardware again and how its absence was
established, because a skip saying only that something was missing sends the
reader to the test to find out what, and that reader is usually somebody
deciding whether their own machine could run it.

A bare `t.Skip` in a harness file is refused by reading the harness source, the
same way every harness test is already held to naming its hardware. That is
what makes the rule reach a test nobody has written yet, rather than resting on
whoever remembers it.

The tally is taken at the end of the test rather than at the call, through a
cleanup that asks whether the test skipped. A test that reaches `Needs` and
skips two lines later has not run, and counting it at the call would report it
as coverage.

## The run says what it examined

    integration-hardware: 1 of its tests ran and 0 did not.

and where something did not run:

    integration-hardware: 1 of its tests ran and 2 did not.
      did not run: TestReadsFromTheDevice, missing a device on the serial port
      did not run: TestWritesToRealStorage, missing the storage device the temporary directory is on
    what those tests would have covered was not verified on this machine.

and the sharpest case:

    integration-hardware: 0 of its tests ran and 0 did not.
    nothing in this harness was executed, so this run is evidence about nothing.

That last pair of lines is an admission, and the comment at `Summary` says what
happens to it: it survives every later edit and gets sharper if it changes at
all. Rewriting a skip notice into a statement that the case passed is worse
than deleting the test.

## The exit code

Record 0011 reserves `3` for a run that was asked for something and delivered
nothing. It is declared in `internal/hardware`, where its producer is, and the
mapping is a function rather than four lines inside `TestMain` because record
0011 requires every code to be reached by a test in the default run and no
default run can produce a harness run that skipped everything.

What a caller actually sees is written at the function rather than left to be
discovered. `go test` collapses every non-zero status from a package to `1`, so
through the go command a harness that was asked for and skipped everything is
red rather than distinctly red. A caller that needs the codes apart runs the
binary.

## One correction this change forces

`cmd/lab/main.go` said its const block was the only place the exit numbers
appear. Adding `3` in the harness makes that false, so the comment now says it
holds the three the runner returns and names where the fourth lives. Record
0011 refuses a code written into the runner as a branch nothing can reach,
which is what a `3` in that block would be, so moving the number there was not
the alternative.

## Means

Go, in the harness package the tests already live in, using `testing`'s own
cleanup and skip machinery and `go/ast` for the source read that the harness
already uses for its other standing requirement. Nothing new: a shell wrapper
counting skips out of the output would be a second apparatus over a format
nobody controls.

## Evidence

Run at `0fdda293092ee16fe4218de0a7d29c90b21b53cd`, the head of this branch.

    $ gofmt -l . ; go vet ./... ; go test -count=1 ./...
    ok  	github.com/Flowfin/lab/cmd/lab	0.769s
    ok  	github.com/Flowfin/lab/internal/check	1.070s
    ok  	github.com/Flowfin/lab/internal/hardware	1.032s

The exit code, end to end, against the compiled harness. Asked for, with one
hardware test reached:

    $ LAB_INTEGRATION_HARDWARE=1 ./harness -test.run TestSequentialWriteOnRealStorage
    PASS
    integration-hardware: 1 of its tests ran and 0 did not.
    exit=0

Asked for, reaching nothing, which is the case the issue is about:

    $ LAB_INTEGRATION_HARDWARE=1 ./harness -test.run TestNoSuchTestExists
    testing: warning: no tests to run
    PASS
    integration-hardware: 0 of its tests ran and 0 did not.
    nothing in this harness was executed, so this run is evidence about nothing.
    exit=3

Not asked for, which stays ordinary and stays zero:

    $ ./harness -test.run TestNoSuchTestExists
    PASS
    the integration-hardware harness was not asked for and nothing in it ran.
    ...
    exit=0

Each guard was then deleted and the suite watched.

Making `Verdict` never return the third code:

    --- FAIL: TestVerdictReachesEveryCodeThisHarnessCanReturn/asked_for,_nothing_ran
        Verdict(0, true, 0) is 0, want 3

Dropping the missing hardware from the summary lines:

    --- FAIL: TestSummaryNamesEveryTestThatDidNotRunAndWhatItWasMissing
        the summary does not say "TestReadsFromTheDevice, missing a device on the serial port"

Removing the admission that a skipped test was not verified:

    --- FAIL: TestSummaryNamesEveryTestThatDidNotRunAndWhatItWasMissing
        the summary does not say "was not verified on this machine"

Putting a bare skip into the one harness test that exists:

    --- FAIL: TestEveryHardwareSkipNamesWhatWasMissing
        storage_integration_hardware_test.go skips directly at storage_integration_hardware_test.go:28:3

## Limits

`Absent` has no caller among the hardware tests today. The one test in the
harness cannot establish that the storage it names is missing without a
per-platform syscall, and inventing that here would be a guess about a
filesystem rather than a prerequisite check. It is exercised by the suite and
it is the route the first test that can detect its own missing hardware takes.

The summary and the disclosure go to the test binary's output, which `go test`
shows under `-v` or when the package fails and swallows otherwise. That is
unchanged by this change and it is worth knowing, because it means a plain `go
test ./...` prints neither. The suite step in #89 runs with `-v`, so both
appear there.

Nobody else has read this change. The evidence above stands in place of a
second reader rather than alongside one.

## What ran on this pull request, and what did not

The build and test workflow is not on the default branch yet. It arrives with
#88, and a `pull_request` run reads the workflow files from the merge of base
and head, so no `build`, `test`, `vet` or `format` job exists for this branch to
report. The suite evidence above is local and one-platform until that workflow
is on `main`.
