### PR TITLE
Run the default suite on every platform the release ships

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,10 +99,12 @@ jobs:
     # record 0012 chose the list from, and each entry below differs from the
     # baseline in at least one of them.
     #
-    # The label is not the platform. `macos-latest` is an arm64 image, which is
-    # the `darwin/arm64` entry; the names below are written from the record's
-    # vocabulary rather than from the runner label, because the record is what a
-    # reader is holding when they ask whether every entry is covered.
+    # The label is not the platform. The names below are written from the
+    # record's vocabulary rather than from the runner label, because the record
+    # is what a reader is holding when they ask whether every entry is covered,
+    # and which architecture a label carries is a property of an image rather
+    # than of this file. Nothing here claims that pairing: the first step of the
+    # job asks the toolchain and refuses the entry when the answer disagrees.
     #
     # Record 0012 leaves open whether a hosted runner is offered for each of
     # these and says the first workflow written against it settles that, since a
@@ -143,6 +145,25 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+
+      - name: Say which platform this entry ran on
+        # The entry names a platform and the image decides what it actually is,
+        # so this asks rather than assumes. An image that moves under its label
+        # reddens the entry that claimed it instead of quietly running the suite
+        # somewhere record 0012 already covers, which is the failure a sentence
+        # in a comment could not catch. It also prints the answer, so a reader
+        # asking which three platforms produced evidence reads it out of the run
+        # rather than out of this file.
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          reported="$(go env GOOS)/$(go env GOARCH)"
+          echo "${PLATFORM}: the toolchain here reports ${reported}"
+          if [ "$reported" != "$PLATFORM" ]; then
+            echo "::error::This entry is written as ${PLATFORM} and the toolchain reports ${reported}."
+            exit 1
+          fi
 
       - name: Run the default suite
         # The same suite on every entry. No platform gets a reduced set and no

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,10 @@
 #
 # The platforms come from docs/decisions/0012-the-supported-platforms.md and
 # from nowhere else. That record names six entries for the build and three for
-# the suite; this workflow holds the build half of it. The suite runs on one
-# platform here, and issue #57 is where it grows to the three the record names.
+# the suite, and both halves are here. The three the suite runs on are the three
+# that differ in what a checkout is, which is the whole of what the runner
+# reads; the other three are compiled and produce no evidence beyond that the
+# source builds.
 #
 # Hardened the way every other workflow in this tree is, because the audit job
 # in zizmor.yml refuses a new one that departs from it: permissions are denied
@@ -89,15 +91,47 @@ jobs:
         run: go build ./...
 
   test:
