### PR TITLE
Refuse a decision record that is not a decision

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -219,6 +219,14 @@ type Result struct {
 	// Records is the number of experiment records read.
 	Records int
 
+	// DecisionsPresent says whether Root held a decisions directory at all.
+	// Absent and empty are different statements about a tree, and only one of
+	// them says the records were read and there were none.
+	DecisionsPresent bool
+
+	// Decisions is the number of decision records read.
+	Decisions int
+
 	// Refusals is what the walk refused, in the order the walk reached
 	// them. Each one names its property and its subject.
 	Refusals []Refusal
@@ -270,7 +278,24 @@ func Walk(root string) (Result, error) {
 	}
 	res.Refusals = append(res.Refusals, strayRefusals...)
 
+	decisions, decisionRefusals, err := refuseDecisions(root)
+	if err != nil {
+		return res, err
+	}
+	res.DecisionsPresent = decisionsPresent(root)
+	res.Decisions = decisions
+	res.Refusals = append(res.Refusals, decisionRefusals...)
+
 	return res, nil
+}
+
+// decisionsPresent says whether the tree holds a decisions directory at all.
+// It is asked separately from the count because a tree with none and a tree
+// whose directory is empty both read zero records, and collapsing the two into
+// that zero is the failure this package exists to avoid.
+func decisionsPresent(root string) bool {
+	info, err := os.Stat(filepath.Join(root, filepath.FromSlash(DecisionsDir)))
+	return err == nil && info.IsDir()
 }
 
 // walkExperiments reads the one directory an experiment may live in and holds
