### PR TITLE
Add the field naming what an experiment needs beyond the runner

### DIFF
--- a/docs/decisions/0008-the-experiment-record.md
+++ b/docs/decisions/0008-the-experiment-record.md
@@ -1,7 +1,8 @@
 # 0008. What an experiment record looks like
 
-Superseded by 0014, which fixes what a slug may be. Everything below stands as
-it was written.
+Superseded by 0014, which fixes what a slug may be, and by 0015, which adds the
+field naming what an experiment needs beyond the runner. Everything below stands
+as it was written.
 
 ## What was decided
 

--- a/docs/decisions/0015-an-experiment-declares-the-harness-it-needs.md
+++ b/docs/decisions/0015-an-experiment-declares-the-harness-it-needs.md
@@ -1,0 +1,130 @@
+# 0015. An experiment declares the harness it needs
+
+## What was decided
+
+This record supersedes 0008. Everything that record fixes about an experiment
+record stands exactly as it is written there, and this adds one field to the
+header.
+
+`Needs-Hardware` names what an experiment needs beyond the runner, in words
+somebody can act on, or the single word `none`.
+
+    Needs-Hardware: a spinning disk with no other load on it
+    Needs-Hardware: none
+
+Record 0007 keeps the default run headless and unelevated, and a test that
+cannot meet both halves goes to the integration-hardware harness under
+`internal/hardware/` instead of skipping itself inside the default run. That
+boundary already exists. What did not exist until this record is a way for a
+reader to see which side of it an experiment sits on without opening its source,
+and a way for a machine to notice when the record and the source disagree.
+
+The field is optional, which record 0013 fixes for every field added after it,
+so a record written before this one stays legal and an absent field is never
+refused. What that costs is stated at the bottom of this section rather than
+left for somebody to discover.
+
+`none` is the reason the field can be checked in both directions. An absent
+field and a field saying `none` are the same sentence to a reader and different
+statements to a checker: the first says nothing, and the second is a claim the
+tree can contradict. Without a word for it, an experiment carrying hardware
+tests and declaring nothing would be indistinguishable from every record written
+before the field existed, and half of the rule would be unenforceable by
+construction.
+
+Two refusals follow, and both read a declaration rather than an absence.
+
+A record declaring hardware whose directory holds no test registered in that
+harness is refused. The failure is ordinary: the tests were moved into the
+default run once they stopped needing the device, and the record still tells a
+reader they need a machine they do not need.
+
+A record declaring `none` whose directory holds a test registered in that
+harness is refused. This is the direction that costs somebody an afternoon. The
+declaration says the result can be reproduced anywhere, the tests say otherwise,
+and the person who finds out is whoever cloned the repository to check the
+answer.
+
+A record declaring the field and writing nothing after the colon is refused as
+well, and it is a separate rule with a separate repair. It names no hardware and
+it does not say `none`, so there is nothing for either direction above to
+compare against, and reading it as one of the two would be a guess written into
+a checker.
+
+What a test registered in that harness is, exactly. The harness's files are
+named `*_integration_hardware_test.go` and sit behind the
+`integration_hardware` build constraint, which is the convention
+`internal/hardware/` already holds itself to and reads its own source for. This
+record fixes the same name as the marker inside an experiment directory, so a
+file that registers a test with the harness is a file whose name says so, and
+nothing has to parse Go to find one.
+
+What this does not judge, and it is most of what the field says. Whether the
+words name the hardware the tests actually need is a reader's judgement.
+`Needs-Hardware: a laptop` satisfies every rule here and tells nobody anything.
+The check holds the two claims to not contradicting each other, and the review
+is where a declaration that says nothing useful is caught.
+
+What the optional field costs, in one sentence, because it is the part somebody
+will meet later: a record that omits the field entirely is not held to either
+direction, so an experiment can carry hardware tests and stay silent about them,
+and no run refuses it.
+
+## What it applies to
+
+Every `EXPERIMENT.md` under `experiments/`, from the commit this record lands
+on, and every check that reads one.
+
+It applies to the template at `docs/experiment-template.md`, which carries the
+field with `none` filled in, because the template is what most records are
+copied from and the value that is right for almost every experiment is the one
+that should already be there.
+
+It applies to the listing, which prints what each record declares. A reader
+scanning for a result they could reproduce themselves is asking exactly this
+question, and the answer is one column rather than a file to open.
+
+It does not apply to the runner's own tests. `internal/hardware/` is the harness
+itself and is not an experiment, and the rules about a record reach nothing
+outside `experiments/`.
+
+It does not apply retroactively. Record 0013 fixes that, and the absence of the
+field in a record written earlier is not a defect in that record.
+
+## What else was considered
+
+A required field, so that every record says which side of the boundary it is on.
+
+Deriving the answer from the tree alone, with no field at all, by reporting
+which experiments hold a file registered in the harness.
+
+A boolean field rather than a field naming the hardware in words.
+
+Reading the build constraint inside each Go file rather than the file's name.
+
+## What each rejected option would have cost
+
+A required field costs what record 0013 spent a whole record refusing to spend.
+Every record written before the field existed would be refused on the day it
+landed, the default branch would be red, and the two repairs available would be
+editing records that are supposed to be permanent or weakening the check that
+had just landed. The rule is worth less than that, and the same coverage arrives
+one record at a time through the template.
+
+Deriving it from the tree costs the declaration, which is the thing worth
+having. A derived answer is always true of the tree and says nothing about what
+the author meant, so the disagreement between the two, which is the failure this
+record exists to surface, becomes impossible to state. It would also make the
+record's own claim unfalsifiable: with nothing declared, nothing can be wrong.
+
+A boolean costs the reader the only part they can act on. Knowing that an
+experiment needs hardware and not which hardware leaves somebody deciding
+whether to reproduce it exactly where they started, and the harness already
+holds its own tests to naming what they need in words for that reason.
+
+Reading the build constraint costs a Go parser pointed at whatever anybody put
+in an experiment directory, on a runner whose input is untrusted and whose
+language was chosen partly for reading almost nothing. It buys very little: a
+file behind the constraint and named for it is the convention the harness
+already enforces on itself, and a file that carries the constraint under some
+other name is not registered with the harness by any route this repository has.

