### PR TITLE
Prove the runner opens no network connection

### DIFF
--- a/cmd/lab/network_test.go
+++ b/cmd/lab/network_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bytes"
+	"io/fs"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Flowfin/lab/internal/check"
+)
+
+// The runner opens no network connection. It reads a checkout and writes to its
+// own output, and that is the whole of its contact with the world. There is no
+// telemetry, no update check, no schema fetched from anywhere and no version
+// ping.
+//
+// The two tests below prove it from different directions, and neither is the
+// whole proof on its own.
+//
+// The first reads the runner's transitive dependency set and refuses any
+// package that can open a socket. It reaches a network client arriving inside a
+// dependency nobody read, which is the shape a hand audit of this package's own
+// imports would miss.
+//
+// The second runs the runner over the largest trees this repository holds, by
+// every verb it has, and asserts each one completed with a verdict. It reaches
+// a route that is never exercised, because a dependency proof says what the
+// binary could do and says nothing about which of it ran.
+//
+// WHAT THE PAIR PROVES AND WHAT IT DOES NOT. Together they say that a full run
+// over the largest input available executed in a binary that links nothing able
+// to open a connection, so no outbound connection was attempted because none
+// was reachable. That is a structural argument, not an observation: nothing
+// here watches syscalls, and there is no portable way to do so across the three
+// platforms this suite runs on that would not itself be the thing most likely
+// to break. A run under a syscall tracer would say more, and it would say it on
+// one platform.
+//
+// The first test is the one that catches the change this claim will actually
+// face, which is a future contributor adding a helpful update check. That
+// arrives with good intentions and a reasonable justification, and it cannot
+// arrive without a network package appearing below.
+
+// networkImport says whether an import path is a package that can open an
+// outbound connection.
+//
+// It is the whole of net rather than a list of the parts of it that dial. A
+// list would have to be right about which parts those are, forever, and the
+// runner needs none of net today, so the strict rule costs nothing and the
+// permissive one would cost a judgement every time the standard library grows.
+// A change that genuinely needs one of these fails here and is argued in the
+// issue that wants it, which is the right place for it.
+func networkImport(path string) bool {
+	return path == "net" || strings.HasPrefix(path, "net/")
+}
+
+// TestTheRunnerLinksNoNetworkPackage is the dependency proof.
+//
+// It asks the toolchain rather than reading this package's own import block,
+// because the import block says what this file reaches for and the question is
+// what the binary carries. The list is transitive, so a network client three
+// dependencies down is in it.
+func TestTheRunnerLinksNoNetworkPackage(t *testing.T) {
+	out, err := exec.Command("go", "list", "-deps", ".").Output()
+	if err != nil {
+		t.Fatalf("cannot read the runner's dependencies: %v", err)
+	}
+
+	deps := strings.Fields(string(out))
+	if len(deps) == 0 {
+		t.Fatal("the dependency list is empty, which cannot be right, and an empty list would pass every check below")
+	}
+
+	// Printed before the verdict and phrased as a count rather than as a
+	// result. A line saying none of them is a network package, written next to
+	// an error saying nine of them are, is the report contradicting itself in
+	// the one run somebody is reading closely.
+	t.Logf("%d packages read", len(deps))
+
+	var found []string
+	for _, dep := range deps {
+		if networkImport(dep) {
+			found = append(found, dep)
+		}
+	}
+	if len(found) > 0 {
+		t.Errorf("the runner links %s, so it can open an outbound connection",
+			strings.Join(found, ", "))
+	}
+}
+
+// TestTheNetworkRuleWouldRefuseANetworkPackage is the near miss. Without it,
+// a rule that refused nothing at all would pass the test above on a tree that
+// happens to be clean, and the two are indistinguishable from a green run.
+func TestTheNetworkRuleWouldRefuseANetworkPackage(t *testing.T) {
+	for _, path := range []string{"net", "net/http", "net/http/httptest", "net/smtp"} {
+		if !networkImport(path) {
+			t.Errorf("%s is not read as a network package, and the rule above would let it into the runner", path)
+		}
+	}
+	for _, path := range []string{"os", "fmt", "internal/check", "strings"} {
+		if networkImport(path) {
+			t.Errorf("%s is read as a network package, and the rule above refuses work it has no business refusing", path)
+		}
+	}
+}
+
+// TestAFullRunOverTheLargestTreeCompletes is the behavioural half.
+//
+// Every verb, over the two largest trees this repository holds, asserting a
+// verdict rather than a broken invocation. The whole fixture corpus is the
+// largest tree the fixtures provide, larger than any single case in it, and the
+// checkout itself is the tree the gate actually runs over. A run that returned
+// exitCannot would prove nothing about a run, and it is the outcome a change to
+// the walk is most likely to produce by accident.
+//
+// A verdict here is a verdict of either colour. Pointed at the fixture corpus
+// the runner refuses a great deal, because that corpus is built out of trees
+// that exist to be refused, and that is a run rather than a failure.
+func TestAFullRunOverTheLargestTreeCompletes(t *testing.T) {
+	now := time.Date(2026, 9, 15, 12, 0, 0, 0, time.UTC)
+
+	for _, root := range []string{
+		filepath.Join("..", "..", check.FixturesDir),
+		filepath.Join("..", ".."),
+	} {
+		t.Logf("%s holds %d files", root, filesUnder(t, root))
+
+		for _, verb := range []string{"check", "list"} {
+			var out, errOut bytes.Buffer
+			code := run([]string{verb, root}, &out, &errOut, edges{
+				walk: check.Walk,
+				list: check.List,
+				now:  now,
+			})
+			if code == exitCannot {
+				t.Fatalf("lab %s over %s could not do its job: %s", verb, root, errOut.String())
+			}
+			if out.Len() == 0 {
+				t.Errorf("lab %s over %s printed nothing, so nothing was examined", verb, root)
+			}
+		}
+	}
+}
+
+// filesUnder counts the files below a directory, so the test says how large the
+// tree it ran over actually was rather than asserting that it was large.
+func filesUnder(t *testing.T, root string) int {
+	t.Helper()
+
+	files := 0
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() && d.Name() == ".git" {
+			return fs.SkipDir
+		}
+		if !d.IsDir() {
+			files++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("cannot walk %s: %v", root, err)
+	}
+	if files == 0 {
+		t.Fatalf("%s holds no files, so a run over it examines nothing", root)
+	}
+	return files
+}

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -72,26 +72,37 @@ operator. The intended-use notice is where that responsibility is placed.
 
 ## What stands behind this
 
