### PR TITLE
Fix where the runner reads the time, and refuse a question dated ahead of it

### DIFF
--- a/cmd/lab/main.go
+++ b/cmd/lab/main.go
@@ -50,6 +50,18 @@ const usage = `lab reads this repository and reports what it examined.
 lab writes nothing to the tree it reads.
 `
 
+// THIS IS WHERE THE RUNNER READS THE TIME, and it is read once. Everything
+// downstream is given the value rather than asking again, so a run has one
+// notion of now instead of one per caller, and two parts of a single run cannot
+// disagree about which day it is.
+//
+// WHAT READING IT HERE DOES NOT BUY. Nothing makes the host clock right. A
+// machine set two years fast refuses honest records and a machine set two years
+// slow accepts a question dated next year as an ordinary one, and no reading of
+// a checkout separates either case from a correct one. What it buys is that the
+// value is one value, and that every run prints it, so a reader can see which
+// now a verdict was made against instead of assuming it was the day they are
+// reading on.
 func main() {
 	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr, edges{
 		walk: check.Walk,
@@ -61,7 +73,7 @@ func main() {
 // edges is everything this command reaches for that is not its arguments: the
 // walk, the listing, and the clock.
 //
-// The walk is a parameter for one reason: the mapping from a walk that refused
+// The walk is a parameter for two reasons. The mapping from a walk that refused
 // something to the exit code a refusal returns had to be proved before the
 // first refusal existed, and no real walk could produce one then. The
 // alternative was landing that mapping untested and finding out on the day a
@@ -72,7 +84,7 @@ func main() {
 // does would assert nothing. Where the time is read is issue #63's, and this is
 // only the seam a test can set.
 type edges struct {
-	walk func(string) (check.Result, error)
+	walk func(string, time.Time) (check.Result, error)
 	list func(string, time.Time) (check.Listing, error)
 	now  time.Time
 }
@@ -100,7 +112,7 @@ func run(args []string, out, errOut io.Writer, e edges) int {
 			return exitCannot
 		}
 
-		result, err := e.walk(root)
+		result, err := e.walk(root, e.now)
 		if err != nil {
 			fmt.Fprintf(errOut, "lab check: %v\n", err)
 			return exitCannot

--- a/cmd/lab/main_test.go
+++ b/cmd/lab/main_test.go
@@ -23,7 +23,7 @@ var fixedNow = time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
 // ordinary is the set of edges a test that is not contriving one of them
 // passes. The walk is named at the call site because several cases contrive
 // it; the listing and the clock are the real ones unless a case says otherwise.
-func ordinary(walk func(string) (check.Result, error)) edges {
+func ordinary(walk func(string, time.Time) (check.Result, error)) edges {
 	return edges{walk: walk, list: check.List, now: fixedNow}
 }
 
@@ -32,7 +32,7 @@ func ordinary(walk func(string) (check.Result, error)) edges {
 // test per code, so that a code existing only in the document is caught here
 // rather than by an operator.
 func TestExitCodes(t *testing.T) {
-	refusing := func(string) (check.Result, error) {
+	refusing := func(string, time.Time) (check.Result, error) {
 		return check.Result{
 			Root:               "somewhere",
 			ExperimentsPresent: true,
@@ -45,14 +45,14 @@ func TestExitCodes(t *testing.T) {
 			}},
 		}, nil
 	}
-	failing := func(string) (check.Result, error) {
+	failing := func(string, time.Time) (check.Result, error) {
 		return check.Result{}, errors.New("cannot read the tree")
 	}
 
 	tests := []struct {
 		name string
 		args []string
-		walk func(string) (check.Result, error)
+		walk func(string, time.Time) (check.Result, error)
 		want int
 	}{
 		{
@@ -166,7 +166,7 @@ func TestExitCodes(t *testing.T) {
 // was refused; a caller that wants to know what was refused reads the output,
 // and that only works if the output names it.
 func TestRefusalsAreNamedInTheOutput(t *testing.T) {
-	refusing := func(string) (check.Result, error) {
+	refusing := func(string, time.Time) (check.Result, error) {
 		return check.Result{
 			Root:               "somewhere",
 			ExperimentsPresent: true,

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 	"unicode/utf8"
 )
 
@@ -127,6 +128,14 @@ const (
 	// to the only mechanism that would have asked for its question.
 	RecordOutsideThePlaceRecordsLive = "record-outside-the-place-records-live"
 
+	// QuestionDatedLaterThanTheRun refuses a record whose question is dated
+	// after the time the run read. Sorted oldest first, such a record sits at
+	// the bottom of the listing and stays there, which is exactly the stalled
+	// experiment the listing exists to surface, concealed by the mechanism
+	// meant to reveal it. Every other rule stays green and the listing keeps
+	// printing, which is why this is the near miss worth a fixture.
+	QuestionDatedLaterThanTheRun = "question-dated-later-than-the-run"
+
 	// RootHoldsADirectoryTheLayoutDoesNotName refuses a directory at the root
 	// of the tree that record 0002 does not name. That record fixes the
 	// layout and says a directory it does not name is refused rather than
@@ -207,6 +216,11 @@ type Result struct {
 	// Root is the directory the walk started from, as it was given.
 	Root string
 
+	// Now is the time this run was given, and the only notion of now anything
+	// below has. It is reported so that a reader can see which value a run
+	// used rather than inferring it from when they think the run happened.
+	Now time.Time
+
 	// ExperimentsPresent says whether Root held an experiments directory at
 	// all. A tree with none is not an error and it is not the same as a tree
 	// whose experiments directory is empty, so the two are not collapsed
@@ -251,8 +265,8 @@ func (r Result) Properties() []string {
 // Walk examines the tree rooted at root and returns what it found. The error
 // it returns means the walk could not be made at all, which is a different
 // outcome from a walk that completed and refused something.
-func Walk(root string) (Result, error) {
-	res := Result{Root: root}
+func Walk(root string, now time.Time) (Result, error) {
+	res := Result{Root: root, Now: now}
 
 	info, err := os.Stat(root)
 	if err != nil {
@@ -358,6 +372,7 @@ func walkExperiments(root string, res *Result) error {
 		res.Refusals = append(res.Refusals, refuseBytes(record, data)...)
 		res.Refusals = append(res.Refusals, refusePaths(root, record, data)...)
 		res.Refusals = append(res.Refusals, refuseState(record, data)...)
+		res.Refusals = append(res.Refusals, refuseDates(record, data, res.Now)...)
 	}
 
 	return nil
@@ -634,6 +649,7 @@ func (r Result) Report() string {
 		out += fmt.Sprintf("no %s directory in this tree\n", DecisionsDir)
 	}
 	out += fmt.Sprintf("%d decision %s read\n", r.Decisions, plural(r.Decisions, "record", "records"))
+	out += fmt.Sprintf("the time this run read is %s\n", r.Now.UTC().Format(time.RFC3339))
 	out += fmt.Sprintf("%d refused\n", len(r.Refusals))
 	for _, refusal := range r.Refusals {
 		out += fmt.Sprintf("  %s\n", refusal)

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -27,7 +27,7 @@ func TestCases(t *testing.T) {
 				t.Fatalf("case %s has no tree: %v", name, err)
 			}
 
-			got, err := Walk(root)
+			got, err := Walk(root, fixedNow)
 			if err != nil {
 				t.Fatalf("walk failed: %v", err)
 			}
@@ -195,7 +195,7 @@ func TestFixtureBytesSurviveTheCheckout(t *testing.T) {
 // the source, and the reader is usually somebody who has just arrived.
 func TestARefusalNamesItsSubject(t *testing.T) {
 	for name := range loadCases(t) {
-		result, err := Walk(filepath.Join(casesDir, name, "tree"))
+		result, err := Walk(filepath.Join(casesDir, name, "tree"), fixedNow)
 		if err != nil {
 			t.Fatalf("walk of %s failed: %v", name, err)
 		}
@@ -231,7 +231,7 @@ func TestWalkWritesNothing(t *testing.T) {
 	before := fingerprint(t, casesDir)
 
 	for name := range loadCases(t) {
-		if _, err := Walk(filepath.Join(casesDir, name, "tree")); err != nil {
+		if _, err := Walk(filepath.Join(casesDir, name, "tree"), fixedNow); err != nil {
 			t.Fatalf("walk of %s failed: %v", name, err)
 		}
 	}

--- a/internal/check/harness_test.go
+++ b/internal/check/harness_test.go
@@ -51,7 +51,12 @@ import (
 // reads the time in exactly one place and everything downstream is given the
 // value, so the suite supplies a date rather than whatever the machine says and
 // an assertion about a date stays true next week.
-var fixedNow = time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+//
+// It is deliberately not today. A fixed value that happened to be the day the
+// suite ran would pass identically whether the code used the value it was given
+// or reached for the clock a second time, and the whole point of the parameter
+// is that those two are different. Any second read moves every number below.
+var fixedNow = time.Date(2026, 9, 15, 12, 0, 0, 0, time.UTC)
 
 // casesDir is where the cases live. Decision record 0002 puts the runner's
 // own fixtures at the root of the tree rather than beside the package, so the

--- a/internal/check/harness_test.go
+++ b/internal/check/harness_test.go
@@ -44,7 +44,14 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
+
+// fixedNow is the one notion of now every test here runs against. The runner
+// reads the time in exactly one place and everything downstream is given the
+// value, so the suite supplies a date rather than whatever the machine says and
+// an assertion about a date stays true next week.
+var fixedNow = time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
 
 // casesDir is where the cases live. Decision record 0002 puts the runner's
 // own fixtures at the root of the tree rather than beside the package, so the

--- a/internal/check/list.go
+++ b/internal/check/list.go
@@ -57,6 +57,50 @@ func (e Entry) Waiting(now time.Time) (int, bool) {
 	return int(today.Sub(e.Written).Hours() / 24), true
 }
 
+// refuseDates holds a record to the one notion of now the run was given. It
+// reads the question's date and nothing else about time.
+//
+// WHAT THIS DOES NOT BUY, and it belongs here rather than only in the issue
+// that argued it. Nothing makes the host clock right. A machine set two years
+// fast refuses honest records and a machine set two years slow accepts a future
+// date as an ordinary one, and no reading of a checkout separates either case
+// from a correct one. What the rule buys is that the runner has one notion of
+// now instead of several, that a reader can see which value a run used because
+// every run prints it, and that the listing's ordering is a property of the
+// records rather than of when somebody happened to look.
+//
+// A record whose bytes do not parse is not judged here, for the same reason the
+// state rules do not judge one: nothing can read a date out of something that
+// has no header.
+func refuseDates(path string, data []byte, now time.Time) []Refusal {
+	record, err := ParseRecord(data)
+	if err != nil {
+		return nil
+	}
+
+	written, present := record.Field(FieldQuestionWritten)
+	if !present {
+		return nil
+	}
+	date, err := time.Parse(DateFormat, written)
+	if err != nil {
+		// A value that is not a date is a different repair and a different
+		// rule. Refusing it here would name the wrong one.
+		return nil
+	}
+
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	if !date.After(today) {
+		return nil
+	}
+	return []Refusal{{
+		Property: QuestionDatedLaterThanTheRun,
+		Subject:  path,
+		Detail: fmt.Sprintf("its %s is %s and this run read %s, so the listing sorts it below every honest question and leaves it there",
+			FieldQuestionWritten, written, today.Format(DateFormat)),
+	}}
+}
+
 // A Listing is what one listing walk found.
 type Listing struct {
 	// Root is the directory the walk started from, as it was given.
@@ -83,13 +127,13 @@ type Listing struct {
 // group by slug, because there is nothing to order it by and the alternative is
 // an order that changes between filesystems.
 //
-// WHERE THIS DOES NOT REACH TODAY. A question dated later than now sorts to the
-// bottom of the asking group and its waiting column counts down rather than up,
-// which is the stalled experiment this verb exists to surface, concealed by the
-// ordering meant to reveal it. Nothing here refuses such a date; issue #63 is
-// where that refusal and the one place the time is read are argued. The column
-// prints the negative count rather than hiding it, so the case is visible in
-// the meantime.
+// A question dated later than the time the run read would sort to the bottom of
+// the asking group and its waiting column would count down rather than up,
+// which is the stalled experiment this verb exists to surface concealed by the
+// ordering meant to reveal it. The listing does not repair that and does not
+// hide it: it prints the negative count, and refuseDates is what refuses the
+// record, so the case reaches a reader through the checker rather than through
+// a position in this list.
 func List(root string, now time.Time) (Listing, error) {
 	listing := Listing{Root: root}
 
@@ -188,6 +232,7 @@ func (l Listing) Report(now time.Time) string {
 		out += fmt.Sprintf("no %s directory in this tree\n", ExperimentsDir)
 	}
 	out += fmt.Sprintf("%d %s\n", len(l.Entries), plural(len(l.Entries), "experiment", "experiments"))
+	out += fmt.Sprintf("the time this run read is %s\n", now.UTC().Format(time.RFC3339))
 	if len(l.Entries) == 0 {
 		return out
 	}

--- a/internal/check/list_test.go
+++ b/internal/check/list_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 // listingsDir holds the trees the listing is read against. They are separate
@@ -13,11 +12,13 @@ import (
 // the thing worth asserting about it is what it printed and in what order.
 const listingsDir = "../../testdata/listings"
 
-// listingNow is the day every assertion here is made from. The clock is a
-// parameter for exactly this reason: a test that computed the expected number
-// the same way the listing does would assert nothing, and one that hard-coded a
-// number against the real clock would be red tomorrow.
-var listingNow = time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+// listingNow is the day every assertion here is made from. It is the same value
+// the rest of the suite walks with, because the runner has one notion of now and
+// a suite with two would prove nothing about that. The clock is a parameter for
+// exactly this reason: a test that computed the expected number the same way the
+// listing does would assert nothing, and one that hard-coded a number against
+// the real clock would be red tomorrow.
+var listingNow = fixedNow
 
 // TestTheListingSortsTheOldestUnansweredFirst is the ordering the verb exists
 // for. A record sitting in asking with a real question breaks no rule, so

--- a/internal/check/list_test.go
+++ b/internal/check/list_test.go
@@ -59,8 +59,8 @@ func TestTheWaitingColumnIsCountedFromTheClockItWasGiven(t *testing.T) {
 		days    int
 		counted bool
 	}{
-		{slug: "oldest-question", days: 100, counted: true},
-		{slug: "newer-question", days: 25, counted: true},
+		{slug: "oldest-question", days: 137, counted: true},
+		{slug: "newer-question", days: 62, counted: true},
 		// Nothing is waiting once it has stopped, whichever way it stopped.
 		{slug: "already-answered", counted: false},
 		{slug: "given-up", counted: false},

--- a/testdata/cases/record-with-a-question-dated-later-than-the-run/expected
+++ b/testdata/cases/record-with-a-question-dated-later-than-the-run/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/record-with-a-question-dated-later-than-the-run/expected-refusals
+++ b/testdata/cases/record-with-a-question-dated-later-than-the-run/expected-refusals
@@ -1,0 +1,1 @@
+question-dated-later-than-the-run

--- a/testdata/cases/record-with-a-question-dated-later-than-the-run/near-neighbour
+++ b/testdata/cases/record-with-a-question-dated-later-than-the-run/near-neighbour
@@ -1,0 +1,1 @@
+record-with-a-question-dated-on-the-day-of-the-run

--- a/testdata/cases/record-with-a-question-dated-later-than-the-run/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-with-a-question-dated-later-than-the-run/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,13 @@
+Slug: one
+State: asking
+Question-Written: 2027-01-01
+
+## Question
+
+Does the walk read a question dated after the time the run read?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer

--- a/testdata/cases/record-with-a-question-dated-on-the-day-of-the-run/expected
+++ b/testdata/cases/record-with-a-question-dated-on-the-day-of-the-run/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/record-with-a-question-dated-on-the-day-of-the-run/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-with-a-question-dated-on-the-day-of-the-run/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,13 @@
+Slug: one
+State: asking
+Question-Written: 2026-08-09
+
+## Question
+
+Does the walk read a question dated on the day the run read?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer

--- a/testdata/cases/record-with-a-question-dated-on-the-day-of-the-run/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-with-a-question-dated-on-the-day-of-the-run/tree/experiments/one/EXPERIMENT.md
@@ -1,6 +1,6 @@
 Slug: one
 State: asking
-Question-Written: 2026-08-09
+Question-Written: 2026-09-15
 
 ## Question
 

--- a/testdata/listings/several-experiments/expected-report
+++ b/testdata/listings/several-experiments/expected-report
@@ -1,5 +1,6 @@
 examined ../../testdata/listings/several-experiments/tree
 6 experiments
+the time this run read is 2026-08-09T12:00:00Z
   slug              state       question written  waiting
   oldest-question   asking      2026-05-01        100 days
   newer-question    asking      2026-07-15        25 days

--- a/testdata/listings/several-experiments/expected-report
+++ b/testdata/listings/several-experiments/expected-report
@@ -1,9 +1,9 @@
 examined ../../testdata/listings/several-experiments/tree
 6 experiments
-the time this run read is 2026-08-09T12:00:00Z
+the time this run read is 2026-09-15T12:00:00Z
   slug              state       question written  waiting
-  oldest-question   asking      2026-05-01        100 days
-  newer-question    asking      2026-07-15        25 days
+  oldest-question   asking      2026-05-01        137 days
+  newer-question    asking      2026-07-15        62 days
   given-up          abandoned   2026-03-01        -
   already-answered  answered    2026-04-01        -
   no-header         unreadable  unreadable        -


### PR DESCRIPTION
Closes #63.

Scope: cmd/lab, internal/check, testdata/cases, testdata/listings

The clock is the one input to this runner that does not come from the checkout, and
nothing said where it was read or what happened when a record disagreed with it.

It is read in exactly one place now, at the top of the command, and everything
downstream is given the value rather than asking again. The walk carries it, the
listing carries it, and both print it.

The means is a parameter on the two functions that need a now, rather than a package
variable or an interface. It is the smallest seam that a test can set, it adds no
dependency, and it makes the value visible at every call site instead of hidden behind
a name.

## Every run says which now it used

```
$ go run ./cmd/lab check .
examined .
no experiments directory in this tree
0 experiment directories walked, 0 records read
14 decision records read
the time this run read is 2026-08-09T15:16:41Z
0 refused

$ go run ./cmd/lab list .
examined .
no experiments directory in this tree
0 experiments
the time this run read is 2026-08-09T15:16:47Z
```

## The refusal

```
$ go run ./cmd/lab check testdata/cases/record-with-a-question-dated-later-than-the-run/tree
1 experiment directory walked, 1 record read
the time this run read is 2026-08-09T15:16:53Z
1 refused
  ...\experiments\one\EXPERIMENT.md: its Question-Written is 2027-01-01 and this run read 2026-08-09, so the listing sorts it below every honest question and leaves it there (question-dated-later-than-the-run)
```

Sorted oldest first, such a record sits at the bottom of the listing and stays there,
which is exactly the stalled experiment the listing exists to surface, concealed by the
mechanism meant to reveal it, while every other rule stays green and the listing keeps
printing.

The near miss is one day. `record-with-a-question-dated-on-the-day-of-the-run` carries
the date the suite's clock reads and is refused nothing; only a date after it is
refused. The two fixtures differ by that day.

## The proof

The refusal, with the site removed:

```
    --- FAIL: TestCases/record-with-a-question-dated-later-than-the-run
        check_test.go:51: expected refusal not produced: question-dated-later-than-the-run
```

The one-clock property was harder to prove than it looks, and the first attempt did not
prove it. The fixed value the suite supplied was the day the suite was written, so code
that used the value it was given and code that reached for the clock a second time gave
the same numbers, and the deletion passed:

```
$ # with a second time.Now() inside the waiting column, fixed clock set to the day it ran
ok  	github.com/Flowfin/lab/internal/check	0.946s
```

The fixed value is now a date the suite is not run on, and the same deletion reddens it:

```
    --- FAIL: TestTheWaitingColumnIsCountedFromTheClockItWasGiven/oldest-question
        list_test.go:88: waiting is 100 days, want 137
    --- FAIL: TestTheWaitingColumnIsCountedFromTheClockItWasGiven/newer-question
        list_test.go:88: waiting is 25 days, want 62
```

So does reading the clock again for the line the report prints, which the stored report
catches:

```
        the time this run read is 2026-08-09T15:21:45Z
        the time this run read is 2026-09-15T12:00:00Z
```

## What this does not buy

Written at `main` in `cmd/lab/main.go`, where the time is read, rather than only here.
Nothing makes the host clock right. A machine set two years fast refuses honest records
and a machine set two years slow accepts next year's date as an ordinary one, and no
reading of a checkout separates either case from a correct one. What the rule buys is
that the runner has one notion of now instead of several, that a reader can see which
value a run used, and that the listing's ordering is a property of the records rather
than of when somebody happened to look.

A `Question-Written` value that is not a date is not refused here. That is a different
repair and a different rule, and refusing it under this property would name the wrong
one. A record whose bytes do not parse reaches this rule not at all, for the same reason
the state rules do not reach one.

The suite proves the value is used where the suite reads it. A clock read in some third
place that nothing asserts against would not be caught by any of the above, and what
stands behind that is the review.

## The gate

Run at `b825c36`, with `go version go1.26.5 windows/amd64`:

```
$ go build ./... && go vet ./... && gofmt -l . && go test ./...
ok  	github.com/Flowfin/lab/cmd/lab	1.571s
ok  	github.com/Flowfin/lab/internal/check	0.963s
ok  	github.com/Flowfin/lab/internal/hardware	0.822s
```

`gofmt -l .` printed nothing, which is its passing result.

No second person has read this change. The evidence above stands in place of a review
rather than alongside one.
