### PR TITLE
Refuse a header whose dates disagree with themselves

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -459,6 +459,7 @@ func walkExperiments(root string, res *Result) error {
 		res.Refusals = append(res.Refusals, refusePaths(root, record, data)...)
 		res.Refusals = append(res.Refusals, refuseQuestion(record, data)...)
 		res.Refusals = append(res.Refusals, refuseState(record, data)...)
+		res.Refusals = append(res.Refusals, refuseHeaderDates(record, data)...)
 		res.Refusals = append(res.Refusals, refuseDates(record, data, res.Now)...)
 		res.Refusals = append(res.Refusals, refusePromotion(record, data)...)
 		if parsed, err := ParseRecord(data); err == nil {

--- a/internal/check/header.go
+++ b/internal/check/header.go
@@ -1,0 +1,130 @@
+package check
+
+import (
+	"fmt"
+	"time"
+)
+
+// The properties a header can be refused for where its own fields disagree.
+const (
+	// RecordHeaderDateIsNotADate refuses a date field carrying something that
+	// is not a date written the one way record 0008 names. A field holding a
+	// month, a season or a sentence parses as nothing, and the listing sorts
+	// on the question's date: a value nothing can read sorts wherever the
+	// comparison happens to put it, and the order is the one thing a reader
+	// takes from that listing.
+	//
+	// A field written with nothing after the colon is refused here too. Record
+	// 0013 makes absence legal for every field and an empty declaration a
+	// different statement, and a declared date with no value is a claim that
+	// there is a date rather than a claim that there is none.
+	RecordHeaderDateIsNotADate = "record-header-date-is-not-a-date"
+
+	// RecordAnswerDateDisagreesWithTheRecord refuses an answer date the rest
+	// of the record contradicts, at two sites.
+	//
+	// An answer dated before the question is a timeline that cannot have
+	// happened, whichever of the two fields is wrong.
+	//
+	// An answer date on a record still saying asking is the arm worth the
+	// fixture. It passes every other rule in this tree, because a record in
+	// asking is allowed an empty answer section and nothing else reads the
+	// field, and what it means is a record edited towards a state it is not
+	// in. Record 0008 says the answer date is added in the same change as the
+	// answer, and this is that sentence made refusable.
+	RecordAnswerDateDisagreesWithTheRecord = "record-answer-date-disagrees-with-the-record"
+)
+
+// headerDateFields are the fields record 0008 fixes as dates, in the order it
+// names them, so a record carrying two bad ones is refused in the order
+// somebody reads the header.
+//
+// A field a later record adds is not here. Record 0013 makes a new field
+// optional and a checker built before it unaware of it, so a date field added
+// later is refused by the change that adds it rather than by this list
+// silently widening.
+var headerDateFields = []string{FieldQuestionWritten, FieldAnswerWritten}
+
+// dateShape is how a refusal spells the format to somebody reading it, and
+// dateExample is a date in it. DateFormat is Go's own spelling of the same
+// shape and it reads as a date rather than as a rule, so a message quoting it
+// tells a reader that the second of January 2006 was expected.
+//
+// The two cannot drift apart in silence: TestTheExampleInAMessageIsADate
+// parses dateExample under DateFormat, so a change to either that leaves them
+// disagreeing reddens the suite.
+const (
+	dateShape   = "YYYY-MM-DD"
+	dateExample = "2026-01-02"
+)
+
+// refuseHeaderDates holds the header's dates to being dates and to agreeing
+// with each other and with the state.
+//
+// WHAT IT DOES NOT JUDGE, and this is the whole of the residual. Nothing in a
+// checkout says when somebody started thinking about a question or when they
+// finished. A date here is a claim its author made, and every rule below is
+// about the shape of that claim and the order of two of them. A record whose
+// dates are both invented and consistent passes, so a green run is evidence
+// that the timeline is readable rather than that it is real.
+//
+// A record whose bytes do not parse as a record is not judged here, for the
+// reason refuseState and refuseDates both give: nothing can read a field out of
+// a file that has no header.
+func refuseHeaderDates(path string, data []byte) []Refusal {
+	record, err := ParseRecord(data)
+	if err != nil {
+		return nil
+	}
+
+	var refusals []Refusal
+	dates := make(map[string]time.Time)
+
+	for _, name := range headerDateFields {
+		written, present := record.Field(name)
+		if !present {
+			// Absence is never a refusal. Record 0013 fixes that, and
+			// Answer-Written is absent from every record that has not been
+			// answered.
+			continue
+		}
+		date, err := time.Parse(DateFormat, written)
+		if err != nil {
+			refusals = append(refusals, Refusal{
+				Property: RecordHeaderDateIsNotADate,
+				Subject:  path,
+				Detail: fmt.Sprintf("its %s is %q, and record 0008 writes a date as %s, for example %s",
+					name, written, dateShape, dateExample),
+			})
+			continue
+		}
+		dates[name] = date
+	}
+
+	answered, hasAnswerDate := dates[FieldAnswerWritten]
+	if !hasAnswerDate {
+		return refusals
+	}
+
+	if state, _ := record.Field(FieldState); state == StateAsking {
+		refusals = append(refusals, Refusal{
+			Property: RecordAnswerDateDisagreesWithTheRecord,
+			Subject:  path,
+			Detail: fmt.Sprintf("it says %s and carries an %s of %s, so it has been edited towards a state it is not in",
+				StateAsking, FieldAnswerWritten, answered.Format(DateFormat)),
+		})
+		return refusals
+	}
+
+	if asked, hasQuestionDate := dates[FieldQuestionWritten]; hasQuestionDate && answered.Before(asked) {
+		refusals = append(refusals, Refusal{
+			Property: RecordAnswerDateDisagreesWithTheRecord,
+			Subject:  path,
+			Detail: fmt.Sprintf("its %s is %s and its %s is %s, so the answer is dated before the question",
+				FieldAnswerWritten, answered.Format(DateFormat),
+				FieldQuestionWritten, asked.Format(DateFormat)),
+		})
+	}
+
+	return refusals
+}

--- a/internal/check/header_test.go
+++ b/internal/check/header_test.go
@@ -1,0 +1,140 @@
+package check
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// The header date refusals are proved by cases under testdata/cases, and the
+// harness compares sets of property identifiers. That is the whole of what a
+// case proves, and it leaves two things open that these tests close.
+//
+// The date-shape rule reads two fields in one loop, so a case with a bad
+// question date satisfies the standing requirement for a bad answer date as
+// well, and a change that stopped reading one of the two would stay green.
+//
+// The answer-date rule is refused at two sites for two different repairs. A
+// record still asking that carries an answer date has been edited towards a
+// state it is not in. A record whose answer is dated before its question has a
+// timeline that could not have happened. The message is the only thing that
+// separates them, and it is what these hold.
+
+// TestBothHeaderDateFieldsAreHeldToTheShape holds the loop to reading both
+// fields rather than only the one a case happens to spend its fixture on.
+func TestBothHeaderDateFieldsAreHeldToTheShape(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		record string
+		wants  string
+	}{
+		{
+			name:   "a question date that is a month",
+			record: "Slug: one\nState: asking\nQuestion-Written: March 2026\n\n## Question\n\nWhy?\n",
+			wants:  `its Question-Written is "March 2026"`,
+		},
+		{
+			name:   "an answer date that is a sentence",
+			record: "Slug: one\nState: answered\nQuestion-Written: 2026-01-01\nAnswer-Written: some time last spring\n\n## Question\n\nWhy?\n\n## Answer\n\nNo.\n",
+			wants:  `its Answer-Written is "some time last spring"`,
+		},
+		{
+			name:   "a date field declared with nothing after the colon",
+			record: "Slug: one\nState: asking\nQuestion-Written:\n\n## Question\n\nWhy?\n",
+			wants:  `its Question-Written is ""`,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			refusals := refuseHeaderDates("experiments/one/EXPERIMENT.md", []byte(c.record))
+			if len(refusals) != 1 {
+				t.Fatalf("refused %d times, want exactly one: %v", len(refusals), refusals)
+			}
+			if refusals[0].Property != RecordHeaderDateIsNotADate {
+				t.Fatalf("refused %s, want %s", refusals[0].Property, RecordHeaderDateIsNotADate)
+			}
+			if !strings.Contains(refusals[0].Detail, c.wants) {
+				t.Errorf("the message is %q and does not say %q", refusals[0].Detail, c.wants)
+			}
+		})
+	}
+}
+
+// TestEachAnswerDateSiteNamesItsOwnRepair holds the two apart.
+func TestEachAnswerDateSiteNamesItsOwnRepair(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		record string
+		wants  string
+	}{
+		{
+			name:   "an answer date on a record still asking",
+			record: "Slug: one\nState: asking\nQuestion-Written: 2026-01-01\nAnswer-Written: 2026-02-02\n\n## Question\n\nWhy?\n",
+			wants:  "edited towards a state it is not in",
+		},
+		{
+			name:   "an answer dated before the question",
+			record: "Slug: one\nState: answered\nQuestion-Written: 2026-03-01\nAnswer-Written: 2026-02-02\n\n## Question\n\nWhy?\n\n## Answer\n\nNo.\n",
+			wants:  "the answer is dated before the question",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			refusals := refuseHeaderDates("experiments/one/EXPERIMENT.md", []byte(c.record))
+			if len(refusals) != 1 {
+				t.Fatalf("refused %d times, want exactly one: %v", len(refusals), refusals)
+			}
+			if refusals[0].Property != RecordAnswerDateDisagreesWithTheRecord {
+				t.Fatalf("refused %s, want %s", refusals[0].Property, RecordAnswerDateDisagreesWithTheRecord)
+			}
+			if !strings.Contains(refusals[0].Detail, c.wants) {
+				t.Errorf("the message is %q and does not say %q, so it names the wrong repair", refusals[0].Detail, c.wants)
+			}
+		})
+	}
+}
+
+// TestTheHeaderDatesARecordInOrderCarriesAreLeftAlone holds the boundaries the
+// rules are written with. An absent answer date is the ordinary state of every
+// record that has not been answered, and record 0013 makes absence legal for
+// every field, so neither of these may refuse.
+func TestTheHeaderDatesARecordInOrderCarriesAreLeftAlone(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		record string
+	}{
+		{
+			name:   "asking, with no answer date",
+			record: "Slug: one\nState: asking\nQuestion-Written: 2026-01-01\n\n## Question\n\nWhy?\n",
+		},
+		{
+			name:   "answered on the day the question was written",
+			record: "Slug: one\nState: answered\nQuestion-Written: 2026-01-01\nAnswer-Written: 2026-01-01\n\n## Question\n\nWhy?\n\n## Answer\n\nNo.\n",
+		},
+		{
+			name:   "no dates in the header at all",
+			record: "Slug: one\nState: asking\n\n## Question\n\nWhy?\n",
+		},
+		{
+			name:   "abandoned, carrying the date the work stopped",
+			record: "Slug: one\nState: abandoned\nQuestion-Written: 2026-01-01\nAnswer-Written: 2026-02-02\n\n## Question\n\nWhy?\n\n## Answer\n\nThe machine went back.\n",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if refusals := refuseHeaderDates("experiments/one/EXPERIMENT.md", []byte(c.record)); len(refusals) != 0 {
+				t.Errorf("refused %v, and this record is in order", refusals)
+			}
+		})
+	}
+}
+
+// TestTheExampleInAMessageIsADate ties the human spelling a refusal prints to
+// the layout the parser uses. Without it the two are separate strings that
+// happen to agree today, and the one that goes wrong is the one nothing reads
+// back.
+func TestTheExampleInAMessageIsADate(t *testing.T) {
+	if _, err := time.Parse(DateFormat, dateExample); err != nil {
+		t.Fatalf("a refusal offers %q as an example of %s and the parser rejects it: %v", dateExample, dateShape, err)
+	}
+	if len(dateExample) != len(dateShape) {
+		t.Errorf("the example %q and the shape %s are different lengths, so one of them is not the other written out", dateExample, dateShape)
+	}
+}