--- a/docs/experiment-template.md
+++ b/docs/experiment-template.md
@@ -1,6 +1,7 @@
 Slug: the-slug-of-this-experiment
 State: asking
 Question-Written: 2026-01-01
+Needs-Hardware: none
 
 Copy this file to `experiments/<slug>/EXPERIMENT.md` and replace every value in
 the header above. The slug is the name of the directory this record sits in. The
@@ -9,8 +10,17 @@ day the question below was written, as `YYYY-MM-DD`, and it does not move
 afterwards, because the listing sorts by it. Add `Answer-Written` in the same
 change that writes the answer.
 
-The format is `docs/decisions/0008-the-experiment-record.md`. This file is a
-convenience and that record is the authority.
+`Needs-Hardware` is what this experiment needs beyond the runner, in words
+somebody deciding whether to reproduce it can act on, or `none`. It starts at
+`none` here because that is the right answer for almost every experiment. A test
+that genuinely needs a device is registered in the integration-hardware harness
+under `internal/hardware`, in a file whose name ends
+`_integration_hardware_test.go`, and a record that says one thing while the
+directory says the other is refused.
+
+The format is `docs/decisions/0008-the-experiment-record.md`, as added to by
+`docs/decisions/0015-an-experiment-declares-the-harness-it-needs.md`. This file
+is a convenience and those records are the authority.
 
 ## Question
 

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -462,6 +462,14 @@ func walkExperiments(root string, res *Result) error {
 		res.Refusals = append(res.Refusals, refuseHeaderDates(record, data)...)
 		res.Refusals = append(res.Refusals, refuseDates(record, data, res.Now)...)
 		res.Refusals = append(res.Refusals, refusePromotion(record, data)...)
+		// The only rule here that reads the directory as well as the record,
+		// which is why it takes both and why it can fail: the others judge
+		// bytes already in hand and this one walks.
+		hardwareRefusals, err := refuseHardware(experiment, record, data)
+		if err != nil {
+			return err
+		}
+		res.Refusals = append(res.Refusals, hardwareRefusals...)
 		if parsed, err := ParseRecord(data); err == nil {
 			seen.slug, seen.declaresSlug = parsed.Field(FieldSlug)
 		}

--- a/internal/check/hardware.go
+++ b/internal/check/hardware.go
@@ -1,0 +1,166 @@
+package check
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// HarnessBuildTag is the build constraint the integration-hardware harness's
+// tests sit behind, and HarnessTestSuffix is what a file holding one is called.
+//
+// Both are written here rather than imported from internal/hardware, because
+// that package imports testing and the runner is a program somebody runs rather
+// than a test binary. TestTheHarnessNamesAreTheHarnessesOwn imports it from the
+// suite and holds the two equal, so the copy cannot drift in silence.
+const (
+	HarnessBuildTag   = "integration_hardware"
+	HarnessTestSuffix = "_" + HarnessBuildTag + "_test.go"
+)
+
+// The properties a record's hardware declaration can be refused for.
+const (
+	// RecordHardwareDeclarationIsEmpty refuses a record that declares
+	// Needs-Hardware and writes nothing after the colon. Record 0013 makes an
+	// absent field legal and an empty declaration a different statement, and
+	// this is the second one: it names no hardware and it does not say none,
+	// so neither direction of the rule below has anything to compare against.
+	// Reading it as one of the two would be a guess written into a checker.
+	RecordHardwareDeclarationIsEmpty = "record-hardware-declaration-is-empty"
+
+	// RecordHardwareDeclarationDisagreesWithItsTests refuses a declaration the
+	// experiment's own directory contradicts, at two sites.
+	//
+	// A record naming hardware whose directory registers no test with the
+	// harness is the ordinary half. The tests moved into the default run once
+	// they stopped needing the device and the record still sends a reader
+	// looking for one.
+	//
+	// A record saying none whose directory registers a test with the harness is
+	// the half worth the fixture. It passes every other rule in this tree, it
+	// reads as a result anybody can reproduce, and the person who finds out
+	// otherwise is whoever cloned the repository to check the answer.
+	RecordHardwareDeclarationDisagreesWithItsTests = "record-hardware-declaration-disagrees-with-its-tests"
+)
+
+// refuseHardware holds a record's hardware declaration to what its directory
+// registers with the integration-hardware harness.
+//
+// WHAT IT DOES NOT JUDGE, and this is most of what the field says. Whether the
+// words name the hardware the tests actually need is a reader's judgement, and
+// a declaration of "a laptop" satisfies every rule here. What a green run says
+// is that the record and the directory do not contradict each other.
+//
+// WHERE IT DOES NOT REACH. An absent field is never refused, which record 0013
+// fixes, so an experiment carrying hardware tests and declaring nothing at all
+// passes this. That is the price of a format that can grow without turning
+// older records red, it is paid deliberately, and the template is what closes
+// the gap for records written from here on rather than a refusal.
+//
+// A record whose bytes do not parse as a record is not judged here, for the
+// reason refuseState and refuseHeaderDates both give: nothing can read a field
+// out of a file that has no header.
+func refuseHardware(experiment, path string, data []byte) ([]Refusal, error) {
+	record, err := ParseRecord(data)
+	if err != nil {
+		return nil, nil
+	}
+
+	declared, present := record.Field(FieldNeedsHardware)
+	if !present {
+		return nil, nil
+	}
+
+	if strings.TrimSpace(declared) == "" {
+		return []Refusal{{
+			Property: RecordHardwareDeclarationIsEmpty,
+			Subject:  path,
+			Detail: fmt.Sprintf("it declares %s and writes nothing after the colon, so it names no hardware and does not say %s",
+				FieldNeedsHardware, HardwareNone),
+		}}, nil
+	}
+
+	registered, err := harnessTestsUnder(experiment)
+	if err != nil {
+		return nil, err
+	}
+
+	if declared == HardwareNone {
+		if len(registered) == 0 {
+			return nil, nil
+		}
+		return []Refusal{{
+			Property: RecordHardwareDeclarationDisagreesWithItsTests,
+			Subject:  path,
+			Detail: fmt.Sprintf("it says %s: %s and %s is registered with the %s harness, so it reads as a result anybody can reproduce",
+				FieldNeedsHardware, HardwareNone, strings.Join(registered, ", "), HarnessBuildTag),
+		}}, nil
+	}
+
+	if len(registered) > 0 {
+		return nil, nil
+	}
+	return []Refusal{{
+		Property: RecordHardwareDeclarationDisagreesWithItsTests,
+		Subject:  path,
+		Detail: fmt.Sprintf("it says %s: %s and no file under %s is named %s, so nothing in it is registered with that harness. a record that needs nothing says %s",
+			FieldNeedsHardware, declared, filepath.ToSlash(experiment), "*"+HarnessTestSuffix, HardwareNone),
+	}}, nil
+}
+
+// harnessTestsUnder returns the files in an experiment directory that register
+// a test with the integration-hardware harness, in the order the walk reached
+// them, relative to that directory.
+//
+// Registration is read from the file's name and from nothing else. That is the
+// convention internal/hardware already holds its own files to, and the
+// alternative is a Go parser pointed at whatever somebody put in an experiment
+// directory, on a runner whose input is untrusted. A file carrying the build
+// constraint under some other name is not registered with the harness by any
+// route this repository has, so there is nothing there to miss.
+//
+// The walk is bounded below the experiment directory by the same depth the
+// stray-record walk uses, for the same reason: the cost of reading a tree is
+// whatever the tree makes it, and a bound is what keeps a run finite against a
+// directory nobody wrote by hand. A directory below the bound is not descended
+// into, and TheTreeIsDeeperThanTheWalkReads is what refuses the tree that
+// reaches it.
+func harnessTestsUnder(experiment string) ([]string, error) {
+	var registered []string
+
+	// filepath.WalkDir does not follow symbolic links, so a link pointing out
+	// of the experiment is reported as a link and never descended into.
+	err := filepath.WalkDir(experiment, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			deeper, err := depthOf(experiment, path)
+			if err != nil {
+				return err
+			}
+			if deeper > WalkDepthBound {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !entry.Type().IsRegular() || !strings.HasSuffix(entry.Name(), HarnessTestSuffix) {
+			return nil
+		}
+		relative, err := filepath.Rel(experiment, path)
+		if err != nil {
+			return fmt.Errorf("cannot place %s inside %s: %w", path, experiment, err)
+		}
+		registered = append(registered, filepath.ToSlash(relative))
+		return nil
+	})
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("cannot walk %s: %w", experiment, err)
+	}
+	return registered, nil
+}

