### PR TITLE
Make the default run say what it did not cover

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,6 +193,20 @@ jobs:
             echo "::error::The suite reported success having executed no tests on ${PLATFORM}."
             exit 1
           fi
+          # The run has to say what it did not cover. internal/hardware prints
+          # one line when its harness was not asked for, saying so and what
+          # asking would cost, and it is printed by a package that passes, so
+          # it reaches the log only under -v. Dropping that flag, or losing the
+          # disclosure, would leave a run that covered less than the whole set
+          # looking exactly like one that covered it and found nothing. The
+          # string is hardware.Disclosure()'s, and a reword there reddens this
+          # rather than passing in silence.
+          disclosed=$(grep -cF 'integration-hardware harness was not asked for' suite.log || true)
+          if [ "$disclosed" -eq 0 ]; then
+            echo "::error::The suite printed no integration-hardware disclosure on ${PLATFORM}, so this run covered less than the whole set without saying so."
+            exit 1
+          fi
+          echo "${PLATFORM}: the integration-hardware disclosure was printed"
 
   vet:
     name: vet

--- a/.github/workflows/headless.yml
+++ b/.github/workflows/headless.yml
@@ -109,3 +109,12 @@ jobs:
             echo "::error::The suite reported success having executed no tests."
             exit 1
           fi
+          # The same disclosure check the build workflow carries, and for the
+          # same reason: a run that covered less than the whole set has to say
+          # so. The string is hardware.Disclosure()'s.
+          disclosed=$(grep -cF 'integration-hardware harness was not asked for' suite.log || true)
+          if [ "$disclosed" -eq 0 ]; then
+            echo "::error::The suite printed no integration-hardware disclosure, so this run covered less than the whole set without saying so."
+            exit 1
+          fi
+          echo "with no display and no elevation: the integration-hardware disclosure was printed"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,21 @@ Run these, in this order, from the root of a checkout:
 go build ./...
 go vet ./...
 gofmt -l .
-go test ./...
+go test -count=1 -v ./...
 ```
 
 `gofmt -l` prints the files it would change and exits zero either way, so read
 its output rather than its exit code. No output is the passing result.
+
+The two flags on the suite are not decoration and the command said `go test
+./...` until they were added. `-count=1` runs the tests rather than replaying a
+cached result, so a green run is one that happened on this machine. `-v` is
+what makes the run say what it did not cover: `go test` prints nothing at all
+for a package that passes, and the line saying the integration-hardware harness
+was not asked for and what asking would cost is printed by a package that
+passes. Without `-v` a run that covered less than the whole set reads exactly
+like one that covered it and found nothing, which is the reading the harness
+under `internal/hardware/` exists to prevent.
 
 That is what the gate runs on the server, so running it here means running the
 same thing rather than something that resembles it. What the checks are and what


### PR DESCRIPTION
Closes #30

## What this changes

The last unmet part of that issue: the default run now prints that the
integration-hardware harness was not asked for and what asking would cost, and
a machine refuses a run where it did not.

`CONTRIBUTING.md` documented the suite as `go test ./...` and said in the next
paragraph that this is what the gate runs on the server. It is not: the gate
runs `go test -count=1 -v ./...`. The command now matches, and both flags are
explained where they are written.

`build.yml` and `headless.yml` fail closed when the disclosure is absent from
the suite output.

## What failure it prevents

`go test` prints nothing at all for a package that passes, and the package that
prints the disclosure passes. So the line existed and reached nobody, and a run
that covered less than the whole set looked exactly like one that covered it
and found nothing. That is the reading the harness was built to prevent.

## What was run

At `36679d5`, the head of this branch.

The disclosure, as the suite now prints it:

```
$ go test -count=1 -v ./...
the integration-hardware harness was not asked for and nothing in it ran.
asking costs a machine with the hardware each test names and an explicit request:
    go test -tags integration_hardware ./internal/hardware
with LAB_INTEGRATION_HARDWARE=1 in the environment. its results are about that machine and are not this suite's results.
ok  	github.com/Flowfin/lab/internal/hardware	3.402s
```

The guard, measured in both directions. The grep the two workflows run finds it
once under the documented command and not at all under the one that was
documented before, where the step exits non-zero:

```
$ go test -count=1 -v ./... > suite.log 2>&1
$ grep -cF 'integration-hardware harness was not asked for' suite.log
1

$ go test -count=1 ./... > suite.log 2>&1
$ grep -cF 'integration-hardware harness was not asked for' suite.log
0
```

The whole gate, under the command this change documents:

```
$ go build ./... && go vet ./...
$ gofmt -l .
$ go test -count=1 -v ./...
52 top-level results, 0 skipped

$ go run ./cmd/lab check . ; echo $?
the time this run read is 2026-08-10T05:06:00Z
0 refused
0
```

## What this does not do

Nothing refuses a drift between the commands `CONTRIBUTING.md` names and the
commands the workflows run. That is exactly the defect this change repairs by
hand, and it can happen again the same way. No check in this tree reads the
document and compares it to the workflows, so what stands behind the sentence
being true tomorrow is whoever edits one of the two.

The disclosure check greps for a string that `hardware.Disclosure()` builds.
That is fail-closed rather than derived: a reword reddens the run instead of
passing, and the repair is to update both. Nothing makes them one string.

It changes nothing about the harness itself. Its tests are still behind a build
constraint and still behind an explicit request, and a measurement it produces
is still a measurement about the machine it ran on rather than this suite's
result.

Nothing here has been read by a second person. The commands above and their
output stand in place of that reading rather than alongside it.