--- a/testdata/cases/record-answered-before-it-was-asked/expected
+++ b/testdata/cases/record-answered-before-it-was-asked/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/record-answered-before-it-was-asked/expected-refusals
+++ b/testdata/cases/record-answered-before-it-was-asked/expected-refusals
@@ -1,0 +1,1 @@
+record-answer-date-disagrees-with-the-record

--- a/testdata/cases/record-answered-before-it-was-asked/near-neighbour
+++ b/testdata/cases/record-answered-before-it-was-asked/near-neighbour
@@ -1,0 +1,1 @@
+record-answered-with-an-answer

--- a/testdata/cases/record-answered-before-it-was-asked/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-answered-before-it-was-asked/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,16 @@
+Slug: one
+State: answered
+Question-Written: 2026-03-01
+Answer-Written: 2026-02-02
+
+## Question
+
+Does the walk read a record that stopped with an answer?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer
+
+No, and that is a finished piece of work.

--- a/testdata/cases/record-still-asking-with-an-answer-date/expected
+++ b/testdata/cases/record-still-asking-with-an-answer-date/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/record-still-asking-with-an-answer-date/expected-refusals
+++ b/testdata/cases/record-still-asking-with-an-answer-date/expected-refusals
@@ -1,0 +1,1 @@
+record-answer-date-disagrees-with-the-record