--- a/internal/check/hardware_test.go
+++ b/internal/check/hardware_test.go
@@ -1,0 +1,85 @@
+package check
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Flowfin/lab/internal/hardware"
+)
+
+// TestTheHarnessNamesAreTheHarnessesOwn holds the copy in this package equal to
+// the harness it is about. The runner cannot import internal/hardware, which
+// imports testing, so the tag is written twice, and a string written twice is a
+// string that drifts. This is the only place the two meet, and the suite is
+// where they may meet because a test binary is allowed to import a test harness.
+//
+// The second leg is the one that would actually catch a rename. The harness
+// finds its own files by that suffix, so a file in it carrying the suffix is
+// evidence that the marker this package looks for in an experiment directory is
+// the marker the harness uses.
+func TestTheHarnessNamesAreTheHarnessesOwn(t *testing.T) {
+	if HarnessBuildTag != hardware.BuildTag {
+		t.Errorf("this package reads %q as the harness constraint and the harness calls it %q", HarnessBuildTag, hardware.BuildTag)
+	}
+
+	entries, err := os.ReadDir("../hardware")
+	if err != nil {
+		t.Fatalf("cannot read the harness package: %v", err)
+	}
+	found := 0
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), HarnessTestSuffix) {
+			found++
+		}
+	}
+	if found == 0 {
+		t.Errorf("no file in the harness is named %s, so the marker this package looks for names nothing", "*"+HarnessTestSuffix)
+	}
+}
+
+// TestWhatCountsAsRegisteredWithTheHarness holds the read the refusal rests on.
+// The rule is a comparison between a declaration and this answer, so a wrong
+// answer here refuses an honest record and clears a dishonest one, and neither
+// failure is visible in the refusal set a case declares.
+func TestWhatCountsAsRegisteredWithTheHarness(t *testing.T) {
+	tests := []struct {
+		name  string
+		count int
+	}{
+		{name: "a-record-that-needs-hardware-and-registers-a-test", count: 1},
+		{name: "a-record-that-needs-nothing-and-registers-a-test", count: 1},
+		{name: "a-record-that-needs-hardware-and-registers-no-test", count: 0},
+		{name: "a-record-that-needs-nothing-and-registers-no-test", count: 0},
+		// An ordinary experiment directory that holds a record and nothing
+		// else registers nothing, which is what almost every one of them is.
+		{name: "one-experiment-with-a-record", count: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			registered, err := harnessTestsUnder(filepath.Join(casesDir, tc.name, "tree", "experiments", "one"))
+			if err != nil {
+				t.Fatalf("reading the directory failed: %v", err)
+			}
+			if len(registered) != tc.count {
+				t.Fatalf("read %v as registered with the harness, want %d file(s)", registered, tc.count)
+			}
+		})
+	}
+}
+
+// TestADirectoryThatIsNotThereRegistersNothing is the boundary between this
+// read and the refusal that already covers its case. A directory under
+// experiments/ with no record at all is refused by ExperimentHasNoRecord, and a
+// second refusal about its harness files would name a repair nobody needs.
+func TestADirectoryThatIsNotThereRegistersNothing(t *testing.T) {
+	registered, err := harnessTestsUnder(filepath.Join(casesDir, "no-experiments-directory", "tree", "experiments", "nothing-here"))
+	if err != nil {
+		t.Fatalf("reading a directory that is not there failed: %v", err)
+	}
+	if len(registered) != 0 {
+		t.Fatalf("read %v as registered, want nothing", registered)
+	}
+}

