### PR TITLE
Refuse a record that states no question

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -189,6 +189,21 @@ const (
 	// printing, which is why this is the near miss worth a fixture.
 	QuestionDatedLaterThanTheRun = "question-dated-later-than-the-run"
 
+	// RecordStatesNoQuestion refuses a record whose question section is empty
+	// or absent. It is the second half of the rule this board is built on:
+	// an experiment states its question before it starts, and a directory that
+	// carries a record with nothing written under the question has stated
+	// none. A heading with nothing under it is the same failure wearing a hat,
+	// which is why the two are one property with two details rather than a
+	// rule about a heading and a separate rule about text.
+	//
+	// WHAT IT DOES NOT JUDGE. Whether the question is a good question, whether
+	// it is really one question, and whether it is a question at all rather
+	// than a topic. No reading of a tree makes any of those, and review is
+	// where a bad question is caught. What a green run says here is that
+	// somebody wrote something under the heading before the work started.
+	RecordStatesNoQuestion = "record-states-no-question"
+
 	// RootHoldsADirectoryTheLayoutDoesNotName refuses a directory at the root
 	// of the tree that record 0002 does not name. That record fixes the
 	// layout and says a directory it does not name is refused rather than
@@ -442,6 +457,7 @@ func walkExperiments(root string, res *Result) error {
 		res.Records++
 		res.Refusals = append(res.Refusals, refuseBytes(record, data)...)
 		res.Refusals = append(res.Refusals, refusePaths(root, record, data)...)
+		res.Refusals = append(res.Refusals, refuseQuestion(record, data)...)
 		res.Refusals = append(res.Refusals, refuseState(record, data)...)
 		res.Refusals = append(res.Refusals, refuseDates(record, data, res.Now)...)
 		res.Refusals = append(res.Refusals, refusePromotion(record, data)...)
@@ -643,6 +659,58 @@ func depthOf(root, path string) (int, error) {
 	return len(strings.Split(filepath.ToSlash(relative), "/")), nil
 }
 
+// refuseQuestion holds a record to having written its question. Record 0008
+// puts the question under a level-two heading and record 0003 says an
+// experiment states it before the work starts; this is the half of that a
+// machine can see.
+//
+// The two arms are the same failure at different stages. A record with no
+// question heading is somebody who meant to write it later. A record with the
+// heading and nothing under it is somebody who started the template and
+// stopped, and it is the one that passes a reader's glance, because the shape
+// of a record is all there.
+//
+// WHERE THIS DOES NOT REACH, and it reaches less far than the property name
+// suggests. A record whose bytes do not parse as a record is not judged here,
+// for the same reason refuseState does not judge one: nothing can read a
+// section out of a file that has no header, and a refusal about the question
+// would send whoever hit it to the wrong repair. So a file under experiments/
+// called EXPERIMENT.md that is ordinary prose with no header states no
+// question and passes this, and the walk counts it as a record read. That hole
+// is the one refuseState's own comment names, it is not closed here, and a
+// green run should be read with it in view.
+//
+// It also judges nothing about what the question says. One character under the
+// heading satisfies it. What it converts is the case where nothing was written
+// at all, which is the case the rule exists for and the only one a reading of
+// the tree can separate from the rest.
+func refuseQuestion(path string, data []byte) []Refusal {
+	rec, err := ParseRecord(data)
+	if err != nil {
+		return nil
+	}
+
+	question, present := rec.Section(SectionQuestion)
+	switch {
+	case !present:
+		return []Refusal{{
+			Property: RecordStatesNoQuestion,
+			Subject:  path,
+			Detail: fmt.Sprintf("it carries no %s section at all, so it states no question, and record 0008 puts the question under that heading",
+				SectionQuestion),
+		}}
+	case strings.TrimSpace(question) == "":
+		return []Refusal{{
+			Property: RecordStatesNoQuestion,
+			Subject:  path,
+			Detail: fmt.Sprintf("its %s heading is there with nothing under it, so it states no question",
+				SectionQuestion),
+		}}
+	}
+
+	return nil
+}
+
 // refuseState holds a record to what its own state says about it. Record 0003
 // fixes the three states and what each one requires; this is the half of that
 // a machine can see.
@@ -660,8 +728,10 @@ func depthOf(root, path string) (int, error) {
 // header, and inventing a state refusal for it would name the wrong repair:
 // whoever hits it has a file that is not a record rather than a record with a
 // bad state. So a record with no header passes every rule below, which is a
-// hole, and it is issue #16's rather than this one's. Read a green run
-// accordingly.
+// hole. It is still open: refuseQuestion above reaches the same wall from the
+// other side and says so at itself, and no check in this package refuses a
+// file under experiments/ that is called EXPERIMENT.md and is not a record.
+// Read a green run accordingly.
 func refuseState(path string, data []byte) []Refusal {
 	rec, err := ParseRecord(data)
 	if err != nil {

--- a/internal/check/question_test.go
+++ b/internal/check/question_test.go
@@ -1,0 +1,85 @@
+package check
+
+import (
+	"strings"
+	"testing"
+)
+
+// The question refusal is proved by two cases under testdata/cases, and the
+// harness compares sets of property identifiers. That is not enough here, for
+// the reason state_test.go already sets out about the state refusal: the
+// property is refused at two sites, and a fixture for either satisfies the
+// standing requirement for both.
+//
+// The two are not interchangeable to the person reading the refusal. A record
+// with no question heading is somebody who has not started writing it. A
+// record with the heading and nothing under it is somebody who copied the
+// template and stopped, and the repair is a sentence rather than a section.
+// The message is the only thing that separates them.
+//
+// Measured rather than supposed. Deleting the absent arm leaves both cases
+// green, because a section that is not there reads back as an empty body and
+// falls through to the arm below, which refuses the same property under the
+// wrong message. That is the bound in harness_test.go acted on, and this test
+// is what acts on it.
+
+// TestEachQuestionSiteNamesItsOwnRepair holds the two apart.
+func TestEachQuestionSiteNamesItsOwnRepair(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		record string
+		wants  string
+	}{
+		{
+			name:   "no question section at all",
+			record: "Slug: one\nState: asking\nQuestion-Written: 2026-01-01\n\n## Method\n\nIt ran.\n\n## Answer\n",
+			wants:  "carries no Question section at all",
+		},
+		{
+			name:   "a question heading with nothing under it",
+			record: "Slug: one\nState: asking\nQuestion-Written: 2026-01-01\n\n## Question\n\n## Method\n\nIt ran.\n\n## Answer\n",
+			wants:  "Question heading is there with nothing under it",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			refusals := refuseQuestion("experiments/one/EXPERIMENT.md", []byte(c.record))
+			if len(refusals) != 1 {
+				t.Fatalf("refused %d times, want exactly one: %v", len(refusals), refusals)
+			}
+			if refusals[0].Property != RecordStatesNoQuestion {
+				t.Fatalf("refused %s, want %s", refusals[0].Property, RecordStatesNoQuestion)
+			}
+			if !strings.Contains(refusals[0].Detail, c.wants) {
+				t.Errorf("the message is %q and does not say %q, so it names the wrong repair", refusals[0].Detail, c.wants)
+			}
+		})
+	}
+}
+
+// TestAQuestionOfOneCharacterIsEnough is the boundary written at the check,
+// held to rather than described. Nothing here judges what the question says,
+// so the smallest thing somebody can write under the heading passes, and a
+// later change that started reading the text would fail this rather than
+// arriving as a surprise refusal on somebody's honest record.
+func TestAQuestionOfOneCharacterIsEnough(t *testing.T) {
+	record := "Slug: one\nState: asking\nQuestion-Written: 2026-01-01\n\n## Question\n\n?\n\n## Answer\n"
+	if refusals := refuseQuestion("experiments/one/EXPERIMENT.md", []byte(record)); len(refusals) != 0 {
+		t.Errorf("refused %v, and this check judges whether something was written rather than what it says", refusals)
+	}
+}
+
+// TestARecordThatIsNotARecordIsNotJudgedHere holds the disclosure at
+// refuseQuestion to being true. A file with no header states no question and
+// is not refused for it, because nothing can read a section out of a file that
+// has no header and the repair a question refusal names would be the wrong
+// one. If a later change closes that hole, this test is what says so out loud
+// instead of the gap quietly changing shape.
+func TestARecordThatIsNotARecordIsNotJudgedHere(t *testing.T) {
+	record := "# Timing test\n\nSomething somebody meant to turn into a record.\n"
+	if _, err := ParseRecord([]byte(record)); err == nil {
+		t.Fatalf("this record parses, so it no longer stands for the case being described")
+	}
+	if refusals := refuseQuestion("experiments/one/EXPERIMENT.md", []byte(record)); len(refusals) != 0 {
+		t.Errorf("refused %v, and the comment at refuseQuestion says this case is not reached", refusals)
+	}
+}

--- a/testdata/cases/record-that-writes-no-question/expected
+++ b/testdata/cases/record-that-writes-no-question/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/record-that-writes-no-question/expected-refusals
+++ b/testdata/cases/record-that-writes-no-question/expected-refusals
@@ -1,0 +1,1 @@
+record-states-no-question

--- a/testdata/cases/record-that-writes-no-question/near-neighbour
+++ b/testdata/cases/record-that-writes-no-question/near-neighbour
@@ -1,0 +1,1 @@
+record-in-asking

--- a/testdata/cases/record-that-writes-no-question/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-that-writes-no-question/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,9 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+
+## Method
+
+It was pointed at this tree.
+
+## Answer

--- a/testdata/cases/record-with-an-empty-question-section/expected
+++ b/testdata/cases/record-with-an-empty-question-section/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/record-with-an-empty-question-section/expected-refusals
+++ b/testdata/cases/record-with-an-empty-question-section/expected-refusals
@@ -1,0 +1,1 @@
+record-states-no-question

--- a/testdata/cases/record-with-an-empty-question-section/near-neighbour
+++ b/testdata/cases/record-with-an-empty-question-section/near-neighbour
@@ -1,0 +1,1 @@
+record-in-asking

--- a/testdata/cases/record-with-an-empty-question-section/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-with-an-empty-question-section/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,11 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+
+## Question
+
+## Method
+
+It was pointed at this tree.
+
+## Answer


### PR DESCRIPTION
Closes #16

## What this changes

The second of the two refusals this issue asks for. A directory under
`experiments/` with no `EXPERIMENT.md` was already refused; a record whose
question section is empty or absent now is too.

One property, `record-states-no-question`, refused at two sites because there
are two repairs. A record with no `Question` section at all is somebody who
meant to write it later. A record whose heading is there with nothing under it
is somebody who copied the template and stopped.

## What failure it prevents

The second arm is the one that arrives in practice, and it is the one this
board's central rule cannot survive. The header is there, the state is there,
the headings are there, and the record reads as finished to anybody skimming
the diff. Every other check in the tree stayed green through it.

## What was run

At `67883fc`, the head of this branch.

Both arms refuse, each with its own message, and the run exits non-zero:

```
$ go run ./cmd/lab check testdata/cases/record-that-writes-no-question/tree ; echo $?
examined testdata/cases/record-that-writes-no-question/tree
1 experiment directory walked, 1 record read
no docs/decisions directory in this tree
0 decision records read
the time this run read is 2026-08-10T04:27:43Z
1 refused
  ...\experiments\one\EXPERIMENT.md: it carries no Question section at all, so it states no question, and record 0008 puts the question under that heading (record-states-no-question)
1

$ go run ./cmd/lab check testdata/cases/record-with-an-empty-question-section/tree ; echo $?
examined testdata/cases/record-with-an-empty-question-section/tree
1 experiment directory walked, 1 record read
no docs/decisions directory in this tree
0 decision records read
the time this run read is 2026-08-10T04:27:48Z
1 refused
  ...\experiments\one\EXPERIMENT.md: its Question heading is there with nothing under it, so it states no question (record-states-no-question)
1
```

The near neighbour both cases declare, which differs from each by one legal
change, refuses nothing:

```
$ go run ./cmd/lab check testdata/cases/record-in-asking/tree ; echo $?
examined testdata/cases/record-in-asking/tree
1 experiment directory walked, 1 record read
no docs/decisions directory in this tree
0 decision records read
the time this run read is 2026-08-10T04:27:53Z
0 refused
0
```

Deleting the call from the walk reddens the suite:

```
$ go test ./internal/check -count=1
--- FAIL: TestCases (0.04s)
    --- FAIL: TestCases/record-with-an-empty-question-section (0.00s)
        check_test.go:51: expected refusal not produced: record-states-no-question
    --- FAIL: TestCases/record-that-writes-no-question (0.00s)
        check_test.go:51: expected refusal not produced: record-states-no-question
FAIL
```

Deleting only the absent arm does not, and that was measured rather than
assumed. The fixture harness compares sets of property identifiers, so a
section that is not there falls through to the arm below and refuses the same
property under the wrong message:

```
$ go test ./internal/check -count=1 -run 'TestCases|TestEveryRefusalHasAFixtureThatProvesItBites|TestARefusalNamesItsSubject'
ok  	github.com/Flowfin/lab/internal/check	3.394s

$ go test ./internal/check -count=1 -run TestEachQuestionSiteNamesItsOwnRepair
--- FAIL: TestEachQuestionSiteNamesItsOwnRepair/no_question_section_at_all
    question_test.go:53: the message is "its Question heading is there with nothing under it, so it states no question" and does not say "carries no Question section at all", so it names the wrong repair
FAIL
```

The whole gate, restored:

```
$ go build ./... && go vet ./... && gofmt -l . && go test ./... -count=1
ok  	github.com/Flowfin/lab/cmd/lab	1.881s
ok  	github.com/Flowfin/lab/internal/check	1.939s
ok  	github.com/Flowfin/lab/internal/hardware	1.705s
ok  	github.com/Flowfin/lab/internal/invariants	2.013s

$ go run ./cmd/lab check . ; echo $?
examined .
no experiments directory in this tree
0 experiment directories walked, 0 records read
15 decision records read
the time this run read is 2026-08-10T04:17:33Z
0 refused
0
```

## What this does not do

It judges nothing about what the question says. One character under the heading
passes, and `TestAQuestionOfOneCharacterIsEnough` holds that boundary so a later
change that started reading the text fails here rather than arriving as a
surprise refusal on somebody's honest record. Whether a question is a good
question, or really one question, is review's.

It does not close the hole `refuseState`'s comment used to hand to this issue.
A file under `experiments/` called `EXPERIMENT.md` with no header at all parses
as nothing, so no section can be read out of it and no refusal in this package
reaches it. That comment now says the hole is open rather than naming an issue
that closed without it, `refuseQuestion` carries the same disclosure at itself,
and `TestARecordThatIsNotARecordIsNotJudgedHere` holds the disclosure to being
true so the gap cannot quietly change shape.

Nothing here has been read by a second person. The commands above and their
output stand in place of that reading rather than alongside it.