@@ -605,6 +630,10 @@ func (r Result) Report() string {
 	out += fmt.Sprintf("%d experiment %s walked, %d %s read\n",
 		r.Directories, plural(r.Directories, "directory", "directories"),
 		r.Records, plural(r.Records, "record", "records"))
+	if !r.DecisionsPresent {
+		out += fmt.Sprintf("no %s directory in this tree\n", DecisionsDir)
+	}
+	out += fmt.Sprintf("%d decision %s read\n", r.Decisions, plural(r.Decisions, "record", "records"))
 	out += fmt.Sprintf("%d refused\n", len(r.Refusals))
 	for _, refusal := range r.Refusals {
 		out += fmt.Sprintf("  %s\n", refusal)

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -41,6 +41,12 @@ func TestCases(t *testing.T) {
 			if got.ExperimentsPresent != want.experimentsPresent {
 				t.Errorf("experiments directory present is %v, case expects %v", got.ExperimentsPresent, want.experimentsPresent)
 			}
+			if got.DecisionsPresent != want.decisionsPresent {
+				t.Errorf("decisions directory present is %v, case expects %v", got.DecisionsPresent, want.decisionsPresent)
+			}
+			if got.Decisions != want.decisions {
+				t.Errorf("read %d decision records, case expects %d", got.Decisions, want.decisions)
+			}
 			for _, diff := range diffRefusalSets(want.refusals, got.Properties()) {
 				t.Error(diff)
 			}

--- a/internal/check/decision.go
+++ b/internal/check/decision.go
@@ -1,0 +1,192 @@
+package check
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// DecisionsDir is where record 0000 puts the decision records, relative to the
+// root of the tree. Record 0002 fixes the directory and record 0000 fixes what
+// a file in it looks like, so the two rules below read one directory rather
+// than searching for records that might be anywhere.
+const DecisionsDir = "docs/decisions"
+
+// The properties the decision records can be refused for. They are separate
+// from the properties about an experiment record because the artefact is
+// different, and they are in the same walk and the same harness because the
+// mechanism is the same one.
+const (
+	// DecisionRecordIsMissingASection refuses a decision record that does not
+	// carry one of the four headings record 0000 fixes. The one that will be
+	// missing is the last, because it is the one that takes work, and it is
+	// the one the format exists for: a record listing no rejected option and
+	// no cost is an announcement rather than a decision, and the rest of this
+	// plan is derived from these records.
+	DecisionRecordIsMissingASection = "decision-record-is-missing-a-section"
+
+	// TwoDecisionRecordsShareANumber refuses a number written twice. A number
+	// is taken from the highest one already landed, so two changes started
+	// from the same base take the same number, both are green on their own
+	// branches, and nothing notices until they meet. Afterwards no rule has
+	// been broken and a reference to that number stops resolving to one
+	// thing. The refusal fires on the pair, which is the last moment
+	// renumbering is still cheap.
+	TwoDecisionRecordsShareANumber = "two-decision-records-share-a-number"
+
+	// SupersessionNamesARecordThatIsNotThere refuses a record that says it
+	// supersedes a number no record carries. Records in this plan supersede
+	// rather than get edited, so this route is walked before the first
+	// release, and a supersession pointing at nothing leaves the superseded
+	// decision reading as current.
+	SupersessionNamesARecordThatIsNotThere = "supersession-names-a-record-that-is-not-there"
+)
+
+// decisionSections are the four headings record 0000 fixes, written here as
+// well as there because a check that reads its list out of a document goes
+// quiet the day the document is reworded.
+//
+// Only presence is judged. Record 0000 also fixes the order they appear in and
+// says what each one is for, and neither of those is read here: a record
+// carrying all four in the wrong order passes, and so does one whose fourth
+// section names an option nobody seriously considered. The first is worth a
+// separate rule and does not have one; the second is a judgement about meaning
+// that no reading of the tree makes, and the review is where it is caught.
+var decisionSections = []string{
+	"What was decided",
+	"What it applies to",
+	"What else was considered",
+	"What each rejected option would have cost",
+}
+
+// decisionFileName is what record 0000 names a decision record: four digits, a
+// hyphen, a slug. A file in the directory that does not match is not read at
+// all, which is a hole and is named rather than hidden: a record misnamed on
+// the way in escapes all three rules below.
+var decisionFileName = regexp.MustCompile(`^(\d{4})-[A-Za-z0-9-]+\.md$`)
+
+// supersession is the active form only. A record saying it supersedes 0008 is
+// asserting that 0008 is there, and that assertion is what the third rule
+// reads. The passive form is deliberately not matched: several records here
+// say that a later record will supersede them one day, and a rule that read
+// those would refuse a record for naming a number that is not supposed to
+// exist yet.
+var supersession = regexp.MustCompile(`(?i)supersedes\s+(?:record\s+)?(\d{4})`)
+
+// refuseDecisions reads the decision records and returns how many it read
+// along with what it refused. A tree with no decisions directory reads none,
+// which is an ordinary state for a fixture tree and is reported rather than
+// treated as an error.
+func refuseDecisions(root string) (int, []Refusal, error) {
+	dir := filepath.Join(root, filepath.FromSlash(DecisionsDir))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil, nil
+		}
+		return 0, nil, fmt.Errorf("cannot read %s: %w", dir, err)
+	}
+
+	var refusals []Refusal
+	read := 0
+	numbers := make(map[string]string)
+	present := make(map[string]bool)
+	var records []string
+
+	// os.ReadDir sorts by filename, so the record that reports a shared number
+	// is the later one of the pair every time this runs rather than whichever
+	// the filesystem happened to hand over first.
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		match := decisionFileName.FindStringSubmatch(entry.Name())
+		if match == nil {
+			continue
+		}
+		read++
+		records = append(records, entry.Name())
+		present[match[1]] = true
+	}
+
+	for _, name := range records {
+		path := filepath.Join(dir, name)
+		number := decisionFileName.FindStringSubmatch(name)[1]
+
+		if first, taken := numbers[number]; taken {
+			refusals = append(refusals, Refusal{
+				Property: TwoDecisionRecordsShareANumber,
+				Subject:  path,
+				Detail:   fmt.Sprintf("it is numbered %s and so is %s, so a reference to %s resolves to two records", number, first, number),
+			})
+		} else {
+			numbers[number] = name
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return read, nil, fmt.Errorf("cannot read %s: %w", path, err)
+		}
+		text := string(data)
+
+		for _, section := range headingsMissingFrom(text) {
+			refusals = append(refusals, Refusal{
+				Property: DecisionRecordIsMissingASection,
+				Subject:  path,
+				Detail:   fmt.Sprintf("it carries no %q section, and record 0000 fixes four: %s", section, strings.Join(decisionSections, "; ")),
+			})
+		}
+
+		for _, named := range numbersSuperseded(text) {
+			if present[named] {
+				continue
+			}
+			refusals = append(refusals, Refusal{
+				Property: SupersessionNamesARecordThatIsNotThere,
+				Subject:  path,
+				Detail:   fmt.Sprintf("it says it supersedes %s and no record in %s carries that number, so whatever it replaced still reads as current", named, DecisionsDir),
+			})
+		}
+	}
+
+	return read, refusals, nil
+}
+
+// headingsMissingFrom returns the fixed sections a record does not carry, in
+// the order record 0000 writes them.
+func headingsMissingFrom(text string) []string {
+	carried := make(map[string]bool)
+	for _, line := range strings.Split(text, "\n") {
+		if heading, isHeading := strings.CutPrefix(strings.TrimSpace(line), "## "); isHeading {
+			carried[strings.TrimSpace(heading)] = true
+		}
+	}
+
+	var missing []string
+	for _, section := range decisionSections {
+		if !carried[section] {
+			missing = append(missing, section)
+		}
+	}
+	return missing
+}
+
+// numbersSuperseded returns the record numbers a text claims to supersede,
+// each once, sorted so that a record naming two of them refuses in an order a
+// reader can predict.
+func numbersSuperseded(text string) []string {
+	seen := make(map[string]bool)
+	var named []string
+	for _, match := range supersession.FindAllStringSubmatch(text, -1) {
+		if seen[match[1]] {
+			continue
+		}
+		seen[match[1]] = true
+		named = append(named, match[1])
+	}
+	sort.Strings(named)
+	return named
+}