--- a/internal/check/list.go
+++ b/internal/check/list.go
@@ -22,6 +22,13 @@ const (
 	stateNotWritten = "not written"
 )
 
+// What the hardware column says about a record that carries no such field.
+// Record 0013 makes the field optional and record 0015 adds it, so a record
+// written before it declares nothing, and "not declared" is a different
+// statement from "none". Collapsing the two would let the listing report a
+// silence as a claim.
+const hardwareNotDeclared = "not declared"
+
 // An Entry is one experiment as the listing reads it. Nothing here is refused
 // and nothing is judged. Where a field cannot be read, the column says so.
 type Entry struct {
@@ -43,6 +50,13 @@ type Entry struct {
 
 	// Dated says whether Written was read from a date.
 	Dated bool
+
+	// NeedsHardware is the Needs-Hardware field as it was written, or one of
+	// the strings above where there is none to print. It is shown rather than
+	// judged: a declaration the directory contradicts is a refusal the
+	// checker produces, and repeating that judgement here would put a verdict
+	// in a report.
+	NeedsHardware string
 }
 
 // Waiting is how long an experiment has been asking, in whole days, and
@@ -173,7 +187,7 @@ func List(root string, now time.Time) (Listing, error) {
 // that stops at the first unreadable record tells a reader nothing about the
 // rest of the tree.
 func readEntry(dir, slug string) Entry {
-	entry := Entry{Slug: slug, State: stateNoRecord, QuestionWritten: stateNoRecord}
+	entry := Entry{Slug: slug, State: stateNoRecord, QuestionWritten: stateNoRecord, NeedsHardware: stateNoRecord}
 
 	data, err := os.ReadFile(filepath.Join(dir, RecordName))
 	if err != nil {
@@ -183,7 +197,16 @@ func readEntry(dir, slug string) Entry {
 	if err != nil {
 		entry.State = stateUnreadable
 		entry.QuestionWritten = stateUnreadable
+		entry.NeedsHardware = stateUnreadable
 		return entry
+	}
+
+	entry.NeedsHardware = hardwareNotDeclared
+	if needs, present := record.Field(FieldNeedsHardware); present {
+		entry.NeedsHardware = needs
+		if strings.TrimSpace(needs) == "" {
+			entry.NeedsHardware = stateNotWritten
+		}
 	}
 
 	entry.State = stateNotWritten
@@ -222,10 +245,16 @@ func asking(e Entry) bool { return e.State == StateAsking }
 // it found before printing any of them, so a run that found none is a sentence
 // rather than an empty screen a reader has to interpret.
 //
-// The columns are the four the verb exists for: the slug, the state, the date
-// the question was written, and how long anything still asking has been there.
-// Nothing else, because a listing wide enough to wrap stops being scannable and
-// scanning it is the whole point.
+// The columns are the ones the verb exists for: the slug, the state, the date
+// the question was written, how long anything still asking has been there, and
+// what the record says it needs beyond the runner. Nothing else, because a
+// listing wide enough to wrap stops being scannable and scanning it is the
+// whole point.
+//
+// The last column is here because the reader this verb is written for is
+// deciding what to do about an experiment, and whether they could reproduce it
+// on the machine in front of them is part of that. Record 0015 adds the field
+// and this prints what it says without judging it.
 func (l Listing) Report(now time.Time) string {
 	out := fmt.Sprintf("examined %s\n", l.Root)
 	if !l.ExperimentsPresent {
@@ -237,16 +266,16 @@ func (l Listing) Report(now time.Time) string {
 		return out
 	}
 
-	rows := [][4]string{{"slug", "state", "question written", "waiting"}}
+	rows := [][5]string{{"slug", "state", "question written", "waiting", "needs"}}
 	for _, entry := range l.Entries {
 		waiting := "-"
 		if days, counted := entry.Waiting(now); counted {
 			waiting = fmt.Sprintf("%d %s", days, plural(days, "day", "days"))
 		}
-		rows = append(rows, [4]string{entry.Slug, entry.State, entry.QuestionWritten, waiting})
+		rows = append(rows, [5]string{entry.Slug, entry.State, entry.QuestionWritten, waiting, entry.NeedsHardware})
 	}
 
-	var width [4]int
+	var width [5]int
 	for _, row := range rows {
 		for i, cell := range row {
 			if len(cell) > width[i] {

--- a/internal/check/list_test.go
+++ b/internal/check/list_test.go
@@ -115,11 +115,33 @@ func TestTheListingReadsWhatItCanAndSaysWhatItCannot(t *testing.T) {
 	}
 }
 
-// TestTheReportPrintsTheFourColumns compares the whole report against the
+// TestTheHardwareColumnKeepsSilenceApartFromAClaim is the half of the column
+// that is easy to lose. A record written before the field existed declares
+// nothing, and a record saying none declares something a tree can contradict.
+// Printing both as an empty cell, or both as none, would report a silence as a
+// claim, which is the one thing this column must not do.
+func TestTheHardwareColumnKeepsSilenceApartFromAClaim(t *testing.T) {
+	want := map[string]string{
+		"oldest-question":  "a spinning disk",
+		"newer-question":   HardwareNone,
+		"already-answered": hardwareNotDeclared,
+		"given-up":         hardwareNotDeclared,
+		"no-header":        stateUnreadable,
+		"no-record-at-all": stateNoRecord,
+	}
+
+	for _, entry := range read(t, "several-experiments").Entries {
+		if entry.NeedsHardware != want[entry.Slug] {
+			t.Errorf("%s declares %q, want %q", entry.Slug, entry.NeedsHardware, want[entry.Slug])
+		}
+	}
+}
+
+// TestTheReportPrintsEveryColumn compares the whole report against the
 // output stored beside the tree. Comparing the whole thing is what makes it
 // mean something: an assertion that a slug appears somewhere would pass on a
 // listing whose columns had silently swapped.
-func TestTheReportPrintsTheFourColumns(t *testing.T) {
+func TestTheReportPrintsEveryColumn(t *testing.T) {
 	name := "several-experiments"
 	got := read(t, name).Report(listingNow)
 

--- a/internal/check/record.go
+++ b/internal/check/record.go
@@ -26,7 +26,18 @@ const (
 	// FieldAnswerWritten is the date the answer was written. It is absent
 	// until there is an answer.
 	FieldAnswerWritten = "Answer-Written"
+
+	// FieldNeedsHardware is what an experiment needs beyond the runner, in
+	// words somebody can act on, or HardwareNone. Record 0015 adds it and
+	// record 0013 makes it optional, so it is absent from every record
+	// written before it and that is never a refusal.
+	FieldNeedsHardware = "Needs-Hardware"
 )
+
+// HardwareNone is how a record says it needs nothing beyond the runner. It is
+// the word that makes the declaration checkable in both directions: an absent
+// field says nothing a tree can contradict, and this says something it can.
+const HardwareNone = "none"
 
 // The three states record 0003 fixes, written exactly as that record writes
 // them.

--- a/internal/check/record_test.go
+++ b/internal/check/record_test.go
@@ -25,10 +25,19 @@ func TestTheTemplateParses(t *testing.T) {
 		t.Fatalf("the template does not parse: %v", err)
 	}
 
-	for _, name := range []string{FieldSlug, FieldState, FieldQuestionWritten} {
+	for _, name := range []string{FieldSlug, FieldState, FieldQuestionWritten, FieldNeedsHardware} {
 		if _, present := rec.Field(name); !present {
 			t.Errorf("the template carries no %s field", name)
 		}
+	}
+
+	// The template carries the hardware declaration filled in rather than
+	// blank. Record 0013 keeps the field optional forever, so the template is
+	// the only thing that makes it usual, and a template shipping it empty
+	// would teach every new record to trip the refusal over an empty
+	// declaration on its first commit.
+	if needs, _ := rec.Field(FieldNeedsHardware); needs != HardwareNone {
+		t.Errorf("the template declares %s: %q, want %q", FieldNeedsHardware, needs, HardwareNone)
 	}
 
 	// Answer-Written is absent on purpose. A template that carried it would

--- a/testdata/cases/a-record-declaring-hardware-with-nothing-after-the-colon/expected
+++ b/testdata/cases/a-record-declaring-hardware-with-nothing-after-the-colon/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/a-record-declaring-hardware-with-nothing-after-the-colon/expected-refusals
+++ b/testdata/cases/a-record-declaring-hardware-with-nothing-after-the-colon/expected-refusals
@@ -1,0 +1,1 @@
+record-hardware-declaration-is-empty

--- a/testdata/cases/a-record-declaring-hardware-with-nothing-after-the-colon/near-neighbour
+++ b/testdata/cases/a-record-declaring-hardware-with-nothing-after-the-colon/near-neighbour
@@ -1,0 +1,1 @@
+a-record-that-needs-nothing-and-registers-no-test

--- a/testdata/cases/a-record-declaring-hardware-with-nothing-after-the-colon/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/a-record-declaring-hardware-with-nothing-after-the-colon/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,14 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+Needs-Hardware:
+
+## Question
+
+Does a sequential write get slower as the disk fills?
+
+## Method
+
+It was measured on the machine the record names.
+
+## Answer

--- a/testdata/cases/a-record-that-needs-hardware-and-registers-a-test/expected
+++ b/testdata/cases/a-record-that-needs-hardware-and-registers-a-test/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/a-record-that-needs-hardware-and-registers-a-test/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/a-record-that-needs-hardware-and-registers-a-test/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,14 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+Needs-Hardware: a spinning disk
+
+## Question
+
+Does a sequential write get slower as the disk fills?
+
+## Method
+
+It was measured on the machine the record names.
+
+## Answer

--- a/testdata/cases/a-record-that-needs-hardware-and-registers-a-test/tree/experiments/one/measure_integration_hardware_test.go
+++ b/testdata/cases/a-record-that-needs-hardware-and-registers-a-test/tree/experiments/one/measure_integration_hardware_test.go
@@ -1,0 +1,13 @@
+//go:build integration_hardware
+
+package one
+
+import "testing"
+
+// A fixture. Nothing compiles it: the go tool ignores every directory named
+// testdata, and this file is behind the harness constraint as well. What it
+// exists for is its name, which is how a record's declaration is checked
+// against what the directory registers.
+func TestSequentialWriteOnASpinningDisk(t *testing.T) {
+	t.Skip("a fixture")
+}

--- a/testdata/cases/a-record-that-needs-hardware-and-registers-no-test/expected
+++ b/testdata/cases/a-record-that-needs-hardware-and-registers-no-test/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/a-record-that-needs-hardware-and-registers-no-test/expected-refusals
+++ b/testdata/cases/a-record-that-needs-hardware-and-registers-no-test/expected-refusals
@@ -1,0 +1,1 @@
+record-hardware-declaration-disagrees-with-its-tests

--- a/testdata/cases/a-record-that-needs-hardware-and-registers-no-test/near-neighbour
+++ b/testdata/cases/a-record-that-needs-hardware-and-registers-no-test/near-neighbour
@@ -1,0 +1,1 @@
+a-record-that-needs-hardware-and-registers-a-test

--- a/testdata/cases/a-record-that-needs-hardware-and-registers-no-test/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/a-record-that-needs-hardware-and-registers-no-test/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,14 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+Needs-Hardware: a spinning disk
+
+## Question
+
+Does a sequential write get slower as the disk fills?
+
+## Method
+
+It was measured on the machine the record names.
+
+## Answer

--- a/testdata/cases/a-record-that-needs-nothing-and-registers-a-test/expected
+++ b/testdata/cases/a-record-that-needs-nothing-and-registers-a-test/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/a-record-that-needs-nothing-and-registers-a-test/expected-refusals
+++ b/testdata/cases/a-record-that-needs-nothing-and-registers-a-test/expected-refusals
@@ -1,0 +1,1 @@
+record-hardware-declaration-disagrees-with-its-tests

--- a/testdata/cases/a-record-that-needs-nothing-and-registers-a-test/near-neighbour
+++ b/testdata/cases/a-record-that-needs-nothing-and-registers-a-test/near-neighbour
@@ -1,0 +1,1 @@
+a-record-that-needs-nothing-and-registers-no-test

--- a/testdata/cases/a-record-that-needs-nothing-and-registers-a-test/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/a-record-that-needs-nothing-and-registers-a-test/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,14 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+Needs-Hardware: none
+
+## Question
+
+Does a sequential write get slower as the disk fills?
+
+## Method
+
+It was measured on the machine the record names.
+
+## Answer

--- a/testdata/cases/a-record-that-needs-nothing-and-registers-a-test/tree/experiments/one/measure_integration_hardware_test.go
+++ b/testdata/cases/a-record-that-needs-nothing-and-registers-a-test/tree/experiments/one/measure_integration_hardware_test.go
@@ -1,0 +1,13 @@
+//go:build integration_hardware
+
+package one
+
+import "testing"
+
+// A fixture. Nothing compiles it: the go tool ignores every directory named
+// testdata, and this file is behind the harness constraint as well. What it
+// exists for is its name, which is how a record's declaration is checked
+// against what the directory registers.
+func TestSequentialWriteOnASpinningDisk(t *testing.T) {
+	t.Skip("a fixture")
+}

--- a/testdata/cases/a-record-that-needs-nothing-and-registers-no-test/expected
+++ b/testdata/cases/a-record-that-needs-nothing-and-registers-no-test/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/a-record-that-needs-nothing-and-registers-no-test/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/a-record-that-needs-nothing-and-registers-no-test/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,14 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+Needs-Hardware: none
+
+## Question
+
+Does a sequential write get slower as the disk fills?
+
+## Method
+
+It was measured on the machine the record names.
+
+## Answer

--- a/testdata/listings/several-experiments/expected-report
+++ b/testdata/listings/several-experiments/expected-report
@@ -1,10 +1,10 @@
 examined ../../testdata/listings/several-experiments/tree
 6 experiments
 the time this run read is 2026-09-15T12:00:00Z
-  slug              state       question written  waiting
-  oldest-question   asking      2026-05-01        137 days
-  newer-question    asking      2026-07-15        62 days
-  given-up          abandoned   2026-03-01        -
-  already-answered  answered    2026-04-01        -
-  no-header         unreadable  unreadable        -
-  no-record-at-all  no record   no record         -
+  slug              state       question written  waiting   needs
+  oldest-question   asking      2026-05-01        137 days  a spinning disk
+  newer-question    asking      2026-07-15        62 days   none
+  given-up          abandoned   2026-03-01        -         not declared
+  already-answered  answered    2026-04-01        -         not declared
+  no-header         unreadable  unreadable        -         unreadable
+  no-record-at-all  no record   no record         -         no record

--- a/testdata/listings/several-experiments/tree/experiments/newer-question/EXPERIMENT.md
+++ b/testdata/listings/several-experiments/tree/experiments/newer-question/EXPERIMENT.md
@@ -1,6 +1,7 @@
 Slug: newer-question
 State: asking
 Question-Written: 2026-07-15
+Needs-Hardware: none
 
 # newer-question
 

--- a/testdata/listings/several-experiments/tree/experiments/oldest-question/EXPERIMENT.md
+++ b/testdata/listings/several-experiments/tree/experiments/oldest-question/EXPERIMENT.md
@@ -1,6 +1,7 @@
 Slug: oldest-question
 State: asking
 Question-Written: 2026-05-01
+Needs-Hardware: a spinning disk
 
 # oldest-question
 

--- a/testdata/listings/several-experiments/tree/experiments/oldest-question/measure_integration_hardware_test.go
+++ b/testdata/listings/several-experiments/tree/experiments/oldest-question/measure_integration_hardware_test.go
@@ -1,0 +1,12 @@
+//go:build integration_hardware
+
+package oldestquestion
+
+import "testing"
+
+// A fixture. It exists so that this tree reads the same way under both verbs:
+// the record declares a spinning disk and this is the file that registers a
+// test with the harness, so a walk of this tree refuses nothing either.
+func TestSequentialWriteOnASpinningDisk(t *testing.T) {
+	t.Skip("a fixture")
+}


### PR DESCRIPTION
Closes #32

## What this changes

Record `0015` supersedes `0008` and adds one header field, `Needs-Hardware`. It
names what an experiment needs beyond the runner, in words somebody deciding
whether to reproduce it can act on, or the single word `none`.

Record `0013` makes a field added after it optional, so nothing already on the
default branch turns red and an absent field is never refused. `none` is what
makes the declaration checkable in both directions: an absent field says
nothing a tree can contradict, and `none` says something it can. Without a word
for it, an experiment carrying hardware tests and declaring nothing would be
indistinguishable from every record written before the field existed, and half
the rule would be unenforceable by construction.

Two properties.

`record-hardware-declaration-disagrees-with-its-tests`, at two sites. A record
naming hardware whose directory registers no test with the integration-hardware
harness, and a record saying `none` whose directory registers one.

`record-hardware-declaration-is-empty`, for a declaration written with nothing
after the colon. It names no hardware and it does not say `none`, so neither
direction above has anything to compare against, and reading it as one of the
two would be a guess written into a checker. Measurement 4 below is what shows
the two rules are genuinely different rather than one rule split for tidiness.

What counts as registered with the harness is a file named
`*_integration_hardware_test.go`. That is the convention `internal/hardware`
already holds its own files to and reads its own source for, so nothing here
parses Go inside an experiment directory.

`lab list` gains a column. `not declared` and `none` print as different cells,
because a record written before the field existed said nothing and a record
saying `none` made a claim, and collapsing the two would report a silence as a
claim.

The means is Go, in the packages that already exist, with the fixtures the
harness already reads. It carries the three rules: the properties are refusable
at one choke point, each has a ledger-style case proving it bites with a near
neighbour that refuses nothing, and every number below carries the command that
produced it. It adds no language, no runtime and no dependency, which is what
the rejected alternative of parsing build constraints inside experiment code
would have cost.

## What failure it prevents

An experiment whose tests quietly need a device lands in the default run and
fails on a machine that does not have one, and whoever sees the red board next
cannot tell a broken change from a missing disk. Record `0007` already sends
such a test to the harness. What was missing is the record saying which side of
that boundary the experiment sits on, and a machine noticing when the record
and the directory disagree.

The half that costs somebody real time is the second one. A record saying
`none` over a directory full of hardware tests reads as a result anybody can
reproduce, it passes every other rule in this tree, and the person who finds
out otherwise is whoever cloned the repository to check the answer.

## What was run

At `e230a5b`, from the root of a checkout.

```
go build ./...
go vet ./...
gofmt -l .
(no output)
go test -count=1 ./...
ok  	github.com/Flowfin/lab/cmd/lab	7.718s
ok  	github.com/Flowfin/lab/internal/check	1.355s
ok  	github.com/Flowfin/lab/internal/hardware	1.291s
ok  	github.com/Flowfin/lab/internal/invariants	1.459s

go run ./cmd/lab check .
examined .
no experiments directory in this tree
0 experiment directories walked, 0 records read
16 decision records read
the time this run read is 2026-08-11T15:49:46Z
0 refused
```

Each guard was then deleted and the suite watched. Four measurements, each one
reverted before the next.

The walk no longer calling the rule at all:

```
--- FAIL: TestCases/a-record-that-needs-nothing-and-registers-a-test
    check_test.go:51: expected refusal not produced: record-hardware-declaration-disagrees-with-its-tests
--- FAIL: TestCases/a-record-declaring-hardware-with-nothing-after-the-colon
    check_test.go:51: expected refusal not produced: record-hardware-declaration-is-empty
--- FAIL: TestCases/a-record-that-needs-hardware-and-registers-no-test
    check_test.go:51: expected refusal not produced: record-hardware-declaration-disagrees-with-its-tests
```

The arm over a record saying `none`, removed on its own:

```
--- FAIL: TestCases/a-record-that-needs-nothing-and-registers-a-test
    check_test.go:51: expected refusal not produced: record-hardware-declaration-disagrees-with-its-tests
```

The arm over a record naming hardware, removed on its own:

```
--- FAIL: TestCases/a-record-that-needs-hardware-and-registers-no-test
    check_test.go:51: expected refusal not produced: record-hardware-declaration-disagrees-with-its-tests
```

The empty-declaration rule, removed on its own. It goes red twice, and the
second line is the argument for the rule existing separately: without it the
empty declaration falls through and is refused by the wrong rule, which would
send the reader to the wrong repair.

```
--- FAIL: TestCases/a-record-declaring-hardware-with-nothing-after-the-colon
    check_test.go:51: expected refusal not produced: record-hardware-declaration-is-empty
    check_test.go:51: refusal produced that no case expected: record-hardware-declaration-disagrees-with-its-tests
```

The suite is green again with all four reverted, which is the last block under
`go test` above.

No second person has read this change. The measurements above stand in place of
that reading and do not replace it.

## What this does not do

It does not refuse an absence. An experiment carrying hardware tests and
declaring nothing at all passes, which record `0013` fixes for every field added
after it and which is written at the check as well as here. The template
carrying the field filled in is what closes the gap for records written from
here on, and it is not a refusal.

It does not judge whether the words are true. `Needs-Hardware: a laptop`
satisfies every rule here and tells a reader nothing. What a green run says is
that the record and the directory do not contradict each other.

It reads a filename rather than a build constraint. A file carrying the
constraint under some other name is not registered with the harness by any
route this repository has, so there is nothing there to miss today, and that is
a property of the harness rather than of this check.

The listing column reports and does not judge. A declaration the directory
contradicts is a refusal the checker produces, and repeating that verdict in a
report would put a judgement where a reader expects a reading.

The diff is larger than the size this board reads comfortably in one sitting.
Most of it is the decision record and the five fixture trees; the runner gains
about a hundred and sixty lines. It is one topic and it was not split, because
the field, the refusals, the template and the column are four halves of one
statement and none of them is reviewable without the others.
