### PR TITLE
Land the parity table, the promotion checklist and the contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/anything-else.md
+++ b/.github/ISSUE_TEMPLATE/anything-else.md
@@ -1,0 +1,24 @@
+---
+name: Anything else
+about: A defect, a change to the tooling, or a decision that needs arguing
+title: ""
+---
+
+<!--
+Three lines is a complete issue here. A form long enough to be irritating gets
+skipped by whoever is in a hurry, and then the fields are empty on exactly the
+issues that needed them filled in.
+-->
+
+## What is wrong
+
+## What the evidence is
+
+<!-- If the evidence is a number, write the command that produced it. -->
+
+## What done looks like
+
+<!--
+What has to be true for this to close. An issue with no done-condition closes
+whenever somebody feels finished.
+-->

--- a/.github/ISSUE_TEMPLATE/propose-an-experiment.md
+++ b/.github/ISSUE_TEMPLATE/propose-an-experiment.md
@@ -1,0 +1,51 @@
+---
+name: Propose an experiment
+about: A question you want to try to answer here, before any code exists
+title: ""
+---
+
+## The question
+
+<!--
+One question, written as a question, with a question mark at the end. Not a
+topic and not a plan. A directory holding three questions has no state that is
+true of all of them, and a record whose question is a topic can never be shown
+to have missed its answer.
+-->
+
+## What would count as an answer
+
+<!--
+What you would have to see to say yes, and what you would have to see to say no.
+Both, because an experiment that only knows what yes looks like will find one.
+
+No is a finished answer here and it is not a lesser outcome. So is finding out
+that the question was the wrong question.
+-->
+
+## What you already know
+
+<!--
+Anything that makes the question worth asking: a measurement somebody else
+published, a behaviour you hit, a claim you doubt. If the answer is already
+known, this is where that shows up, and the issue is cheaper to close than the
+experiment is to run.
+-->
+
+## What it would need
+
+<!--
+Anything beyond a checkout and the runner. Real data, a particular machine, a
+device. Say it here rather than finding out at the point where the work stops.
+CONTRIBUTING.md at the root of this repository sets out what may never be
+committed and what happens to an experiment that needs hardware.
+-->
+
+<!--
+This issue is not the experiment's record. The record lives in
+experiments/<slug>/EXPERIMENT.md, it is written in the commit that creates the
+directory, and it is the thing the runner reads. This issue is where the
+question is argued before that commit exists. Two places holding one question is
+how one of them quietly goes stale, so once the record exists it is the
+authority and this issue is history.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+Closes #
+
+<!--
+The issue reference goes on the first line, before anything else. That line is
+the field a check reads, and a pull request that opens with prose and mentions
+its issue three paragraphs down is a pull request whose reference nothing can
+find. Use "Closes #123" where this change finishes the issue, "Refs #123" where
+it does not.
+
+Everything below is prose. Delete a heading only if you have nothing to write
+under it, and say why the heading is gone rather than leaving a blank one.
+-->
+
+## What this changes
+
+<!-- What the change does, in the words somebody reviewing it needs. -->
+
+## What failure it prevents
+
+<!--
+The failure this exists to stop, rather than the feature it adds. A change that
+prevents nothing is a change nobody can weigh, and the answer is sometimes that
+it prevents a reader being misled rather than a machine going wrong.
+-->
+
+## What was run
+
+<!--
+The commands, with their output, run at the commit being pushed. A claim about
+a change is worth what the command behind it is worth. If a command was not run,
+say so here rather than leaving it out, because a missing line reads as a clean
+result to everybody except whoever left it out.
+
+CONTRIBUTING.md at the root of this repository says which commands to run and
+what a passing result looks like. They are not copied here, because a list in a
+form drifts against the thing that decides it.
+-->
+
+```
+```
+
+## What this does not do
+
+<!--
+The bound, where the change has one. A guard that covers less than its name
+suggests is worth saying so here, so a reader does not take the tick for more
+than it is.
+-->