-Nothing yet, and that is the honest answer rather than a temporary one.
-
-There is no runner in this tree, so the claim that it opens no network connection
-is a commitment about what will be built rather than a description of something
-that exists:
+The claim that the runner opens no network connection is tested, and the test
+is in the default suite. Run it:
 
 ```
-git ls-files cmd internal | wc -l
-0
+go test ./cmd/lab -count=1 -v -run 'TestTheRunnerLinksNoNetworkPackage|TestAFullRunOverTheLargestTreeCompletes'
 ```
 
-Issue #34 is where that claim gets a test that proves it, and until that lands the
-sentence above is a promise a reader has to take on trust. Issue #27 keeps the
-list of what the repository depends on, which is the other half of the same
-argument, because a tool with no dependencies has very few places for a network
-call to hide.
+Two legs, because each catches what the other misses. The first reads the
+runner's whole transitive dependency set from the toolchain and refuses any
+package that can open a socket, so a network client cannot arrive inside a
+dependency nobody read. The second runs every verb the runner has over the two
+largest trees in this repository and asserts each one reached a verdict, so a
+route that is never exercised is not mistaken for one that is clean. The test
+prints how many packages it read and how many files each tree held, so a reader
+sees the size of what was covered rather than being told it was enough.
+
+What the pair proves is that a full run executed in a binary that links nothing
+able to open a connection. That is a structural argument rather than an
+observation. Nothing here watches system calls, and a run under a tracer would
+say more while saying it on one platform only, so this is not a claim that
+something watched the process and saw no traffic. The bound is written at the
+test as well, in `cmd/lab/network_test.go`, so it is not only here.
+
+The other half of the same argument is what the repository depends on, which is
+[docs/supply-chain.md](supply-chain.md). A tool with no dependencies has very
+few places for a network call to hide, and the dependency leg above is what
+holds that true rather than assumed.
 
 The rule about real data staying on the host has no mechanism behind it and can
