### PR TITLE
Run the record checks on every pull request under their own name

### DIFF
--- a/.github/workflows/records.yml
+++ b/.github/workflows/records.yml
@@ -1,0 +1,76 @@
+# This repository's own records, checked on the way in.
+#
+# Run on demand the record checks are a linter somebody remembers, and the
+# records that most need checking are written by whoever was least likely to
+# remember. This runs them on every pull request.
+#
+# It is separate from the build and test workflow on purpose. The two answer
+# different questions: that one says the tool compiles and its tests pass, this
+# one says this repository's own records are in order, and a reader looking at a
+# red tick should know which of those broke without opening it.
+#
+# WHAT THIS GATE DOES NOT JUDGE. It never asks whether an experiment worked. An
+# experiment that answered no passes exactly like one that answered yes, because
+# a no is a finished piece of work here. What it judges is whether the record is
+# honest and complete. Anyone who ever feels this check pushing them towards a
+# more flattering answer should read that as a defect in the check.
+#
+# The check name below is what a required set refers to later, and a job renamed
+# in passing removes itself from that set while the tab still looks green. The
+# name is written here rather than left to the job id for that reason, and
+# changing it is a change to the gate rather than tidying.
+#
+# Hardened the way every other workflow in this tree is, because the audit job in
+# zizmor.yml refuses a new one that departs from it: permissions denied at the
+# top and granted per job, every action pinned to a commit with its version in a
+# comment, and checkout without persisted credentials.
+name: Records
+
+on:
+  pull_request:
+    branches: ["**"]
+  push:
+    branches: [main]
+
+# Explicit deny-all at workflow level; the job below grants only what it needs.
+permissions: {}
+
+# Cancel a superseded run on the same ref. Nothing here publishes, so a run that
+# has been overtaken is safe to drop.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  records:
+    name: records
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          # The toolchain comes from go.mod, so the version this job uses moves
+          # when the module says so and never separately.
+          go-version-file: go.mod
+          # This module has no dependencies and therefore no go.sum for a cache
+          # key to be built from. Asking for a cache anyway makes the step
+          # depend on a file that is not there.
+          cache: false
+
+      - name: Check this repository's records
+        # Built from this commit rather than downloaded, so a change that breaks
+        # a refusal is caught by the pull request that made it instead of by the
+        # next release. The exit codes are the contract in
+        # docs/decisions/0011-the-exit-codes.md: 0 refused nothing, 1 refused
+        # something, 2 could not do the job. This step keys on all three by
+        # letting the runner's own code become the job's, which is what makes
+        # this job a reader of that record.
+        run: go run ./cmd/lab check .


### PR DESCRIPTION
Closes #21.

Scope: .github/workflows

The record refusals only mean something if they run on the way in. Run on demand they
are a linter somebody remembers, and the records that most need checking are written by
whoever was least likely to remember.

`Records` is a workflow of its own, reporting under the name `records`, written into the
file rather than left to the job id. It is separate from the build and test workflow on
purpose: the two answer different questions, and a reader looking at a red tick should
know which of them broke without opening it.

It builds the runner from the same commit rather than downloading a release, so a change
that breaks a refusal is caught by the pull request that made it instead of by the next
release.

The means is a workflow file, which is the only place this can live: the check has to run
on the server on every pull request, and nothing in the runner can make that happen.
Hardened the way the audit job requires, which is why that job passing is part of the
evidence below rather than an aside.

## Red on a branch carrying an experiment that states no question

Not described, run. #99 carries `experiments/measuring-the-gate/`, a directory with notes
and no record, and the `records` job on it failed while every other check stayed green:

```
records	fail	13s	https://github.com/Flowfin/lab/actions/runs/31321349207/job/93264719307
```

From that job's log:

```
1 refused
  experiments/measuring-the-gate: there is no EXPERIMENT.md in it, so it states no question (experiment-has-no-record)
exit status 1
##[error]Process completed with exit code 1.
```

That pull request is closed. Its branch stays, because its head was never merged.

One thing worth being exact about. The refusal that fired is `experiment-has-no-record`,
for a directory carrying no record at all. A record that is present and whose
`## Question` section is empty is refused by nothing in this tree today, which is issue
#16 and is open. So the demonstration covers the case the tree refuses now rather than
every case the phrase in this issue covers.

## Green on this tree

```
$ go run ./cmd/lab check .
examined .
no experiments directory in this tree
0 experiment directories walked, 0 records read
14 decision records read
the time this run read is 2026-08-09T15:30:24Z
0 refused
```

Green on the default branch is the last part of the Done-when, and it is a run rather
than a prediction. On the merge commit `b611431`:

```
$ gh run list --branch main --workflow Records --limit 1
completed success b611431 https://github.com/Flowfin/lab/actions/runs/31321520230
```

## What this gate never judges

Whether an experiment worked. An experiment that answered no passes exactly like one
that answered yes, because a no is a finished piece of work here. That sentence is at
the workflow rather than only in this body, so somebody reading the file finds it.

Nothing here makes the job required on the default branch. That is issue #26, and a job
that can be renamed without the gate noticing is issue #71. A red tick that blocks
nothing is what this is until then.

No second person has read this change. The evidence above and the check results on this
pull request stand in place of a review rather than alongside one.