--- a/testdata/cases/record-still-asking-with-an-answer-date/near-neighbour
+++ b/testdata/cases/record-still-asking-with-an-answer-date/near-neighbour
@@ -1,0 +1,1 @@
+record-in-asking

--- a/testdata/cases/record-still-asking-with-an-answer-date/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-still-asking-with-an-answer-date/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,14 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+Answer-Written: 2026-02-02
+
+## Question
+
+Does the walk read a record that is still running?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer

--- a/testdata/cases/record-with-a-question-date-that-is-not-a-date/expected
+++ b/testdata/cases/record-with-a-question-date-that-is-not-a-date/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/record-with-a-question-date-that-is-not-a-date/expected-refusals
+++ b/testdata/cases/record-with-a-question-date-that-is-not-a-date/expected-refusals
@@ -1,0 +1,1 @@
+record-header-date-is-not-a-date

--- a/testdata/cases/record-with-a-question-date-that-is-not-a-date/near-neighbour
+++ b/testdata/cases/record-with-a-question-date-that-is-not-a-date/near-neighbour
@@ -1,0 +1,1 @@
+record-in-asking

--- a/testdata/cases/record-with-a-question-date-that-is-not-a-date/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/record-with-a-question-date-that-is-not-a-date/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,13 @@
+Slug: one
+State: asking
+Question-Written: March 2026
+
+## Question
+
+Does the walk read a record that is still running?
+
+## Method
+
+It was pointed at this tree.
+
+## Answer