-    # Named for the platform it runs on rather than `test`, because issue #57
-    # adds the other two entries record 0012 names and a bare `test` would have
-    # to be renamed to make room for them. A rename is a change to the gate, so
-    # the name that survives that change is the one to write now.
-    name: test (linux/amd64)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # One entry per platform record 0012 says the release ships a binary for and
+    # the suite runs on. Compiling for a platform is not the property that
+    # matters most here: the runner's whole job is reading a checkout, and what
+    # a checkout is differs between these three. Case folding, the path
+    # separator and what a line ending arrives as are the three properties
+    # record 0012 chose the list from, and each entry below differs from the
+    # baseline in at least one of them.
+    #
+    # The label is not the platform. `macos-latest` is an arm64 image, which is
+    # the `darwin/arm64` entry; the names below are written from the record's
+    # vocabulary rather than from the runner label, because the record is what a
+    # reader is holding when they ask whether every entry is covered.
+    #
+    # Record 0012 leaves open whether a hosted runner is offered for each of
+    # these and says the first workflow written against it settles that, since a
+    # run either arrives on the label or does not. This job is that workflow.
+    # The build matrix above never asked, because it cross-compiles.
+    name: test (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
     permissions:
       contents: read
+    strategy:
+      # Every platform runs. Stopping at the first failure would leave the other
+      # two unexamined, and a checker whose whole job is reading a checkout is
+      # the last thing to learn about on one platform at a time.
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: windows/amd64
+            runner: windows-latest
+          - platform: darwin/arm64
+            runner: macos-latest
+    defaults:
+      run:
+        # One shell for all three entries, so the counting step below is one
+        # script rather than three that have to be kept saying the same thing.
+        # Every image these entries run on carries bash.
+        shell: bash
     steps:
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -111,7 +145,33 @@ jobs:
           cache: false
 
       - name: Run the default suite
-        run: go test ./...
+        # The same suite on every entry. No platform gets a reduced set and no
+        # package is excluded here, because the platform whose difficult tests
+        # are left out is the platform the defect is on.
+        #
+        # -count=1 rather than the cache, so a green entry is a suite that ran
+        # on this machine rather than one whose stored output was replayed.
+        #
+        # The count is what separates a suite that ran everything and passed
+        # from one that executed nothing and reported success, which look
+        # identical from outside. Top-level results are counted: a subtest's
+        # line is indented, so the anchored pattern does not read it twice.
+        #
+        # The platform reaches the script through the environment rather than
+        # through an expression inside it, which is the pattern the other
+        # workflows here already carry.
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          go test -count=1 -v ./... 2>&1 | tee suite.log
+          executed=$(grep -cE '^--- (PASS|FAIL): ' suite.log || true)
+          skipped=$(grep -cE '^--- SKIP: ' suite.log || true)
+          echo "${PLATFORM}: executed ${executed} test(s), skipped ${skipped}"
+          if [ "$executed" -eq 0 ]; then
+            echo "::error::The suite reported success having executed no tests on ${PLATFORM}."
+            exit 1
+          fi
 
   vet:
     name: vet


### PR DESCRIPTION
Closes #57.

Scope: .github/workflows

The build covered six platforms and the suite ran on one. Compiling is not the
property that matters most here. What the runner does is read a checkout, and whether
a filesystem folds case, what separates a path, and what a line ending arrives as are
exactly the parts that differ between machines. The earliest thing that would have
caught any of those was the smoke run against a published artefact, which happens after
the release.

The suite now runs on the three entries record 0012 names, in the same workflow that
builds the six. Each reports under a name written into the file, `test (linux/amd64)`,
`test (windows/amd64)` and `test (darwin/arm64)`, in the record's vocabulary rather
than under a runner label, because the record is what a reader is holding when they ask
whether every entry is covered.

The means is the workflow file this repository already carries, hardened the way the
audit job requires: permissions denied at the top and granted per job, actions pinned
to a commit with the version in a comment, checkout without persisted credentials. A
platform matrix is what the build half of this file already uses, so the suite half
needs no second mechanism and no new tool.

## The two properties the issue asks for

Every platform runs the same suite. `go test -count=1 -v ./...` on all three, no
reduced set and no package left out, because the platform whose difficult tests are
skipped is the platform the defect is on. `-count=1` rather than the cache, so a green
entry is a suite that ran on that machine rather than one whose stored output was
replayed.

Each run says what it examined. It counts the top-level results in its own output and
prints them, and fails when the executed count is zero, since a suite that reports
success having executed nothing looks identical to one that ran everything and passed.
Subtest lines are indented, so the anchored pattern does not read them twice.

The pattern was checked against a real run of the suite rather than reasoned about.
Locally, at `22fc7f0` with `go version go1.26.5 windows/amd64`:

```
$ go test -v ./... > suite.log
$ grep -cE '^--- (PASS|FAIL): ' suite.log
31
$ grep -cE '^--- SKIP: ' suite.log
0
```

## The label is not the platform

An entry names a platform and the image decides what the machine actually is. Record
0012 leaves open whether a hosted runner is offered for each of the three and says the
first workflow written against it settles that, since a run either arrives on the label
or does not. This is that workflow, so it asks rather than asserts. Before running
anything, each entry reads `go env GOOS` and `go env GOARCH`, prints the answer and
fails when it disagrees with the name the entry carries.

That replaces a sentence in a comment claiming which architecture a label carries. An
image that moves under its label now reddens the entry that claimed it, instead of
quietly running the suite on a platform record 0012 already covers.

## Where this bites first

The fixtures. `.gitattributes` holds `testdata/**` out of line-ending translation, and
`TestFixtureBytesSurviveTheCheckout` reads the fixtures that exist to carry a carriage
return, a byte-order mark, a null byte and an invalid encoding sequence. A checkout on
a system that translates by default is the case that rule exists for, and a green
`test (windows/amd64)` is the evidence that the settings in the tree do what they claim
rather than a claim that they do.

## What the three entries reported

From the job logs of the run on this pull request, `31319491595`:

```
linux/amd64: the toolchain here reports linux/amd64
linux/amd64: executed 31 test(s), skipped 0

windows/amd64: the toolchain here reports windows/amd64
windows/amd64: executed 31 test(s), skipped 0

darwin/arm64: the toolchain here reports darwin/arm64
darwin/arm64: executed 31 test(s), skipped 0
```

That is record 0012's open question answered by measurement: all three labels are
offered, and each reported the platform its entry names. The three counts agree, which
is what a suite with no platform-specific skips looks like.

## What this does not settle

The three build-only entries, `linux/arm64`, `darwin/amd64` and `windows/arm64`,
produce no evidence beyond that the source compiles. That is record 0012's choice and
this change does not move it.

Nothing here makes any of these entries required on the default branch. That is issue
#26, which assembles the required set from the names a completed run reported, and a
job that can be renamed without the gate noticing is issue #71. A green board here is
not the same as a gate.

The commit that carries the matrix was written before the tip of `main` moved and is
unchanged in this branch. The second commit is the platform assertion.

No second person has read this change. The evidence above and the check results on this
pull request stand in place of a review rather than alongside one.
