### PR TITLE
Make a stalled experiment visible with lab list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Every other board in this organisation carries a promise, which is right for them and makes them a bad place to try something that will probably fail. Without somewhere to fail, experiments either do not happen or they happen inside a board that then has to explain them. The rule that keeps this from becoming a graveyard is that every experiment states its question before it starts and its answer when it stops, and the answer may be no. An experiment with no written answer is not finished, it is abandoned, and the difference should be visible. Everything here is public from the first commit, which means a failed experiment is public too.
 
+To see what has been tried and how it ended, run this from a checkout:
+
+```
+go run ./cmd/lab list
+```
+
+It prints one line per experiment, oldest unanswered first, with how long each
+unanswered question has been waiting. The output is not reproduced here on
+purpose. A listing copied into a page is correct on the day it is copied and
+wrong on the next experiment, and it is wrong in the direction that matters,
+which is a record that exists in the tree and not in the page a visitor reads.
+
 Planning happens on the issue tracker first. Every decision that shapes
 the architecture is argued there with its reasons before the code
 that depends on it exists.

--- a/cmd/lab/main.go
+++ b/cmd/lab/main.go
@@ -1,12 +1,13 @@
 // Command lab reads a checkout of this repository and reports what it
-// examined. It has one verb that does work, it takes no flags, and it writes
-// nothing to the tree it reads.
+// examined. It has two verbs that do work, one that judges and one that only
+// reports, it takes no flags, and it writes nothing to the tree it reads.
 package main
 
 import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/Flowfin/lab/internal/check"
 )
@@ -42,24 +43,43 @@ const (
 const usage = `lab reads this repository and reports what it examined.
 
     lab check [path]   walk the tree at path, default ".", and report
+    lab list [path]    list the experiments at path, default ".", oldest
+                       unanswered first
     lab help           print this text
 
 lab writes nothing to the tree it reads.
 `
 
 func main() {
-	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr, check.Walk))
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr, edges{
+		walk: check.Walk,
+		list: check.List,
+		now:  time.Now(),
+	}))
+}
+
+// edges is everything this command reaches for that is not its arguments: the
+// walk, the listing, and the clock.
+//
+// The walk is a parameter for one reason: the mapping from a walk that refused
+// something to the exit code a refusal returns had to be proved before the
+// first refusal existed, and no real walk could produce one then. The
+// alternative was landing that mapping untested and finding out on the day a
+// gate should have gone red.
+//
+// The clock is here because the listing prints how long an experiment has been
+// asking, and a test that computed the expected number the same way the command
+// does would assert nothing. Where the time is read is issue #63's, and this is
+// only the seam a test can set.
+type edges struct {
+	walk func(string) (check.Result, error)
+	list func(string, time.Time) (check.Listing, error)
+	now  time.Time
 }
 
 // run is main with its edges passed in, so that what the command prints and
 // what it returns can both be read by a test without starting a process.