--- a/docs/promotion.md
+++ b/docs/promotion.md
@@ -1,0 +1,78 @@
+# The promotion checklist
+
+A product board takes work by its own rules, and it is entitled to. What this
+board can do is make sure that what it hands over is takeable, so the
+conversation on the other side is about the result rather than about
+archaeology.
+
+This is the list somebody works through before the hand-over. What the record
+then says is fixed by
+[docs/decisions/0005-how-a-result-leaves.md](docs/decisions/0005-how-a-result-leaves.md),
+which this document does not restate. Work through the list, then write the
+section that record describes.
+
+The list is short on purpose. A checklist nobody finishes reading is a
+checklist whose last item is never met.
+
+## What an experiment carries into a hand-over
+
+The question and the answer, as they are in the record. That is what the
+receiving board is being asked to believe, and it is the one thing on this list
+that already exists before the hand-over is considered, because a record with
+no written answer is not finished.
+
+The measurement and the command that produced it, at the commit being handed
+over rather than in somebody's working tree. A number produced on a machine
+nobody else has is a claim, and it is worth writing as one instead of as a
+measurement. The commit is named because the tree moves afterwards and the
+result did not.
+
+What the experiment did not test. This is usually the more useful half and it
+is always the half that gets left out. A reader on the other side is deciding
+whether the result holds for their case, and the fastest way to answer that is
+the list of cases it was never put to.
+
+The licence the code carries out. This board declares no licence today, so
+there is nothing to inherit and the terms have to be settled before anything
+leaves. Entry one of issue #46 is where that is answered, and entry three asks
+who may place a contributor's work under another board's terms. Until both
+carry an answer, the honest state of this line is that a hand-over of somebody
+else's work cannot be completed, and writing anything else into it would be
+inventing permission nobody gave.
+
+What would have to change for this to be production code, written by whoever
+did the work. They know and nobody else does. An experiment is allowed to cut
+every corner that is not the question, and the value of this line is that it
+names which corners those were while the reason is still remembered.
+
+## What promotion does not create
+
+It is not a promise of support from this board. Nothing here is maintained
+against anybody else's use of it, and an experiment does not gain a maintainer
+by being taken somewhere.
+
+It is not a claim that the code is finished. The line above about what would
+have to change is the measure of that, and it is part of the hand-over rather
+than an admission bolted onto it.
+
+It creates no obligation on the receiving board to take anything. That board
+may take the idea and none of the code, rewrite what it takes, or decline it.
+An experiment that is offered and declined is still an answered experiment, and
+its record says so without gaining a section, because nothing left this board.
+
+It is not a dependency edge. Nothing on another board is allowed to depend on
+anything here, and nothing in this repository ever writes to another one. A
+hand-over is a copy somebody else chose to take, recorded on both sides.
+
+## What this document cannot do
+
+Nothing checks that this list was worked through. The runner reads a checkout
+and can see whether a promotion section names the four things record `0005`
+fixes, which is shape rather than substance. Whether the measurement is real,
+whether the untested half is honestly listed, and whether the licence line was
+agreed with anybody are all things a reader decides by following the link and
+asking.
+
+So a green run on a promoted record says the section is complete, and it says
+nothing about whether the hand-over was earned. That is the boundary, and it is
+written here rather than discovered by somebody who trusted the tick.

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -1,0 +1,106 @@
+# Quality parity with the sso gate
+
+Being goal-free is not being rule-free. The bar this board holds itself to is
+the merge gate of another repository in this organisation rather than one
+invented here, because a bar invented here would be set by the same people it
+constrains.
+
+The target is `Flowfin/jellyfin-plugin-sso`. Its required set is printed rather
+than copied, since a list written into a document drifts against the ruleset
+that decides it:
+
+```
+gh api repos/Flowfin/jellyfin-plugin-sso/rules/branches/main \
+  --jq '.[] | select(.type=="required_status_checks")
+        | .parameters.required_status_checks[].context'
+```
+
+On 2026-08-10 that printed thirteen contexts, and the table below carries one
+row for each of them. Re-run the command before trusting the table. A row that
+no longer has an entry behind it, or an entry with no row, is the drift this
+document is most likely to develop, and finding it costs one command.
+
+## The gap this rests on
+
+The ruleset on the default branch of this board requires no status check at
+all:
+
+```
+gh api repos/Flowfin/lab/rules/branches/main --jq '[.[].type]'
+["deletion","non_fast_forward","pull_request"]
+
+gh api repos/Flowfin/lab/rules/branches/main \
+  --jq '.[] | select(.type=="required_status_checks")
+        | .parameters.required_status_checks[].context'
+(no output)
+```
+
+Every workflow in this tree runs, and none of them holds a merge. A red tick
+and a green tick have the same effect on whether a change lands, so the checks
+here are documentation until that changes. Parity is therefore mostly a
+question of a required set that does not exist yet rather than of checks that
+have not been written. Issue #26 is where the set is assembled.
+
+Read the table with that in front of it. "Kept" below means kept as a rule this
+board holds itself to, and it does not mean the tick holds a merge, because
+today no tick does.
+
+## The table
+
+| Target context | Verdict here | Reason |
+| --- | --- | --- |
+| `build` | Kept, renamed | This repository builds a runner rather than a plugin assembly, and the entries are per platform, which `docs/decisions/0012-the-supported-platforms.md` fixes. |
+| `ABI floor build` | Dropped | It exists so a plugin loads against the oldest server it claims to support, and nothing here loads into a host. |
+| `Package (JPRM) / Build package` | Dropped | This repository ships no plugin, so there is no package to build. |
+| `Package (JPRM) / Generate SBOM` | Kept in substance, moved out of the gate | A bill of materials is owed for anything downloadable, and this one is produced by the release build rather than by a check on a pull request. Issue #37 builds it and nothing in this tree produces one today. |
+| `CodeQL` | Kept, retargeted | Static analysis of the runner's own source, in the language record `0001` chose rather than in C#. |
+| `Analyze (csharp)` | Dropped as a name | The language-specific analysis job is replaced by the equivalent for this language rather than carried across under a name that describes nothing here. |
+| `DCO sign-off` | Kept unchanged | Already in the tree, asserting the text at `DCO` on every non-merge commit. |
+| `Deterministic PR-hygiene checks` | Kept, adapted | The class the other checks miss is the pull request itself, and one of the three refusals is this board's own invariant about a record moving with the code it describes. Issue #24 builds it and nothing in this tree reasons about a pull request today. |
+| `Enforce greppable invariants` | Kept, different invariants | The invariants are properties of this repository's own tracked text, which is a different set from the target's, and they are in `internal/invariants/`. |
+| `Reject Trojan Source Unicode` | Kept unchanged | Already in the tree, and the attack it refuses is a property of source rather than of a language. |
+| `Audit workflows (zizmor)` | Kept unchanged | Already in the tree. The workflow YAML is the other executable thing here and it runs with write scopes. |
+| `prettier` | Kept, split in two | Records here are Markdown, and a whitespace diff on a record hides the sentence that changed. The runner's own source is held to `gofmt` by a job already in the tree; the prose half is issue #50 and nothing in this tree formats Markdown today. |
+| `dependency-review` | Kept unchanged | Already in the tree, refusing a newly introduced dependency carrying a known advisory. |
+
+## What this board adds that the target does not have
+
+The record checks. The question and the answer are this repository's primary
+artefact, so a change that leaves a record wrong is the failure this board most
+needs to refuse, and the target has no equivalent because it has no records.
+They belong in the required set here.
+
+The headless and unelevated run. Record `0007` makes both halves a birth
+requirement, and the job proves the default suite completes with no graphical
+session and as an ordinary user. The target does not carry it because a plugin
+assembly is not run by a contributor on their own machine in the same way.
+
+The supply-chain self-audit stays outside the required set, for the same reason
+it is outside the target's. It publishes from the default branch and cannot
+gate a pull request, so requiring it would require a context that never
+arrives on the thing being gated.
+
+## What each side reports today
+
+Neither list is written here. Both are printed, from a completed run rather
+than from a workflow file, because a job name and a check-run name are not
+always the same string:
+
+```
+gh api repos/Flowfin/lab/commits/$(git rev-parse origin/main)/check-runs \
+  --jq '.check_runs[].name' | sort -u
+```
+
+That is the command issue #26 assembles the required set from, and it is the
+one to run before quoting any context name back at this document.
+
+## What this document is not
+
+It is not a claim that this board is as safe as the target. It records which of
+the target's entries survive here and why, and a row saying kept is a statement
+about a rule rather than about a mechanism: several of the rows above name an
+issue that has not been built, and those say so.
+
+It is also not a list of the checks in this tree. Two of the rows are already
+about work that does not exist yet, so a reader who wants to know what actually
+ran should read what a run printed. The run says what it examined.


