### PR TITLE
Add static analysis for the runner and triage what it finds

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,79 @@
+# Static analysis of the runner's own source.
+#
+# Until this landed the only thing standing between a defect in the runner and
+# the default branch was a reader. The gate this board is measured against runs
+# static analysis on every pull request and surfaces what it finds in the
+# code-scanning tab, and this is that half.
+#
+# Go only. That is what the runner is written in, and record 0001 is where that
+# was decided. The workflow files are the other executable thing in this tree and
+# they are analysed by zizmor.yml rather than here, so the two tools do not both
+# claim the same subject and leave a reader guessing which verdict is which.
+#
+# The schedule is not decoration. A query published after the last pull request
+# reaches this repository on the next scheduled run rather than waiting for
+# somebody to open one, and on a board where weeks can pass between changes that
+# is the difference between a finding arriving and a finding not arriving.
+#
+# The job name is what a required set refers to later, and a job renamed in
+# passing removes itself from that set while the tab still looks green.
+#
+# Hardened the way every other workflow in this tree is, because the audit job in
+# zizmor.yml refuses a new one that departs from it: permissions denied at the
+# top and granted per job, every action pinned to a commit with its version in a
+# comment, and checkout without persisted credentials. The one write scope here
+# is security-events, which is what uploading the results needs and nothing more.
+name: CodeQL
+
+on:
+  pull_request:
+    branches: ["**"]
+  push:
+    branches: [main]
+  schedule:
+    # Weekly, at a minute nobody else picked, so a newly published query reaches
+    # this repository without waiting for a pull request.
+    - cron: "41 5 * * 2"
+
+# Explicit deny-all at workflow level; the job below grants only what it needs.
+permissions: {}
+
+# Cancel a superseded run on the same ref. This is an analysis job, not a
+# publish, so dropping a run that has been overtaken is safe.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyse:
+    name: CodeQL (go)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      security-events: write # upload the results into the code-scanning tab
+      contents: read # checkout the source to analyse
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          # The toolchain comes from go.mod, so the analysis builds with the
+          # same compiler the suite does rather than with whatever the image
+          # happens to carry.
+          go-version-file: go.mod
+          cache: false
+
+      - name: Initialise CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          languages: go
+          build-mode: autobuild
+
+      - name: Analyse
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          category: "/language:go"


### PR DESCRIPTION
Closes #23.

Scope: .github/workflows

This board had no static analysis of the runner at all, which means the only thing
standing between a defect in it and the default branch was a reader.

CodeQL for Go, on pull requests against every branch, on pushes to the default branch,
and weekly. The job reports as `CodeQL (go)`, written into the workflow, because that
name is what a required set refers to later.

The means is the analysis the target gate already uses, run from a workflow file, which
is the only place it can run. Nothing is added to the runner and no dependency enters
`go.mod`.

Go only, and that is a choice rather than an omission. The workflow files are the other
executable thing in this tree and `zizmor.yml` already analyses them, so the two tools do
not both claim one subject and leave a reader guessing which verdict is which.

The weekly run is not decoration. A query published after the last pull request reaches
this repository on the next scheduled run rather than waiting for somebody to open one,
and on a board where weeks can pass between changes that is the difference between a
finding arriving and a finding not arriving.

## Hardening

Permissions denied at the workflow level, `security-events: write` and `contents: read`
granted on the one job that needs them, both actions pinned to a commit with the version
in a comment, checkout without persisted credentials. The audit job passing on this pull
request is the evidence rather than this paragraph.

The pin was resolved rather than copied:

```
$ gh api repos/github/codeql-action/git/ref/tags/v4 --jq '.object.sha, .object.type'
24c7eb380a2dc368f2d129e4c65e51d172983a1e
tag
$ gh api repos/github/codeql-action/git/tags/24c7eb380a2dc368f2d129e4c65e51d172983a1e --jq '.object.sha'
5595ccaf912efad79be6eef63a5619ff05969be3
```

The `v4` ref is an annotated tag, so its object name is the tag rather than the commit,
and pinning to the first of those two would not be pinning to a commit at all.

## What was there before

```
$ gh api repos/Flowfin/lab/code-scanning/default-setup --jq '.state'
not-configured
```

So this workflow is the only CodeQL configuration on the repository, and there is no
default setup for it to collide with.

## Triage

Read after the run on the default branch, because that is the run whose results the tab
holds. On the merge commit `5bd29ef`:

```
$ gh api "repos/Flowfin/lab/code-scanning/analyses?tool_name=CodeQL&ref=refs/heads/main"     --jq '.[0] | "\(.tool.name) \(.created_at) results=\(.results_count) rules=\(.rules_count)"'
CodeQL 2026-08-09T16:19:07Z results=0 rules=34

$ gh api "repos/Flowfin/lab/code-scanning/alerts?tool_name=CodeQL&state=open" --jq 'length'
0
```

Thirty-four rules ran and produced nothing, so the CodeQL alert list is empty and there is
nothing to triage. That is a result about a runner of a few hundred lines with no
dependencies rather than a strong statement about the queries.

The tab also holds eight open alerts, all from the supply-chain self-audit:

```
$ gh api "repos/Flowfin/lab/code-scanning/alerts?state=open&per_page=100"     --jq 'group_by(.tool.name) | .[] | "\(.[0].tool.name): \(length)"'
Scorecard: 8
```

Those are a different tool with its own triage, and each of the eight has its written
reason under its own heading in `docs/supply-chain.md`: Branch-Protection,
CII-Best-Practices, Code-Review, Dependency-Update-Tool, Fuzzing, License, Maintained and
Security-Policy. They are not what this issue is about and this change does not move them.

No second person has read this change. The check results on this pull request stand in
place of a review rather than alongside one.