-//
-// The walk is a parameter for one reason: the mapping from a walk that refused
-// something to the exit code a refusal returns has to be proved before the
-// first refusal exists, and no real walk can produce one yet. The alternative
-// is landing that mapping untested and finding out on the day a gate should
-// have gone red.
-func run(args []string, out, errOut io.Writer, walk func(string) (check.Result, error)) int {
+func run(args []string, out, errOut io.Writer, e edges) int {
 	if len(args) == 0 {
 		fmt.Fprint(errOut, usage)
 		return exitCannot
@@ -75,17 +95,12 @@ func run(args []string, out, errOut io.Writer, walk func(string) (check.Result, 
 		return exitClean
 
 	case "check":
-		root := "."
-		switch len(args) {
-		case 1:
-		case 2:
-			root = args[1]
-		default:
-			fmt.Fprintf(errOut, "lab check takes at most one path\n")
+		root, ok := pathArgument(args, errOut)
+		if !ok {
 			return exitCannot
 		}
 
-		result, err := walk(root)
+		result, err := e.walk(root)
 		if err != nil {
 			fmt.Fprintf(errOut, "lab check: %v\n", err)
 			return exitCannot
@@ -96,9 +111,44 @@ func run(args []string, out, errOut io.Writer, walk func(string) (check.Result, 
 		}
 		return exitClean
 
+	case "list":
+		root, ok := pathArgument(args, errOut)
+		if !ok {
+			return exitCannot
+		}
+
+		listing, err := e.list(root, e.now)
+		if err != nil {
+			fmt.Fprintf(errOut, "lab list: %v\n", err)
+			return exitCannot
+		}
+		fmt.Fprint(out, listing.Report(e.now))
+		// Clean whatever it found. Nothing here fails because an experiment
+		// is old, and that is deliberate: some questions take months, and a
+		// check that timed them out would push somebody towards a hasty
+		// answer to keep a build green. What the listing does is make the
+		// choice between answering and abandoning a visible one.
+		return exitClean
+
 	default:
 		fmt.Fprintf(errOut, "lab: unknown verb %q\n\n", args[0])
 		fmt.Fprint(errOut, usage)
 		return exitCannot
+	}
+}
+
+// pathArgument reads the one optional path both walking verbs take. It is one
+// function rather than two copies so that the two verbs cannot drift into
+// taking different numbers of arguments, which is the kind of difference
+// nobody notices until a script written against one is pointed at the other.
+func pathArgument(args []string, errOut io.Writer) (string, bool) {
+	switch len(args) {
+	case 1:
+		return ".", true
+	case 2:
+		return args[1], true
+	default:
+		fmt.Fprintf(errOut, "lab %s takes at most one path\n", args[0])
+		return "", false
 	}
 }

--- a/cmd/lab/main_test.go
+++ b/cmd/lab/main_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Flowfin/lab/internal/check"
 )
@@ -13,6 +14,18 @@ import (
 // that wants the ordinary behaviour passes this, so a case exercising a
 // contrived walk is visible as one at the call site.
 var realWalk = check.Walk
+
+// fixedNow is the value every test here supplies for the clock. It is a date
+// rather than whatever the machine says, so the waiting column a test asserts
+// is the same number next week.
+var fixedNow = time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+
+// ordinary is the set of edges a test that is not contriving one of them
+// passes. The walk is named at the call site because several cases contrive
+// it; the listing and the clock are the real ones unless a case says otherwise.
+func ordinary(walk func(string) (check.Result, error)) edges {
+	return edges{walk: walk, list: check.List, now: fixedNow}
+}
 
 // TestExitCodes reaches every code this runner can return, and names the
 // record that decides what each one means. Decision record 0011 requires a
@@ -107,12 +120,39 @@ func TestExitCodes(t *testing.T) {
 			walk: realWalk,
 			want: exitCannot,
 		},
+		{
+			name: "a listing of a tree with experiments in it",
+			args: []string{"list", "../../testdata/listings/several-experiments/tree"},
+			walk: realWalk,
+			want: exitClean,
+		},
+		{
+			// The listing is a report and not a gate. This tree carries a
+			// record the checker refuses, and the listing still leaves with
+			// the clean code, because nothing here fails for what it found.
+			name: "a listing of a tree holding a record the checker refuses",
+			args: []string{"list", "../../testdata/cases/record-answered-with-no-answer/tree"},
+			walk: realWalk,
+			want: exitClean,
+		},
+		{
+			name: "a listing of a tree that is not there",
+			args: []string{"list", "no-such-directory"},
+			walk: realWalk,
+			want: exitCannot,
+		},
+		{
+			name: "more paths than list takes",
+			args: []string{"list", "one", "two"},
+			walk: realWalk,
+			want: exitCannot,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var out, errOut bytes.Buffer
-			got := run(tc.args, &out, &errOut, tc.walk)
+			got := run(tc.args, &out, &errOut, ordinary(tc.walk))
 			if got != tc.want {
 				t.Fatalf("exit code %d, want %d\nstdout: %s\nstderr: %s",
 					got, tc.want, out.String(), errOut.String())
@@ -139,7 +179,7 @@ func TestRefusalsAreNamedInTheOutput(t *testing.T) {
 	}
 
 	var out, errOut bytes.Buffer
-	if got := run([]string{"check", "."}, &out, &errOut, refusing); got != exitRefused {
+	if got := run([]string{"check", "."}, &out, &errOut, ordinary(refusing)); got != exitRefused {
 		t.Fatalf("exit code %d, want %d", got, exitRefused)
 	}
 	if !strings.Contains(out.String(), "somewhere/experiments/one/EXPERIMENT.md") {

--- a/internal/check/list.go
+++ b/internal/check/list.go
@@ -1,0 +1,224 @@
+package check
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// DateFormat is how record 0008 writes a date in a header field.
+const DateFormat = "2006-01-02"
+
+// What the state column says when there is no state to print. Each of these is
+// a thing a refusal already names, and the listing repeats none of that
+// judgement: it is a report, and a report that silently dropped a directory it
+// could not read would hide exactly the experiment somebody is looking for.
+const (
+	stateNoRecord   = "no record"
+	stateUnreadable = "unreadable"
+	stateNotWritten = "not written"
+)
+
+// An Entry is one experiment as the listing reads it. Nothing here is refused
+// and nothing is judged. Where a field cannot be read, the column says so.
+type Entry struct {
+	// Slug is the directory name, which is what the tree calls the
+	// experiment whatever its header says.
+	Slug string
+
+	// State is the record's State field as it was written, or one of the
+	// three strings above where there is none to print.
+	State string
+
+	// QuestionWritten is the Question-Written field as it was written, so a
+	// value that is not a date is shown rather than swallowed.
+	QuestionWritten string
+
+	// Written is that field parsed as a date. It is the zero time where the
+	// field is absent or is not a date, and Dated says which.
+	Written time.Time
+
+	// Dated says whether Written was read from a date.
+	Dated bool
+}
+
+// Waiting is how long an experiment has been asking, in whole days, and
+// whether the question has a date to count from. It counts calendar days in
+// UTC, so a run at one hour of the day and a run at another give the same
+// answer for the same record.
+func (e Entry) Waiting(now time.Time) (int, bool) {
+	if !e.Dated || e.State != StateAsking {
+		return 0, false
+	}
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	return int(today.Sub(e.Written).Hours() / 24), true
+}
+
+// A Listing is what one listing walk found.
+type Listing struct {
+	// Root is the directory the walk started from, as it was given.
+	Root string
+
+	// ExperimentsPresent says whether Root held an experiments directory at
+	// all, for the same reason Result carries it: a tree with none and a tree
+	// whose directory is empty are different statements.
+	ExperimentsPresent bool
+
+	// Entries are the experiments, in the order the listing prints them.
+	Entries []Entry
+}
+
+// List reads every experiment and returns them in the order the listing prints
+// them. It refuses nothing and it is not a gate.
+//
+// The ordering is the whole point of the verb. Everything still asking comes
+// first, oldest question at the top, because a record sitting in asking with a
+// real question breaks no rule and is the graveyard arriving by the front door.
+// Everything else follows in the same order, so a reader scrolling past the
+// unanswered work reaches the finished work oldest first rather than at random.
+// A record whose question carries no readable date sorts to the end of its
+// group by slug, because there is nothing to order it by and the alternative is
+// an order that changes between filesystems.
+//
+// WHERE THIS DOES NOT REACH TODAY. A question dated later than now sorts to the
+// bottom of the asking group and its waiting column counts down rather than up,
+// which is the stalled experiment this verb exists to surface, concealed by the
+// ordering meant to reveal it. Nothing here refuses such a date; issue #63 is
+// where that refusal and the one place the time is read are argued. The column
+// prints the negative count rather than hiding it, so the case is visible in
+// the meantime.
+func List(root string, now time.Time) (Listing, error) {
+	listing := Listing{Root: root}
+
+	info, err := os.Stat(root)
+	if err != nil {
+		return listing, fmt.Errorf("cannot read %s: %w", root, err)
+	}
+	if !info.IsDir() {
+		return listing, fmt.Errorf("%s is not a directory", root)
+	}
+
+	dir := filepath.Join(root, ExperimentsDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return listing, nil
+		}
+		return listing, fmt.Errorf("cannot read %s: %w", dir, err)
+	}
+	listing.ExperimentsPresent = true
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		listing.Entries = append(listing.Entries, readEntry(filepath.Join(dir, entry.Name()), entry.Name()))
+	}
+
+	sort.SliceStable(listing.Entries, func(i, j int) bool {
+		return earlier(listing.Entries[i], listing.Entries[j])
+	})
+	return listing, nil
+}
+
+// readEntry reads one experiment directory into an entry. Every failure to read
+// something becomes a value in a column rather than an error, because a listing
+// that stops at the first unreadable record tells a reader nothing about the
+// rest of the tree.
+func readEntry(dir, slug string) Entry {
+	entry := Entry{Slug: slug, State: stateNoRecord, QuestionWritten: stateNoRecord}
+
+	data, err := os.ReadFile(filepath.Join(dir, RecordName))
+	if err != nil {
+		return entry
+	}
+	record, err := ParseRecord(data)
+	if err != nil {
+		entry.State = stateUnreadable
+		entry.QuestionWritten = stateUnreadable
+		return entry
+	}
+
+	entry.State = stateNotWritten
+	if state, present := record.Field(FieldState); present {
+		entry.State = state
+	}
+
+	entry.QuestionWritten = stateNotWritten
+	if written, present := record.Field(FieldQuestionWritten); present {
+		entry.QuestionWritten = written
+		if date, err := time.Parse(DateFormat, written); err == nil {
+			entry.Written = date
+			entry.Dated = true
+		}
+	}
+	return entry
+}
+
+// earlier decides which of two entries the listing prints first.
+func earlier(a, b Entry) bool {
+	if asking(a) != asking(b) {
+		return asking(a)
+	}
+	if a.Dated != b.Dated {
+		return a.Dated
+	}
+	if a.Dated && !a.Written.Equal(b.Written) {
+		return a.Written.Before(b.Written)
+	}
+	return a.Slug < b.Slug
+}
+
+func asking(e Entry) bool { return e.State == StateAsking }
+
+// Report writes the listing. It says where it looked and how many experiments
+// it found before printing any of them, so a run that found none is a sentence
+// rather than an empty screen a reader has to interpret.
+//
+// The columns are the four the verb exists for: the slug, the state, the date
+// the question was written, and how long anything still asking has been there.
+// Nothing else, because a listing wide enough to wrap stops being scannable and
+// scanning it is the whole point.
+func (l Listing) Report(now time.Time) string {
+	out := fmt.Sprintf("examined %s\n", l.Root)
+	if !l.ExperimentsPresent {
+		out += fmt.Sprintf("no %s directory in this tree\n", ExperimentsDir)
+	}
+	out += fmt.Sprintf("%d %s\n", len(l.Entries), plural(len(l.Entries), "experiment", "experiments"))
+	if len(l.Entries) == 0 {
+		return out
+	}
+
+	rows := [][4]string{{"slug", "state", "question written", "waiting"}}
+	for _, entry := range l.Entries {
+		waiting := "-"
+		if days, counted := entry.Waiting(now); counted {
+			waiting = fmt.Sprintf("%d %s", days, plural(days, "day", "days"))
+		}
+		rows = append(rows, [4]string{entry.Slug, entry.State, entry.QuestionWritten, waiting})
+	}
+
+	var width [4]int
+	for _, row := range rows {
+		for i, cell := range row {
+			if len(cell) > width[i] {
+				width[i] = len(cell)
+			}
+		}
+	}
+	for _, row := range rows {
+		line := make([]string, 0, len(row))
+		for i, cell := range row {
+			if i == len(row)-1 {
+				line = append(line, cell)
+				continue
+			}
+			line = append(line, cell+strings.Repeat(" ", width[i]-len(cell)))
+		}
+		out += "  " + strings.Join(line, "  ") + "\n"
+	}
+	return out
+}

--- a/internal/check/list_test.go
+++ b/internal/check/list_test.go
@@ -1,0 +1,164 @@
+package check
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// listingsDir holds the trees the listing is read against. They are separate
+// from the cases under testdata/cases because a case declares which refusals a
+// tree produces and a listing declares nothing of the kind: it is a report, and
+// the thing worth asserting about it is what it printed and in what order.
+const listingsDir = "../../testdata/listings"
+
+// listingNow is the day every assertion here is made from. The clock is a
+// parameter for exactly this reason: a test that computed the expected number
+// the same way the listing does would assert nothing, and one that hard-coded a
+// number against the real clock would be red tomorrow.
+var listingNow = time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+
+// TestTheListingSortsTheOldestUnansweredFirst is the ordering the verb exists
+// for. A record sitting in asking with a real question breaks no rule, so
+// nothing refuses it and the only thing that surfaces it is where it appears in
+// this list.
+func TestTheListingSortsTheOldestUnansweredFirst(t *testing.T) {
+	listing := read(t, "several-experiments")
+
+	want := []string{
+		// Asking, oldest question first. These two are the whole point.
+		"oldest-question",
+		"newer-question",
+		// Then everything else, oldest first.
+		"given-up",
+		"already-answered",
+		// Then whatever carries no date to sort by, ordered by slug so the
+		// answer does not depend on the filesystem.
+		"no-header",
+		"no-record-at-all",
+	}
+
+	if len(listing.Entries) != len(want) {
+		t.Fatalf("listed %d experiments, want %d", len(listing.Entries), len(want))
+	}
+	for i, slug := range want {
+		if listing.Entries[i].Slug != slug {
+			t.Errorf("position %d is %s, want %s", i, listing.Entries[i].Slug, slug)
+		}
+	}
+}
+
+// TestTheWaitingColumnIsCountedFromTheClockItWasGiven asserts the column that
+// carries the whole point of the listing against a fixed value, which is only
+// possible because the time arrives as a parameter.
+func TestTheWaitingColumnIsCountedFromTheClockItWasGiven(t *testing.T) {
+	tests := []struct {
+		slug    string
+		days    int
+		counted bool
+	}{
+		{slug: "oldest-question", days: 100, counted: true},
+		{slug: "newer-question", days: 25, counted: true},
+		// Nothing is waiting once it has stopped, whichever way it stopped.
+		{slug: "already-answered", counted: false},
+		{slug: "given-up", counted: false},
+		// Nothing to count from, and the column says so rather than guessing.
+		{slug: "no-header", counted: false},
+		{slug: "no-record-at-all", counted: false},
+	}
+
+	entries := make(map[string]Entry)
+	for _, entry := range read(t, "several-experiments").Entries {
+		entries[entry.Slug] = entry
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.slug, func(t *testing.T) {
+			entry, listed := entries[tc.slug]
+			if !listed {
+				t.Fatalf("%s is not in the listing", tc.slug)
+			}
+			days, counted := entry.Waiting(listingNow)
+			if counted != tc.counted {
+				t.Fatalf("waiting is counted %v, want %v", counted, tc.counted)
+			}
+			if counted && days != tc.days {
+				t.Fatalf("waiting is %d days, want %d", days, tc.days)
+			}
+		})
+	}
+}
+
+// TestTheListingReadsWhatItCanAndSaysWhatItCannot holds the half that decides
+// whether this verb is useful on a tree that is not in order. A listing that
+// stopped at the first unreadable record, or dropped the directory from the
+// output, would hide exactly the experiment somebody is looking for.
+func TestTheListingReadsWhatItCanAndSaysWhatItCannot(t *testing.T) {
+	states := map[string]string{
+		"oldest-question":  StateAsking,
+		"already-answered": StateAnswered,
+		"given-up":         StateAbandoned,
+		"no-header":        stateUnreadable,
+		"no-record-at-all": stateNoRecord,
+	}
+
+	for _, entry := range read(t, "several-experiments").Entries {
+		want, named := states[entry.Slug]
+		if !named {
+			continue
+		}
+		if entry.State != want {
+			t.Errorf("%s is listed as %q, want %q", entry.Slug, entry.State, want)
+		}
+	}
+}
+
+// TestTheReportPrintsTheFourColumns compares the whole report against the
+// output stored beside the tree. Comparing the whole thing is what makes it
+// mean something: an assertion that a slug appears somewhere would pass on a
+// listing whose columns had silently swapped.
+func TestTheReportPrintsTheFourColumns(t *testing.T) {
+	name := "several-experiments"
+	got := read(t, name).Report(listingNow)
+
+	data, err := os.ReadFile(filepath.Join(listingsDir, name, "expected-report"))
+	if err != nil {
+		t.Fatalf("cannot read the expected report: %v", err)
+	}
+	if got != string(data) {
+		t.Fatalf("the report is\n%s\nand the case expects\n%s", got, data)
+	}
+}
+
+// TestAListingOfATreeWithNoExperimentsSaysSo keeps the two statements apart. A
+// tree with no experiments directory and one whose directory is empty both list
+// nothing, and only one of them says the tree has no such directory.
+func TestAListingOfATreeWithNoExperimentsSaysSo(t *testing.T) {
+	listing, err := List(filepath.Join(casesDir, "no-experiments-directory", "tree"), listingNow)
+	if err != nil {
+		t.Fatalf("the listing failed: %v", err)
+	}
+	if listing.ExperimentsPresent {
+		t.Error("the listing says the tree holds an experiments directory")
+	}
+	if len(listing.Entries) != 0 {
+		t.Errorf("the listing holds %d entries, want none", len(listing.Entries))
+	}
+}
+
+// read reads one listing tree, failing rather than skipping when it is not
+// there, because a test that quietly ran against nothing is a green test that
+// proves nothing.
+func read(t *testing.T, name string) Listing {
+	t.Helper()
+
+	// Forward slashes rather than filepath.Join, because the report prints the
+	// root exactly as it was given and the expected report is one file read on
+	// every platform the suite runs on.
+	listing, err := List(listingsDir+"/"+name+"/tree", listingNow)
+	if err != nil {
+		t.Fatalf("listing %s failed: %v", name, err)
+	}
+	return listing
+}

--- a/testdata/listings/several-experiments/expected-report
+++ b/testdata/listings/several-experiments/expected-report
@@ -1,0 +1,9 @@
+examined ../../testdata/listings/several-experiments/tree
+6 experiments
+  slug              state       question written  waiting
+  oldest-question   asking      2026-05-01        100 days
+  newer-question    asking      2026-07-15        25 days
+  given-up          abandoned   2026-03-01        -
+  already-answered  answered    2026-04-01        -
+  no-header         unreadable  unreadable        -
+  no-record-at-all  no record   no record         -

--- a/testdata/listings/several-experiments/tree/experiments/already-answered/EXPERIMENT.md
+++ b/testdata/listings/several-experiments/tree/experiments/already-answered/EXPERIMENT.md
@@ -1,0 +1,18 @@
+Slug: already-answered
+State: answered
+Question-Written: 2026-04-01
+Answer-Written: 2026-06-01
+
+# already-answered
+
+## Question
+
+Does it?
+
+## Method
+
+Run it and look.
+
+## Answer
+
+No, and that is the answer.

--- a/testdata/listings/several-experiments/tree/experiments/given-up/EXPERIMENT.md
+++ b/testdata/listings/several-experiments/tree/experiments/given-up/EXPERIMENT.md
@@ -1,0 +1,17 @@
+Slug: given-up
+State: abandoned
+Question-Written: 2026-03-01
+
+# given-up
+
+## Question
+
+Does it?
+
+## Method
+
+Run it and look.
+
+## Answer
+
+The machine it needed went away.

--- a/testdata/listings/several-experiments/tree/experiments/newer-question/EXPERIMENT.md
+++ b/testdata/listings/several-experiments/tree/experiments/newer-question/EXPERIMENT.md
@@ -1,0 +1,17 @@
+Slug: newer-question
+State: asking
+Question-Written: 2026-07-15
+
+# newer-question
+
+## Question
+
+Does it?
+
+## Method
+
+Run it and look.
+
+## Answer
+
+

--- a/testdata/listings/several-experiments/tree/experiments/no-header/EXPERIMENT.md
+++ b/testdata/listings/several-experiments/tree/experiments/no-header/EXPERIMENT.md
@@ -1,0 +1,3 @@
+# No header
+
+Prose where a header should be.

--- a/testdata/listings/several-experiments/tree/experiments/no-record-at-all/notes.md
+++ b/testdata/listings/several-experiments/tree/experiments/no-record-at-all/notes.md
@@ -1,0 +1,1 @@
+Code dropped in with no record beside it.

--- a/testdata/listings/several-experiments/tree/experiments/oldest-question/EXPERIMENT.md
+++ b/testdata/listings/several-experiments/tree/experiments/oldest-question/EXPERIMENT.md
@@ -1,0 +1,17 @@
+Slug: oldest-question
+State: asking
+Question-Written: 2026-05-01
+
+# oldest-question
+
+## Question
+
+Does it?
+
+## Method
+
+Run it and look.
+
+## Answer
+
+


### PR DESCRIPTION
Closes #19.

Scope: cmd/lab, internal/check, testdata/listings, README.md

Refusals catch a record that contradicts itself. They cannot catch an experiment that
is honest and stalled, because a record sitting in `asking` with a real question breaks
no rule. That is the graveyard arriving by the front door, and the answer to it is
visibility rather than refusal.

The means is a verb of the runner rather than a script or a workflow. It reads a
checkout, which is the one thing this runner already does, it needs no network and no
dependency, and it is proved by the suite that already exists rather than by a parallel
apparatus.

## What it prints

```
$ go run ./cmd/lab list testdata/listings/several-experiments/tree
examined testdata/listings/several-experiments/tree
6 experiments
  slug              state       question written  waiting
  oldest-question   asking      2026-05-01        100 days
  newer-question    asking      2026-07-15        25 days
  given-up          abandoned   2026-03-01        -
  already-answered  answered    2026-04-01        -
  no-header         unreadable  unreadable        -
  no-record-at-all  no record   no record         -
```

Everything still asking comes first, oldest question at the top. Everything else
follows in the same order, so a reader scrolling past the unanswered work reaches the
finished work oldest first rather than at random. Anything carrying no date to sort by
goes to the end of its group by slug, because the alternative is an order that changes
between filesystems.

Where a record cannot be read, the column says so and the directory still appears. A
listing that dropped what it could not parse would hide exactly the experiment somebody
is looking for.

## It is a report and not a gate

It exits clean whatever it finds. Nothing fails because an experiment is old, and that
is deliberate: some questions take months, and a check that timed them out would push
somebody towards a hasty answer to keep a build green, which is the opposite of what
the record is for. A tree carrying a record the checker refuses is listed and not
judged, and that case is in the exit-code table.

## The clock is a parameter

The waiting column carries the whole point of the listing and it reads a clock. A test
that worked the expected number out the same way the listing does would assert nothing,
and one that hard-coded a number against the real clock would be red tomorrow. The time
arrives as an argument, a fixed value is supplied in the suite, and the column becomes
an ordinary assertion. Where the time is read is issue #63's; this is only the seam.

## The proof that it bites

Three guards, each checked by breaking it and running the suite, with the tree restored
after each run.

The ordering, with the comparator neutered:

```
    list_test.go:47: position 0 is already-answered, want oldest-question
    list_test.go:47: position 1 is given-up, want newer-question
    list_test.go:47: position 2 is newer-question, want given-up
```

The waiting column, moved by one day:

```
    --- FAIL: TestTheWaitingColumnIsCountedFromTheClockItWasGiven/oldest-question
        list_test.go:87: waiting is 101 days, want 100
    --- FAIL: TestTheWaitingColumnIsCountedFromTheClockItWasGiven/newer-question
        list_test.go:87: waiting is 26 days, want 25
```

The exit code, made to follow what the listing found:

```
    --- FAIL: TestExitCodes/a_listing_of_a_tree_with_experiments_in_it
        main_test.go:157: exit code 1, want 0
    --- FAIL: TestExitCodes/a_listing_of_a_tree_holding_a_record_the_checker_refuses
        main_test.go:157: exit code 1, want 0
```

The whole report is compared against the output stored beside the tree, so two columns
swapping is a failure rather than something an assertion about one slug would pass.

## The README

It names the command and does not paste the output. A listing copied into a page is
correct on the day it is copied and wrong on the next experiment, and it is wrong in
the direction that matters, which is a record that exists in the tree and not in the
page a visitor reads.

## What this does not reach

A question dated later than now sorts to the bottom of the asking group and its waiting
column counts down rather than up, which is the stalled experiment this verb exists to
surface, concealed by the ordering meant to reveal it. Nothing here refuses such a date.
The limit is written at `List` in `internal/check/list.go` and issue #63 holds the
refusal and the one place the time is read.

The listing trees live under `testdata/listings/` rather than under `testdata/cases/`,
because a case declares which refusals a tree produces and a listing declares nothing of
the kind. Nothing in the case harness reads them, so a listing tree that nobody asserts
against would go unnoticed there; the four tests here name the one tree that exists.

## The gate

Run at `5347d37`, with `go version go1.26.5 windows/amd64`:

```
$ go build ./... && go vet ./... && gofmt -l . && go test ./...
ok  	github.com/Flowfin/lab/cmd/lab	0.970s
ok  	github.com/Flowfin/lab/internal/check	1.091s
ok  	github.com/Flowfin/lab/internal/hardware	0.966s

$ go run ./cmd/lab list .
examined .
no experiments directory in this tree
0 experiments

$ go run ./cmd/lab check .
examined .
no experiments directory in this tree
0 experiment directories walked, 0 records read
14 decision records read
0 refused
```

`gofmt -l .` printed nothing, which is its passing result.

No second person has read this change. The evidence above stands in place of a review
rather than alongside one.
