### PR TITLE
Refuse a promotion section that points at nothing

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -377,6 +377,7 @@ func walkExperiments(root string, res *Result) error {
 		res.Refusals = append(res.Refusals, refusePaths(root, record, data)...)
 		res.Refusals = append(res.Refusals, refuseState(record, data)...)
 		res.Refusals = append(res.Refusals, refuseDates(record, data, res.Now)...)
+		res.Refusals = append(res.Refusals, refusePromotion(record, data)...)
 		if parsed, err := ParseRecord(data); err == nil {
 			seen.slug, seen.declaresSlug = parsed.Field(FieldSlug)
 		}

--- a/internal/check/promotion.go
+++ b/internal/check/promotion.go
@@ -1,0 +1,129 @@
+package check
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// The properties a promotion section can be refused for.
+const (
+	// PromotionSectionIsMissingSomething refuses a promotion section that does
+	// not name all four of the things record 0005 fixes. A promotion that is
+	// described but not linked rots: six months later the record says the work
+	// continued on another board and nobody can find where, which is the same
+	// as the work not having continued.
+	PromotionSectionIsMissingSomething = "promotion-section-is-missing-something"
+
+	// PromotionNamesABranchRatherThanARange refuses a commit range written as
+	// something that moves. The whole purpose of the record is to say what was
+	// handed over rather than what is there now, and a branch name answers the
+	// second question on whatever day it is read.
+	PromotionNamesABranchRatherThanARange = "promotion-names-a-branch-rather-than-a-range"
+
+	// PromotionOnARecordThatIsNotAnswered refuses a promotion section on a
+	// record in any other state. Record 0005 says the state does not change on
+	// promotion, because an experiment that was offered elsewhere is still
+	// answered, and that sentence only holds if the reverse is refused. A
+	// record still asking that already names where its result went is either a
+	// promotion of something with no written answer or a state nobody updated,
+	// and both are the half-finished shape this board exists to make visible.
+	PromotionOnARecordThatIsNotAnswered = "promotion-on-a-record-that-is-not-answered"
+)
+
+// The four things record 0005 says a promotion section names, and nothing about
+// it is optional. They are read as a name, a colon and a value, which is the
+// shape the record header already uses, so a reader writing one is not learning
+// a second syntax for the same job.
+const (
+	PromotionRepository = "Repository"
+	PromotionIssue      = "Issue"
+	PromotionCommits    = "Commits"
+	PromotionLicence    = "Licence"
+)
+
+// promotionFields are those four in the order record 0005 names them, so a
+// refusal lists what is missing in the order somebody would fill it in.
+var promotionFields = []string{
+	PromotionRepository,
+	PromotionIssue,
+	PromotionCommits,
+	PromotionLicence,
+}
+
+// commitRange is what the commits line has to look like: two revisions with two
+// dots between them, each written as a hexadecimal object name long enough to
+// be worth quoting. A name that is not one of those is something that moves,
+// which is what this rule exists to refuse.
+var commitRange = regexp.MustCompile(`^[0-9a-f]{7,40}\.\.\.?[0-9a-f]{7,40}$`)
+
+// promotionLine reads one line of the section as a name, a colon and a value.
+var promotionLine = regexp.MustCompile(`^([A-Za-z][A-Za-z0-9-]*):\s*(.*)$`)
+
+// refusePromotion holds a record that carries a promotion section to what
+// record 0005 says such a section is.
+//
+// WHAT THIS CANNOT DO, and it is here rather than only in the issue that argued
+// it. Nothing verifies that the destination repository exists, that the issue
+// was ever opened, that anybody agreed to anything, or that the commit range is
+// the one the receiving board took. The runner reads a checkout and makes no
+// network call, which is a decision taken elsewhere and not one to trade away
+// for this check. So the refusal is about shape, and the truth of the link is
+// what a reader sees when they follow it. A green run is not confirmation that
+// the hand-over happened.
+func refusePromotion(path string, data []byte) []Refusal {
+	record, err := ParseRecord(data)
+	if err != nil {
+		return nil
+	}
+
+	body, present := record.Section(SectionPromotion)
+	if !present {
+		// Absent from every record that has not been handed over, which record
+		// 0005 fixes and which is the ordinary case rather than an omission.
+		return nil
+	}
+
+	state, _ := record.Field(FieldState)
+	if state != StateAnswered {
+		return []Refusal{{
+			Property: PromotionOnARecordThatIsNotAnswered,
+			Subject:  path,
+			Detail: fmt.Sprintf("it carries a %s section and its %s is %q, and record 0005 hands over an experiment that is %s",
+				SectionPromotion, FieldState, state, StateAnswered),
+		}}
+	}
+
+	named := make(map[string]string)
+	for _, line := range strings.Split(body, "\n") {
+		if match := promotionLine.FindStringSubmatch(strings.TrimSpace(line)); match != nil {
+			named[match[1]] = strings.TrimSpace(match[2])
+		}
+	}
+
+	var missing []string
+	for _, field := range promotionFields {
+		if named[field] == "" {
+			missing = append(missing, field)
+		}
+	}
+	if len(missing) > 0 {
+		return []Refusal{{
+			Property: PromotionSectionIsMissingSomething,
+			Subject:  path,
+			Detail: fmt.Sprintf("its %s section names no %s, and record 0005 says it names %s and that nothing about it is optional",
+				SectionPromotion, strings.Join(missing, " and no "), strings.Join(promotionFields, ", ")),
+		}}
+	}
+
+	if !commitRange.MatchString(named[PromotionCommits]) {
+		return []Refusal{{
+			Property: PromotionNamesABranchRatherThanARange,
+			Subject:  path,
+			Detail: fmt.Sprintf("its %s is %q, which is not two object names with dots between them, so it points at something that moves rather than at what was handed over",
+				PromotionCommits, named[PromotionCommits]),
+		}}
+	}
+
+	return nil
+}

--- a/testdata/cases/a-promotion-naming-a-branch/expected
+++ b/testdata/cases/a-promotion-naming-a-branch/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/a-promotion-naming-a-branch/expected-refusals
+++ b/testdata/cases/a-promotion-naming-a-branch/expected-refusals
@@ -1,0 +1,1 @@
+promotion-names-a-branch-rather-than-a-range

--- a/testdata/cases/a-promotion-naming-a-branch/near-neighbour
+++ b/testdata/cases/a-promotion-naming-a-branch/near-neighbour
@@ -1,0 +1,1 @@
+a-promotion-that-names-all-four

--- a/testdata/cases/a-promotion-naming-a-branch/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/a-promotion-naming-a-branch/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,24 @@
+Slug: one
+State: answered
+Question-Written: 2026-01-01
+Answer-Written: 2026-06-01
+
+## Question
+
+Does it work?
+
+## Method
+
+It was run.
+
+## Answer
+
+It works, and here is the number.
+
+## Promotion
+
+Repository: Flowfin/jellyfin-plugin-sso
+Issue: Flowfin/jellyfin-plugin-sso#404
+Commits: main
+Licence: GPL-3.0-only
+

--- a/testdata/cases/a-promotion-on-a-record-still-asking/expected
+++ b/testdata/cases/a-promotion-on-a-record-still-asking/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/a-promotion-on-a-record-still-asking/expected-refusals
+++ b/testdata/cases/a-promotion-on-a-record-still-asking/expected-refusals
@@ -1,0 +1,1 @@
+promotion-on-a-record-that-is-not-answered

--- a/testdata/cases/a-promotion-on-a-record-still-asking/near-neighbour
+++ b/testdata/cases/a-promotion-on-a-record-still-asking/near-neighbour
@@ -1,0 +1,1 @@
+a-promotion-that-names-all-four

--- a/testdata/cases/a-promotion-on-a-record-still-asking/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/a-promotion-on-a-record-still-asking/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,23 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+
+## Question
+
+Does it work?
+
+## Method
+
+It was run.
+
+## Answer
+
+
+
+## Promotion
+
+Repository: Flowfin/jellyfin-plugin-sso
+Issue: Flowfin/jellyfin-plugin-sso#404
+Commits: 3f2a1b0..9c8d7e6
+Licence: GPL-3.0-only
+

--- a/testdata/cases/a-promotion-that-names-all-four/expected
+++ b/testdata/cases/a-promotion-that-names-all-four/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/a-promotion-that-names-all-four/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/a-promotion-that-names-all-four/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,24 @@
+Slug: one
+State: answered
+Question-Written: 2026-01-01
+Answer-Written: 2026-06-01
+
+## Question
+
+Does it work?
+
+## Method
+
+It was run.
+
+## Answer
+
+It works, and here is the number.
+
+## Promotion
+
+Repository: Flowfin/jellyfin-plugin-sso
+Issue: Flowfin/jellyfin-plugin-sso#404
+Commits: 3f2a1b0..9c8d7e6
+Licence: GPL-3.0-only
+

--- a/testdata/cases/a-promotion-that-names-no-licence/expected
+++ b/testdata/cases/a-promotion-that-names-no-licence/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/a-promotion-that-names-no-licence/expected-refusals
+++ b/testdata/cases/a-promotion-that-names-no-licence/expected-refusals
@@ -1,0 +1,1 @@
+promotion-section-is-missing-something

--- a/testdata/cases/a-promotion-that-names-no-licence/near-neighbour
+++ b/testdata/cases/a-promotion-that-names-no-licence/near-neighbour
@@ -1,0 +1,1 @@
+a-promotion-that-names-all-four

--- a/testdata/cases/a-promotion-that-names-no-licence/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/a-promotion-that-names-no-licence/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,23 @@
+Slug: one
+State: answered
+Question-Written: 2026-01-01
+Answer-Written: 2026-06-01
+
+## Question
+
+Does it work?
+
+## Method
+
+It was run.
+
+## Answer
+
+It works, and here is the number.
+
+## Promotion
+
+Repository: Flowfin/jellyfin-plugin-sso
+Issue: Flowfin/jellyfin-plugin-sso#404
+Commits: 3f2a1b0..9c8d7e6
+


### PR DESCRIPTION
Closes #39.

Scope: internal/check, testdata/cases

A promotion that is described but not linked rots. Six months later the record says the
work continued on another board and nobody can find where, which is the same as the work
not having continued.

The means is the same package, walk and harness as every other record refusal. Nothing
here needs a network call, and the one thing that would need one is the thing this check
deliberately does not do.

## The three refusals

```
$ go run ./cmd/lab check testdata/cases/a-promotion-that-names-no-licence/tree
  ...\EXPERIMENT.md: its Promotion section names no Licence, and record 0005 says it names Repository, Issue, Commits, Licence and that nothing about it is optional (promotion-section-is-missing-something)

$ go run ./cmd/lab check testdata/cases/a-promotion-naming-a-branch/tree
  ...\EXPERIMENT.md: its Commits is "main", which is not two object names with dots between them, so it points at something that moves rather than at what was handed over (promotion-names-a-branch-rather-than-a-range)

$ go run ./cmd/lab check testdata/cases/a-promotion-on-a-record-still-asking/tree
  ...\EXPERIMENT.md: it carries a Promotion section and its State is "asking", and record 0005 hands over an experiment that is answered (promotion-on-a-record-that-is-not-answered)
```

The third is the one that needs its reverse stated. Record 0005 says the state does not
change on promotion, because an experiment offered elsewhere is still answered, and that
sentence only holds if a promotion on any other state is refused. A record still asking
that already names where its result went is either a promotion of something with no
written answer or a state nobody updated, and both are the half-finished shape this board
exists to make visible.

## How the four are read

Record 0005 fixes what the section names and not how a line in it is written. The four
are read as a name, a colon and a value, which is the shape the record header already
uses, so somebody writing one is not learning a second syntax for the same job. That is
the ordinary judgement of how a check reads a rule somebody else decided rather than a
new decision, and it is written at `promotion.go` where the names live.

## The proof that each one bites

Each refusal has a fixture declaring exactly that property and no other. All three name
the same near neighbour, `a-promotion-that-names-all-four`, which is the fully formed
hand-over and refuses nothing. Each site was then removed and the suite run, with the tree
restored after each run.

```
    --- FAIL: TestCases/a-promotion-that-names-no-licence
        check_test.go:51: expected refusal not produced: promotion-section-is-missing-something

    --- FAIL: TestCases/a-promotion-naming-a-branch
        check_test.go:51: expected refusal not produced: promotion-names-a-branch-rather-than-a-range

    --- FAIL: TestCases/a-promotion-on-a-record-still-asking
        check_test.go:51: expected refusal not produced: promotion-on-a-record-that-is-not-answered
```

## What this cannot do

Written at `refusePromotion` rather than only here. Nothing verifies that the destination
repository exists, that the issue was ever opened, that anybody agreed to anything, or
that the commit range is the one the receiving board took. The runner reads a checkout and
makes no network call, which is a decision taken elsewhere and not one to trade away for
this check. So the refusal is about shape, and the truth of the link is what a reader sees
when they follow it. A green run is not confirmation that the hand-over happened.

A record whose bytes do not parse reaches this rule not at all, for the same reason the
state rules do not reach one.

Who may place a contributor's work under another board's terms is entry three of #46 and
is open. This check reads the licence line the section carries and takes no position on
what may be written there.

## The gate

Run at `473f709`, with `go version go1.26.5 windows/amd64`:

```
$ go build ./... && go vet ./... && gofmt -l . && go test ./...
ok  	github.com/Flowfin/lab/cmd/lab	4.749s
ok  	github.com/Flowfin/lab/internal/check	5.633s
ok  	github.com/Flowfin/lab/internal/hardware	5.311s

$ go run ./cmd/lab check .
15 decision records read
the time this run read is 2026-08-09T16:00:14Z
0 refused
```

`gofmt -l .` printed nothing, which is its passing result.

No second person has read this change. The evidence above stands in place of a review
rather than alongside one.