### PR DESCRIPTION
Closes #22
Closes #38
Closes #48

## What this changes

Three documents this plan already depends on, landed together because each of
them is only text and a separate landing for each moves the mainline under the
other two.

`docs/quality-parity.md` walks the required set on the merge gate this board is
measured against and says, for each of its thirteen contexts, whether it is
kept, renamed, dropped or moved out of the gate, with the reason for every row
that is not kept unchanged.

`docs/promotion.md` is the checklist somebody works through before writing the
promotion section that record `0005` fixes. It carries what an experiment takes
into a hand-over and what promotion does not create.

`.github/pull_request_template.md` and two templates under
`.github/ISSUE_TEMPLATE/` put the shape of a contribution in front of whoever
is writing one, instead of leaving it to be learned from a red check.

## What failure it prevents

The parity table stops the bar from being reconstructed out of the workflows in
the tree, which answers a different question: what runs here rather than what
was deliberately dropped and why. It also states, first, the gap the rest of
that milestone rests on, which is that the ruleset on this board requires no
status check at all, so a tick of either colour has the same effect on whether
a change lands.

The promotion checklist stops a hand-over arriving with four filled-in fields
and no measurement, no commit, and no list of what was never tested.

The templates stop the cheapest repair for a demand nobody knew about being
whatever turns the check green.