--- a/internal/check/harness_test.go
+++ b/internal/check/harness_test.go
@@ -14,7 +14,7 @@
 // The layout of a case:
 //
 //	testdata/cases/<name>/tree/               what the runner walks
-//	testdata/cases/<name>/expected            three lines, see readExpectation
+//	testdata/cases/<name>/expected            four lines, see readExpectation
 //	testdata/cases/<name>/expected-refusals   one property per line, may be empty
 //	testdata/cases/<name>/near-neighbour      the case that differs by the
 //	                                          smallest legal change, required
@@ -56,6 +56,8 @@ type expectation struct {
 	directories        int
 	records            int
 	experimentsPresent bool
+	decisionsPresent   bool
+	decisions          int
 	refusals           []string
 }
 
@@ -117,13 +119,25 @@ func readExpectation(t *testing.T, dir string) expectation {
 			default:
 				t.Fatalf("case %s: experiments is %q, want present or absent", dir, value)
 			}
+		case "decisions":
+			// One key carrying both facts. A tree with no decisions
+			// directory and one whose directory is empty both read zero
+			// records, so a case saying zero would not separate them, and
+			// absent is how a case says which of the two it is.
+			if value == "absent" {
+				exp.decisionsPresent = false
+				exp.decisions = 0
+				break
+			}
+			exp.decisionsPresent = true
+			exp.decisions = mustAtoi(t, dir, value)
 		default:
 			t.Fatalf("case %s: unknown expectation %q", dir, key)
 		}
 	}
 	sort.Strings(seen)