-have none. Nothing in a checkout can tell a number somebody measured on their own
-machine from a number they made up, and no check reads what an experiment did
-before it wrote its record. Review is where a record carrying something it should
-not is caught, and this is stated plainly here rather than left for a reader to
-assume otherwise.
+have none. Nothing in a checkout can tell a number somebody measured on their
+own machine from a number they made up, and no check reads what an experiment
+did before it wrote its record. Review is where a record carrying something it
+should not is caught, and this is stated plainly here rather than left for a
+reader to assume otherwise.


### PR DESCRIPTION
Closes #34

## What this changes

Two tests in the default suite that hold the runner to opening no network
connection, and the privacy document's evidence section rewritten to quote the
command that runs them.

## What failure it prevents

The privacy position rested on nobody having written the wrong line yet. Its own
last section said so, and it also described a tree with no runner in it and
quoted a command returning zero to show it, which stopped being true when the
runner landed. A reader who checks a document and finds it wrong about something
easy has no reason to trust it about something hard.

The dependency leg is the one that catches what will actually arrive: a helpful
update check, added with good intentions and a reasonable justification. It
cannot arrive without a network package appearing in the runner's dependency
set.

## What was run

At `efaf63d`, the head of this branch.

```
$ go test ./cmd/lab -count=1 -v -run 'TestTheRunnerLinksNoNetworkPackage|TestAFullRunOverTheLargestTreeCompletes'
    network_test.go:81: 72 packages read
--- PASS: TestTheRunnerLinksNoNetworkPackage (5.90s)
    network_test.go:130: ..\..\testdata holds 272 files
    network_test.go:130: ..\.. holds 340 files
--- PASS: TestAFullRunOverTheLargestTreeCompletes (0.07s)
ok  	github.com/Flowfin/lab/cmd/lab	8.062s
```

The guard bites, measured rather than supposed. Adding `_ "net/http"` to the
runner takes the dependency set from 72 packages to 190 and reddens the proof,
naming every network package that arrived with it:

```
$ go test ./cmd/lab -count=1 -run TestTheRunnerLinksNoNetworkPackage
--- FAIL: TestTheRunnerLinksNoNetworkPackage (6.10s)
    network_test.go:84: the runner links net/netip, net, net/url, net/textproto, net/http/httptrace, net/http/internal, net/http/internal/ascii, net/http/internal/httpcommon, net/http, so it can open an outbound connection
FAIL
```

The whole gate, with the import removed again:

```
$ go build ./... && go vet ./... && gofmt -l . && go test -count=1 ./...
ok  	github.com/Flowfin/lab/cmd/lab	4.626s
ok  	github.com/Flowfin/lab/internal/check	1.303s
ok  	github.com/Flowfin/lab/internal/hardware	1.089s
ok  	github.com/Flowfin/lab/internal/invariants	1.218s

$ go run ./cmd/lab check . | tail -2
the time this run read is 2026-08-10T05:23:17Z
0 refused
```

## What this does not do

Nothing watches system calls. What the two legs prove together is that a full
run executed in a binary that links nothing able to open a connection, which is
a structural argument and not an observation that a process was traced and no
traffic was seen. A run under a tracer would say more, and it would say it on
one of the three platforms this suite runs on. That bound is written at the test
and in the privacy document, not only here.

The issue's body also asks for the claim to be said in the operator guide. Its
done-condition does not, and there is no operator guide in this tree. That half
belongs to #42 and is not carried here.

The rule about real data staying on the host still has no mechanism and can have
none. That sentence survives this change unaltered in the privacy document,
because nothing in a checkout can tell a number somebody measured from a number
they made up.

Nothing here has been read by a second person. The commands above and their
output stand in place of that reading rather than alongside it.