## What was run

At `2c55ed7`, which is the head of this branch:

```
$ go build ./... && go vet ./...
$ gofmt -l .
$ go test ./...
ok  	github.com/Flowfin/lab/cmd/lab	0.360s
ok  	github.com/Flowfin/lab/internal/check	1.537s
ok  	github.com/Flowfin/lab/internal/hardware	(cached)
ok  	github.com/Flowfin/lab/internal/invariants	0.771s

$ go run ./cmd/lab check . ; echo $?
examined .
no experiments directory in this tree
0 experiment directories walked, 0 records read
15 decision records read
the time this run read is 2026-08-10T04:17:33Z
0 refused
0

$ go test ./internal/invariants -run 'TestThisRepositorySatisfiesTheInvariants|TestTheLicenceLegSaysWhetherItWasAsked' -count=1 -v
    examined ../..
    64 text files read
      the intended-use notice: 2 examined
      the licence: NOT ASKED, no licence is declared, so there is nothing to compare LICENSE against. asking costs answering entry one of the open questions issue and landing the file, the repository metadata and the decision record that names it, which is issue #47
      credential shapes in tracked text: 64 examined
      attribution markers in tracked text: 64 examined
      paths this repository's own documents name: 28 examined
    0 refused
--- PASS: TestThisRepositorySatisfiesTheInvariants (0.05s)
--- PASS: TestTheLicenceLegSaysWhetherItWasAsked (0.05s)
```

The path leg matters here more than usual, since two of the three deliverables
are documents that name paths. It examined 28 documents and refused none, so
every repository-relative path the two new documents under `docs/` name
resolves at this commit.

The required set on the target was read live rather than copied:

```
$ gh api repos/Flowfin/jellyfin-plugin-sso/rules/branches/main \
    --jq '.[] | select(.type=="required_status_checks")
          | .parameters.required_status_checks[].context' | wc -l
13
```

## What this does not do

No check refuses a wrong row in the parity table. The table is prose, nothing
in this tree reads it, and the only thing standing behind a row is the command
printed beside it and whoever re-runs it.

Nothing verifies that the promotion checklist was worked through. The runner
sees the shape of a promotion section and never its substance.

The issue-reference field in the pull-request template sits on the first line
because that is a position a later check can read. No check reads it today, so
until #24 exists the field is a convention and the template says so in the
file rather than only here.

`docs/quality-parity.md` records three rows whose work is not in this tree:
the bill of materials, the deterministic pull-request check, and the prose
half of the formatting check. Those rows say "kept" about a rule and not about
a mechanism, and each names the issue that owes it.

Nothing here has been read by a second person. The commands above and their
output stand in place of that reading rather than alongside it.