### PR DESCRIPTION
Refs #54

## What this changes

Two of the three refusals that issue argues, and the third is not here. Both of
these read the header record `0008` fixes.

Every date field in the header has to be a date written the one way that record
names. A field carrying a month, a season, a sentence, or nothing at all after
the colon is refused.

An answer date has to agree with the rest of the record. Two sites: an answer
dated before the question, and an answer date on a record that still says
`asking`.

## What failure it prevents

The listing sorts on the question's date, and `refuseDates` read that field only
to compare it against the run. Its own comment said a value that is not a date
is a different rule and refused it nowhere, so a record whose date is a
sentence sorted wherever the comparison put it while the listing kept printing.

The `asking` arm is the one worth the fixture. A record in `asking` is allowed
an empty answer section, nothing else in the tree reads `Answer-Written`, and a
record carrying one while claiming to still be asking passes every other check
here. What it means is a record edited towards a state it is not in.

## What was run

At `54d3c7e`, the head of this branch. Each of the three sites, with its own
message, exiting non-zero:

```
$ go run ./cmd/lab check testdata/cases/record-with-a-question-date-that-is-not-a-date/tree ; echo $?
  ...\experiments\one\EXPERIMENT.md: its Question-Written is "March 2026", and record 0008 writes a date as YYYY-MM-DD, for example 2026-01-02 (record-header-date-is-not-a-date)
1

$ go run ./cmd/lab check testdata/cases/record-still-asking-with-an-answer-date/tree ; echo $?
  ...\experiments\one\EXPERIMENT.md: it says asking and carries an Answer-Written of 2026-02-02, so it has been edited towards a state it is not in (record-answer-date-disagrees-with-the-record)
1

$ go run ./cmd/lab check testdata/cases/record-answered-before-it-was-asked/tree ; echo $?
  ...\experiments\one\EXPERIMENT.md: its Answer-Written is 2026-02-02 and its Question-Written is 2026-03-01, so the answer is dated before the question (record-answer-date-disagrees-with-the-record)
1
```