-	if strings.Join(seen, ",") != "directories,experiments,records" {
-		t.Fatalf("case %s: expectation names %v, want all three of directories, experiments and records", dir, seen)
+	if strings.Join(seen, ",") != "decisions,directories,experiments,records" {
+		t.Fatalf("case %s: expectation names %v, want all four of directories, experiments, records and decisions", dir, seen)
 	}
 
 	refusals, err := os.ReadFile(filepath.Join(dir, "expected-refusals"))

--- a/testdata/cases/a-record-under-the-fixtures-directory/expected
+++ b/testdata/cases/a-record-under-the-fixtures-directory/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/a-supersession-naming-a-record-that-is-not-there/expected
+++ b/testdata/cases/a-supersession-naming-a-record-that-is-not-there/expected
@@ -1,0 +1,4 @@
+directories 0
+records 0
+experiments absent
+decisions 2

--- a/testdata/cases/a-supersession-naming-a-record-that-is-not-there/expected-refusals
+++ b/testdata/cases/a-supersession-naming-a-record-that-is-not-there/expected-refusals
@@ -1,0 +1,1 @@
+supersession-names-a-record-that-is-not-there

--- a/testdata/cases/a-supersession-naming-a-record-that-is-not-there/near-neighbour
+++ b/testdata/cases/a-supersession-naming-a-record-that-is-not-there/near-neighbour
@@ -1,0 +1,1 @@
+a-supersession-naming-a-record-that-is-there

--- a/testdata/cases/a-supersession-naming-a-record-that-is-not-there/tree/docs/decisions/0000-the-first-decision.md
+++ b/testdata/cases/a-supersession-naming-a-record-that-is-not-there/tree/docs/decisions/0000-the-first-decision.md
@@ -1,0 +1,17 @@
+# 0000. The first decision
+
+## What was decided
+
+The smallest thing a decision record can decide.
+
+## What it applies to
+
+This fixture tree and nothing else.
+
+## What else was considered
+
+Deciding the other way.
+
+## What each rejected option would have cost
+
+Everything this record was written to avoid.

--- a/testdata/cases/a-supersession-naming-a-record-that-is-not-there/tree/docs/decisions/0001-the-later-decision.md
+++ b/testdata/cases/a-supersession-naming-a-record-that-is-not-there/tree/docs/decisions/0001-the-later-decision.md
@@ -1,0 +1,17 @@
+# 0001. The later decision
+
+## What was decided
+
+The smallest thing a decision record can decide. This supersedes 0009.
+
+## What it applies to
+
+This fixture tree and nothing else.
+
+## What else was considered
+
+Deciding the other way.
+
+## What each rejected option would have cost
+
+Everything this record was written to avoid.

--- a/testdata/cases/a-supersession-naming-a-record-that-is-there/expected
+++ b/testdata/cases/a-supersession-naming-a-record-that-is-there/expected
@@ -1,0 +1,4 @@
+directories 0
+records 0
+experiments absent
+decisions 2

--- a/testdata/cases/a-supersession-naming-a-record-that-is-there/tree/docs/decisions/0000-the-first-decision.md
+++ b/testdata/cases/a-supersession-naming-a-record-that-is-there/tree/docs/decisions/0000-the-first-decision.md
@@ -1,0 +1,17 @@
+# 0000. The first decision
+
+## What was decided
+
+The smallest thing a decision record can decide.
+
+## What it applies to
+
+This fixture tree and nothing else.
+
+## What else was considered
+
+Deciding the other way.
+
+## What each rejected option would have cost
+
+Everything this record was written to avoid.

--- a/testdata/cases/a-supersession-naming-a-record-that-is-there/tree/docs/decisions/0001-the-later-decision.md
+++ b/testdata/cases/a-supersession-naming-a-record-that-is-there/tree/docs/decisions/0001-the-later-decision.md
@@ -1,0 +1,17 @@
+# 0001. The later decision
+
+## What was decided
+
+The smallest thing a decision record can decide. This supersedes 0000.
+
+## What it applies to
+
+This fixture tree and nothing else.
+
+## What else was considered
+
+Deciding the other way.
+
+## What each rejected option would have cost
+
+Everything this record was written to avoid.

--- a/testdata/cases/decision-record-missing-a-section/expected
+++ b/testdata/cases/decision-record-missing-a-section/expected
@@ -1,0 +1,4 @@
+directories 0
+records 0
+experiments absent
+decisions 1

--- a/testdata/cases/decision-record-missing-a-section/expected-refusals
+++ b/testdata/cases/decision-record-missing-a-section/expected-refusals
@@ -1,0 +1,1 @@
+decision-record-is-missing-a-section

--- a/testdata/cases/decision-record-missing-a-section/near-neighbour
+++ b/testdata/cases/decision-record-missing-a-section/near-neighbour
@@ -1,0 +1,1 @@
+decision-record-with-every-section

--- a/testdata/cases/decision-record-missing-a-section/tree/docs/decisions/0000-the-first-decision.md
+++ b/testdata/cases/decision-record-missing-a-section/tree/docs/decisions/0000-the-first-decision.md
@@ -1,0 +1,13 @@
+# 0000. The first decision
+
+## What was decided
+
+The smallest thing a decision record can decide.
+
+## What it applies to
+
+This fixture tree and nothing else.
+
+## What else was considered
+
+Deciding the other way.

--- a/testdata/cases/decision-record-with-every-section/expected
+++ b/testdata/cases/decision-record-with-every-section/expected
@@ -1,0 +1,4 @@
+directories 0
+records 0
+experiments absent
+decisions 1

--- a/testdata/cases/decision-record-with-every-section/tree/docs/decisions/0000-the-first-decision.md
+++ b/testdata/cases/decision-record-with-every-section/tree/docs/decisions/0000-the-first-decision.md
@@ -1,0 +1,17 @@
+# 0000. The first decision
+
+## What was decided
+
+The smallest thing a decision record can decide.
+
+## What it applies to
+
+This fixture tree and nothing else.
+
+## What else was considered
+
+Deciding the other way.
+
+## What each rejected option would have cost
+
+Everything this record was written to avoid.

--- a/testdata/cases/empty-experiments-directory/expected
+++ b/testdata/cases/empty-experiments-directory/expected
@@ -1,3 +1,4 @@
 directories 0
 records 0
 experiments present
+decisions absent

--- a/testdata/cases/experiment-without-a-record/expected
+++ b/testdata/cases/experiment-without-a-record/expected
@@ -1,3 +1,4 @@
 directories 1
 records 0
 experiments present
+decisions absent

--- a/testdata/cases/file-directly-under-experiments/expected
+++ b/testdata/cases/file-directly-under-experiments/expected
@@ -1,3 +1,4 @@
 directories 0
 records 0
 experiments present
+decisions absent

--- a/testdata/cases/no-experiments-directory/expected
+++ b/testdata/cases/no-experiments-directory/expected
@@ -1,3 +1,4 @@
 directories 0
 records 0
 experiments absent
+decisions absent

--- a/testdata/cases/one-experiment-with-a-record/expected
+++ b/testdata/cases/one-experiment-with-a-record/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-abandoned-with-a-reason/expected
+++ b/testdata/cases/record-abandoned-with-a-reason/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-abandoned-with-no-reason/expected
+++ b/testdata/cases/record-abandoned-with-no-reason/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-answered-with-an-answer/expected
+++ b/testdata/cases/record-answered-with-an-answer/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-answered-with-no-answer/expected
+++ b/testdata/cases/record-answered-with-no-answer/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-in-asking/expected
+++ b/testdata/cases/record-in-asking/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-is-a-directory/expected
+++ b/testdata/cases/record-is-a-directory/expected
@@ -1,3 +1,4 @@
 directories 1
 records 0
 experiments present
+decisions absent

--- a/testdata/cases/record-naming-a-path-that-is-not-there/expected
+++ b/testdata/cases/record-naming-a-path-that-is-not-there/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-naming-a-path-that-is-there/expected
+++ b/testdata/cases/record-naming-a-path-that-is-there/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-one-level-too-deep/expected
+++ b/testdata/cases/record-one-level-too-deep/expected
@@ -1,3 +1,4 @@
 directories 1
 records 0
 experiments present
+decisions absent

--- a/testdata/cases/record-with-a-byte-order-mark/expected
+++ b/testdata/cases/record-with-a-byte-order-mark/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-with-a-misspelled-state/expected
+++ b/testdata/cases/record-with-a-misspelled-state/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-with-a-null-byte/expected
+++ b/testdata/cases/record-with-a-null-byte/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-with-a-valid-sequence/expected
+++ b/testdata/cases/record-with-a-valid-sequence/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-with-an-empty-state/expected
+++ b/testdata/cases/record-with-an-empty-state/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-with-an-invalid-sequence/expected
+++ b/testdata/cases/record-with-an-invalid-sequence/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-with-carriage-returns/expected
+++ b/testdata/cases/record-with-carriage-returns/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-with-no-null-byte/expected
+++ b/testdata/cases/record-with-no-null-byte/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-with-no-state-field/expected
+++ b/testdata/cases/record-with-no-state-field/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/record-without-the-byte-order-mark/expected
+++ b/testdata/cases/record-without-the-byte-order-mark/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/root-directory-the-layout-does-not-name/expected
+++ b/testdata/cases/root-directory-the-layout-does-not-name/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/root-directory-the-layout-names/expected
+++ b/testdata/cases/root-directory-the-layout-names/expected
@@ -1,3 +1,4 @@
 directories 1
 records 1
 experiments present
+decisions absent

--- a/testdata/cases/two-decision-records-with-one-number/expected
+++ b/testdata/cases/two-decision-records-with-one-number/expected
@@ -1,0 +1,4 @@
+directories 0
+records 0
+experiments absent
+decisions 2

--- a/testdata/cases/two-decision-records-with-one-number/expected-refusals
+++ b/testdata/cases/two-decision-records-with-one-number/expected-refusals
@@ -1,0 +1,1 @@
+two-decision-records-share-a-number

--- a/testdata/cases/two-decision-records-with-one-number/near-neighbour
+++ b/testdata/cases/two-decision-records-with-one-number/near-neighbour
@@ -1,0 +1,1 @@
+two-decision-records-with-two-numbers

--- a/testdata/cases/two-decision-records-with-one-number/tree/docs/decisions/0001-the-first-of-them.md
+++ b/testdata/cases/two-decision-records-with-one-number/tree/docs/decisions/0001-the-first-of-them.md
@@ -1,0 +1,17 @@
+# 0001. The first of them
+
+## What was decided
+
+The smallest thing a decision record can decide.
+
+## What it applies to
+
+This fixture tree and nothing else.
+
+## What else was considered
+
+Deciding the other way.
+
+## What each rejected option would have cost
+
+Everything this record was written to avoid.

--- a/testdata/cases/two-decision-records-with-one-number/tree/docs/decisions/0001-the-second-of-them.md
+++ b/testdata/cases/two-decision-records-with-one-number/tree/docs/decisions/0001-the-second-of-them.md
@@ -1,0 +1,17 @@
+# 0001. The second of them
+
+## What was decided
+
+The smallest thing a decision record can decide.
+
+## What it applies to
+
+This fixture tree and nothing else.
+
+## What else was considered
+
+Deciding the other way.
+
+## What each rejected option would have cost
+
+Everything this record was written to avoid.

--- a/testdata/cases/two-decision-records-with-two-numbers/expected
+++ b/testdata/cases/two-decision-records-with-two-numbers/expected
@@ -1,0 +1,4 @@
+directories 0
+records 0
+experiments absent
+decisions 2

--- a/testdata/cases/two-decision-records-with-two-numbers/tree/docs/decisions/0001-the-first-of-them.md
+++ b/testdata/cases/two-decision-records-with-two-numbers/tree/docs/decisions/0001-the-first-of-them.md
@@ -1,0 +1,17 @@
+# 0001. The first of them
+
+## What was decided
+
+The smallest thing a decision record can decide.
+
+## What it applies to
+
+This fixture tree and nothing else.
+
+## What else was considered
+
+Deciding the other way.
+
+## What each rejected option would have cost
+
+Everything this record was written to avoid.

--- a/testdata/cases/two-decision-records-with-two-numbers/tree/docs/decisions/0002-the-second-of-them.md
+++ b/testdata/cases/two-decision-records-with-two-numbers/tree/docs/decisions/0002-the-second-of-them.md
@@ -1,0 +1,17 @@
+# 0002. The second of them
+
+## What was decided
+
+The smallest thing a decision record can decide.
+
+## What it applies to
+
+This fixture tree and nothing else.
+
+## What else was considered
+
+Deciding the other way.
+
+## What each rejected option would have cost
+
+Everything this record was written to avoid.


### PR DESCRIPTION
Closes #67.

Scope: internal/check, testdata/cases

Record 0000 fixes four sections and says that a record listing no rejected option is
an announcement rather than a decision. It then leaves a reader to notice, which is an
explanation of a rule sitting under the one artefact the rest of the plan is derived
from. This adds the three refusals that make it a rule.

The means is Go, in the package that already holds every refusal, read by the same
walk and proved by the same harness and the same shape of fixture. The artefact is a
decision record rather than an experiment record and the mechanism is the same one, so
nothing here adds a language, a runtime or a dependency.

## What the refusals say

```
$ go run ./cmd/lab check testdata/cases/decision-record-missing-a-section/tree
1 decision record read
1 refused
  ...\0000-the-first-decision.md: it carries no "What each rejected option would have cost" section, and record 0000 fixes four: What was decided; What it applies to; What else was considered; What each rejected option would have cost (decision-record-is-missing-a-section)

$ go run ./cmd/lab check testdata/cases/two-decision-records-with-one-number/tree
2 decision records read
1 refused
  ...\0001-the-second-of-them.md: it is numbered 0001 and so is 0001-the-first-of-them.md, so a reference to 0001 resolves to two records (two-decision-records-share-a-number)

$ go run ./cmd/lab check testdata/cases/a-supersession-naming-a-record-that-is-not-there/tree
2 decision records read
1 refused
  ...\0001-the-later-decision.md: it says it supersedes 0009 and no record in docs/decisions carries that number, so whatever it replaced still reads as current (supersession-names-a-record-that-is-not-there)
```

The shared number is the near miss, and the refusal fires on the later of the pair
because that is the last moment renumbering is still cheap. Reading the directory in
sorted order is what makes it the same one of the two every run rather than whichever
the filesystem handed over first.

## The proof that each one bites

Each refusal has a fixture declaring exactly that property and no other, with a near
neighbour differing by the smallest change that makes it legal and refusing nothing.
Each guard was then deleted and the suite run, with the tree restored after each run.

```
    --- FAIL: TestCases/decision-record-missing-a-section
        check_test.go:51: expected refusal not produced: decision-record-is-missing-a-section

    --- FAIL: TestCases/two-decision-records-with-one-number
        check_test.go:51: expected refusal not produced: two-decision-records-share-a-number

    --- FAIL: TestCases/a-supersession-naming-a-record-that-is-not-there
        check_test.go:51: expected refusal not produced: supersession-names-a-record-that-is-not-there
```

## What the run now says it read

The report gains the number of decision records the walk read, and the case format
gains one key that carries it. A tree with no decisions directory and one whose
directory is empty both read zero records, so that key says `absent` or a number
rather than a zero that reads the same either way. Every existing case declares
`decisions absent`, which is what those fixture trees hold.

## What is not judged

The order of the four sections. Record 0000 fixes it and only presence is read here,
so a record carrying all four out of order passes. That is worth a separate rule and
does not have one.

Whether a rejected option was real. A record naming one alternative nobody seriously
considered passes, and so does one whose reasons are thin. No reading of the tree makes
that judgement and the review is where it is caught.

A file in the directory whose name does not match the shape record 0000 fixes. It is
not read at all, so a record misnamed on the way in escapes all three rules. The hole
is named at `decisionFileName` in `internal/check/decision.go` rather than left to be
discovered.

The passive form of a supersession is deliberately not matched. Records 0008, 0009 and
0012 each say that a later record will supersede them, and a rule reading those would
refuse a record for naming a number that is not supposed to exist yet. Only a record
asserting that it supersedes a number is held to that number existing.

## The gate

Run at `ca770c1`, with `go version go1.26.5 windows/amd64`:

```
$ go build ./... && go vet ./... && gofmt -l . && go test ./...
ok  	github.com/Flowfin/lab/cmd/lab	1.275s
ok  	github.com/Flowfin/lab/internal/check	1.400s
ok  	github.com/Flowfin/lab/internal/hardware	1.271s

$ go run ./cmd/lab check .
examined .
no experiments directory in this tree
0 experiment directories walked, 0 records read
14 decision records read
0 refused
```

`gofmt -l .` printed nothing, which is its passing result. The fourteen records this
tree carries pass all three rules unchanged.

No second person has read this change. The evidence above stands in place of a
review rather than alongside one.
