### PR TITLE
Move the pinned actions, and remove the exemption nothing starts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,54 @@
+# Keep the pinned actions current.
+#
+# Every workflow here pins the actions it uses to a commit with the version in a
+# comment. That is the right shape and it is also a shape that goes stale in
+# silence: a pin does not move when the action it names publishes a fix, and a
+# repository that pins everything and updates nothing is running the code it
+# reviewed once, for as long as nobody looks. Nothing in this tree moved those
+# pins before this file existed.
+#
+# WHAT AN UPDATE TOOL DOES NOT DO, and it belongs here rather than only in the
+# issue that asked for the file. It proposes and it does not review. A version
+# bump that arrives as a pull request has been read by nothing until somebody
+# reads it, and a green tick on that pull request says the checks passed rather
+# than that the change is wanted. Nobody should be able to read an automated
+# update as a reviewed one.
+#
+# Updates arrive as pull requests, which is the point. An update then walks the
+# same gate as any other change instead of arriving as a push nobody reads.
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    # Weekly rather than daily. The actions here are few and a daily cadence on
+    # a board with weeks between changes produces a queue of open pull requests
+    # that teaches a reader to scroll past them.
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "actions"
+    labels:
+      - ci
+      - security
+
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    # The runner has no dependencies today, so this entry finds nothing:
+    #
+    #     go list -m all
+    #     github.com/Flowfin/lab
+    #
+    # It is here rather than left out because the day that stops being true is
+    # the day somebody adds a dependency, and an entry added then is an entry
+    # somebody has to remember. Near-zero dependencies is one of the reasons the
+    # runner's language was chosen, and this is what notices when it changes.
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "go"
+    labels:
+      - ci
+      - security

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,22 @@ updates:
     # Weekly rather than daily. The actions here are few and a daily cadence on
     # a board with weeks between changes produces a queue of open pull requests
     # that teaches a reader to scroll past them.
+    #
+    # A published release does not become a pull request here for seven days.
+    # The window is what a compromised or yanked release is caught in: an
+    # account takeover that publishes a malicious version is usually found
+    # within days, and an update tool with no cooldown proposes that version
+    # while it is still the newest thing anybody has seen. The audit job in
+    # zizmor.yml refuses a configuration without one, so this is checkable
+    # rather than advisory.
+    #
+    # What it costs is that a genuine fix waits the same seven days. That is
+    # paid knowingly: nothing here is exposed to the internet, no release is
+    # published from this tree today, and a fix that cannot wait a week is one
+    # somebody moves by hand rather than one this file was going to deliver
+    # faster.
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     commit-message:
       prefix: "actions"
@@ -46,6 +62,10 @@ updates:
     # the day somebody adds a dependency, and an entry added then is an entry
     # somebody has to remember. Near-zero dependencies is one of the reasons the
     # runner's language was chosen, and this is what notices when it changes.
+    #
+    # The same window as the entry above and for the same reason.
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     commit-message:
       prefix: "go"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -56,15 +56,21 @@ jobs:
           for sha in $commits; do
             author_name=$(git show -s --format='%an' "$sha")
             author_email=$(git show -s --format='%ae' "$sha")
-            # Trusted first-party automation authors bot commits that cannot
-            # self-sign; exempt them, as the DCO App does. An explicit allowlist of
-            # GitHub's own bot identities - not a `*[bot]@...` glob - so a human
-            # cannot self-exempt by crafting a `[bot]`-shaped author email.
+            # One exemption, for the one automation that authors commits here.
+            # A bot cannot certify its own work under the DCO, so its commits
+            # are skipped as the DCO App skips them. The identity is written out
+            # rather than matched by a `*[bot]@...` glob, so a human cannot
+            # self-exempt by crafting a `[bot]`-shaped author email.
+            #
+            # What starts it is .github/dependabot.yml in this repository, so
+            # the next reader can check that claim instead of trusting it. An
+            # exemption whose actor nothing starts is an open route nobody is
+            # watching, which is why the github-actions[bot] entry that used to
+            # sit here is gone: no configuration in this tree starts it, and it
+            # authored nothing.
             case "$author_email" in
               *"+dependabot[bot]@users.noreply.github.com" \
-              | "dependabot[bot]@users.noreply.github.com" \
-              | *"+github-actions[bot]@users.noreply.github.com" \
-              | "github-actions[bot]@users.noreply.github.com")
+              | "dependabot[bot]@users.noreply.github.com")
                 echo "skip  $sha (bot: $author_email)"; continue ;;
             esac
             expected="Signed-off-by: ${author_name} <${author_email}>"


### PR DESCRIPTION
Refs #56

## What this changes

`.github/dependabot.yml`, which proposes moves for the pinned actions and for
the module's dependencies as weekly pull requests, and the sign-off workflow's
exemption list narrowed to the one automation that now authors commits here.

## What failure it prevents

A pin does not move when the action it names publishes a fix. Nothing in this
tree moved those pins and nothing said anybody should, so the repository was
running the code it reviewed once, for as long as nobody looked.

The exemption half is the defect the issue already named. The sign-off gate
exempted `github-actions[bot]`, which authored nothing here and which no
configuration in this tree starts. A guard carrying an exemption for an actor
that does not exist is an open route nobody is watching.

## What was run

At `5d96e24`, the head of this branch.

The module entry finds nothing today, which is why the comment beside it says
so:

```
$ go list -m all
github.com/Flowfin/lab
```

The narrowed case statement, run against the four author shapes it has to
separate:

```
skip 49699333+dependabot[bot]@users.noreply.github.com
skip dependabot[bot]@users.noreply.github.com
judge 41898282+github-actions[bot]@users.noreply.github.com
judge 30603423+iderex@users.noreply.github.com
```

Both spellings of the remaining exemption are skipped, and the removed one is
now judged like any other author. The labels the configuration asks for exist on
this repository:

```
$ gh label list --repo Flowfin/lab --json name --jq '.[].name'
... security ci ...
```

The whole gate:

```
$ go build ./... && go vet ./... && gofmt -l . && go test -count=1 ./...
ok  	github.com/Flowfin/lab/internal/hardware	1.416s
ok  	github.com/Flowfin/lab/internal/invariants	1.549s

$ go run ./cmd/lab check . | tail -1
0 refused
```

## What this does not do

This does not finish #56. One clause of that done-condition is that at least one
update pull request has been opened by the configuration and has run the
checks, and no such pull request exists at this commit. Whether the
configuration works is therefore claimed rather than measured here, and the
first update it opens is what settles it.

The other open clause is that the required set does not exist yet, so "has run
the checks the required set holds" has nothing to be true of. That is #26.

An update tool proposes and does not review. That sentence is in the
configuration file rather than only here, because the reader who most needs it
is somebody looking at a green tick on an automated bump.

Nothing here has been read by a second person. The commands above and their
output stand in place of that reading rather than alongside it.