The two near neighbours the three cases declare, each one legal change away,
refuse nothing:

```
$ go run ./cmd/lab check testdata/cases/record-in-asking/tree
0 refused
$ go run ./cmd/lab check testdata/cases/record-answered-with-an-answer/tree
0 refused
```

Deleting the call from the walk reddens the suite:

```
$ go test ./internal/check -count=1
--- FAIL: TestCases (0.05s)
    --- FAIL: TestCases/record-still-asking-with-an-answer-date (0.00s)
        check_test.go:51: expected refusal not produced: record-answer-date-disagrees-with-the-record
    --- FAIL: TestCases/record-with-a-question-date-that-is-not-a-date (0.00s)
        check_test.go:51: expected refusal not produced: record-header-date-is-not-a-date
    --- FAIL: TestCases/record-answered-before-it-was-asked (0.00s)
        check_test.go:51: expected refusal not produced: record-answer-date-disagrees-with-the-record
FAIL
```

The whole gate:

```
$ go build ./... && go vet ./... && gofmt -l . && go test ./... -count=1
ok  	github.com/Flowfin/lab/cmd/lab	0.446s
ok  	github.com/Flowfin/lab/internal/check	2.025s
ok  	github.com/Flowfin/lab/internal/hardware	1.817s
ok  	github.com/Flowfin/lab/internal/invariants	1.943s

$ go run ./cmd/lab check . ; echo $?
0 refused
0
```

## What this does not do

It does not carry the third refusal, and the issue stays open for it. A record
whose `Slug` disagrees with the directory it sits in is still not refused, and
the reason is written into #54 with the measurement: enforcing it makes
`two-experiments-share-a-slug` unreachable, because two experiments can only
answer to one slug when at least one of them disagrees with its directory, and
that property's fixture then has no tree that trips it alone.

It judges nothing about whether a date is true. Nothing in a checkout says when
somebody started thinking about a question, so a record whose dates are invented
and consistent passes every rule here. That bound is written at the check.

An answer date on an `abandoned` record is not refused. The issue asks for the
`asking` case, an abandoned record can legitimately carry the date the work
stopped, and widening the rule to a state the issue did not argue would be
deciding that here.

Nothing here has been read by a second person. The commands above and their
output stand in place of that reading rather than alongside it.
