### PR TITLE
Judge the pull request rather than only the tree it lands

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,87 @@
+# The pull request itself, checked on the way in.
+#
+# Every other check here reads a checkout. The record checks walk experiments/,
+# the invariants read tracked text, the formatting rules read the bytes around
+# the words, and the build and test workflow says the runner compiles and its
+# tests pass. None of them can see the change: whether it says which problem it
+# solves, and whether the record moved with the code it describes. That class is
+# what this one is for.
+#
+# WHAT IT DOES NOT JUDGE. It never asks whether the change is good and it never
+# says the change was read. Each rule is a property of the shape of a pull
+# request rather than of its content: that a number was written down, not that
+# it is the right number; that two files moved together, not that what they say
+# agrees. The reasons are written at the rules themselves, in
+# internal/pullrequest/, rather than only here.
+#
+# It runs on pull requests and on nothing else. A push carries no pull request,
+# so a run there could only report that it judged nothing, and a green tick over
+# a run that judged nothing is the reading this whole check is built to prevent.
+# There is no path filter and no job-level condition, so the context arrives on
+# every pull request rather than on the ones somebody expected it to matter for.
+#
+# The check name below is what a required set refers to later, and a job renamed
+# in passing removes itself from that set while the tab still looks green. The
+# name is written here rather than left to the job id for that reason, and
+# changing it is a change to the gate rather than tidying.
+#
+# Hardened the way every other workflow in this tree is, because the audit job in
+# zizmor.yml refuses a new one that departs from it: permissions denied at the
+# top and granted per job, every action pinned to a commit with its version in a
+# comment, and checkout without persisted credentials.
+name: Pull request
+
+on:
+  pull_request:
+    branches: ["**"]
+
+# Explicit deny-all at workflow level; the job below grants only what it needs.
+permissions: {}
+
+# Cancel a superseded run on the same ref. Nothing here publishes, so a run that
+# has been overtaken is safe to drop.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pull-request:
+    name: pull request
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The whole history, because the check reads the range between the two
+          # ends of the pull request and a shallow clone has no commit the two
+          # ends agree on. Without this the check cannot do its job, which it
+          # reports as such rather than as a clean pull request.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          # The toolchain comes from go.mod, so the version this job uses moves
+          # when the module says so and never separately.
+          go-version-file: go.mod
+          # This module has no dependencies and therefore no go.sum for a cache
+          # key to be built from. Asking for a cache anyway makes the step
+          # depend on a file that is not there.
+          cache: false
+
+      - name: Judge this pull request
+        # Built from this commit rather than downloaded, so a change that breaks
+        # a refusal is caught by the pull request that made it. The exit codes
+        # are the contract in docs/decisions/0011-the-exit-codes.md: 0 refused
+        # nothing, 1 refused something, 2 could not do the job. This step keys
+        # on all three by letting the command's own code become the job's.
+        #
+        # Nothing is expanded into this line. What the check reads about the
+        # pull request it reads out of the event file the platform wrote, whose
+        # path is in the environment, so no value an author controls is ever
+        # part of a command.
+        run: go run ./cmd/pullrequest

--- a/cmd/pullrequest/main.go
+++ b/cmd/pullrequest/main.go
@@ -1,0 +1,215 @@
+// Command pullrequest judges a pull request and is the only thing in this
+// repository that talks to git. It reads the event the platform wrote, asks git
+// what the range contains, hands both to internal/pullrequest, prints what it
+// examined and returns what record 0011 says it should return.
+//
+// WHY THIS IS NOT A VERB OF THE RUNNER. lab reads a checkout and writes
+// nothing, which is a claim a downloader is asked to take on trust, and every
+// document here repeats it. Telling a change from the tree it lands needs both
+// ends of a range, which is history rather than a checkout, and the only thing
+// that can answer about history is git. Putting that inside lab would ship a
+// verb that is useless everywhere except inside a workflow and would widen what
+// an operator has to believe about a binary they downloaded. Keeping it here
+// costs a second entry point under cmd/, which record 0002 does not name, and
+// that is the one judgement in this file a reader should check rather than
+// accept.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/Flowfin/lab/internal/pullrequest"
+)
+
+// The exit codes. Decision record 0011 is the contract, and this command
+// returns the same three the runner does, for the same reasons, which is why
+// they are written here with the record named rather than invented. The
+// integration-hardware harness declares its own code where its producer is, and
+// this follows that shape: a code lives next to the thing that can return it.
+const (
+	// exitClean means the run completed and refused nothing. It does not mean
+	// the pull request is good, only that nothing this check judges was found
+	// wrong, and the report says what it examined so the two are not confused.
+	exitClean = 0
+
+	// exitRefused means the run completed and refused something. It is the
+	// only code that carries refusals.
+	exitRefused = 1
+
+	// exitCannot means the check could not do its job: no event to read, a
+	// payload it cannot parse, a range git will not answer about. It is
+	// deliberately not the code a refusal returns, because a gate that treats
+	// a broken invocation like a violation reports one as the other and
+	// nobody investigates either.
+	exitCannot = 2
+)
+
+func main() {
+	os.Exit(run(os.Stdout, os.Stderr, edges{
+		event: eventFromTheEnvironment,
+		git:   gitInThisCheckout,
+	}))
+}
+
+// edges is everything this command reaches for that is not its own logic: the
+// event the platform wrote and git. Both are parameters so that what the
+// command prints and what it returns can be read by a test without a pull
+// request, a platform or a repository existing.
+type edges struct {
+	event func() ([]byte, error)
+	git   func(args ...string) ([]byte, error)
+}
+
+// run is main with its edges passed in.
+func run(out, errOut io.Writer, e edges) int {
+	data, err := e.event()
+	if err != nil {
+		fmt.Fprintf(errOut, "pullrequest: %v\n", err)
+		return exitCannot
+	}
+
+	event, err := pullrequest.ParseEvent(data)
+	if err != nil {
+		fmt.Fprintf(errOut, "pullrequest: %v\n", err)
+		return exitCannot
+	}
+	if !event.IsPullRequest {
+		// Asked to judge a pull request where there is none. This is a broken
+		// invocation rather than a clean run, and the difference matters more
+		// here than anywhere else in this repository: a check that answered
+		// zero refusals to this would be a green tick on a gate that had been
+		// pointed at the wrong event, which is the failure issue #62 is about.
+		fmt.Fprintf(errOut, "pullrequest: this event is not a pull request, so there was nothing to judge\n")
+		return exitCannot
+	}
+	for _, end := range []string{event.Base, event.Head} {
+		if !looksLikeAnObjectName(end) {
+			// A range end is read out of a payload and handed to git as an
+			// argument. It arrives from the platform rather than from an
+			// author, so this is a bound rather than a defence, and it is
+			// cheap: a value beginning with a dash would be read by git as a
+			// flag, and a check that passed one on would be a check whose
+			// behaviour a payload decides.
+			fmt.Fprintf(errOut, "pullrequest: %q is not an object name, so the range was not read\n", end)
+			return exitCannot
+		}
+	}
+
+	change, err := readChange(event, e.git)
+	if err != nil {
+		fmt.Fprintf(errOut, "pullrequest: %v\n", err)
+		return exitCannot
+	}
+
+	verdict := pullrequest.Judge(change)
+	fmt.Fprint(out, verdict.Report(change))
+	if len(verdict.Refusals) > 0 {
+		return exitRefused
+	}
+	return exitClean
+}
+
+// readChange asks git the three questions this check has, and stops at the
+// first one git will not answer.
+//
+// It stops rather than judging what it managed to read. A range git cannot
+// answer about is usually a checkout without enough history for the merge base,
+// and a run that quietly judged the two questions it could answer would report
+// a clean pull request having read a third of it.
+func readChange(event pullrequest.Event, git func(args ...string) ([]byte, error)) (pullrequest.Change, error) {
+	change := pullrequest.Change{Body: event.Body, BodyRead: true}
+
+	// Three dots rather than two for the files and the counts, so what is
+	// judged is what this branch added since the two ends last agreed rather
+	// than everything that happened on the base meanwhile. Somebody else's
+	// commit landing on the base is not this pull request's change.
+	span := event.Base + "..." + event.Head
+
+	out, err := git("diff", "--name-status", "-z", span)
+	if err != nil {
+		return change, err
+	}
+	files, err := pullrequest.ParseFiles(out)
+	if err != nil {
+		return change, err
+	}
+	change.Files = files
+	change.FilesRead = true
+
+	out, err = git("log", "--no-merges", "-z", "--format="+pullrequest.CommitFormat, event.Base+".."+event.Head)
+	if err != nil {
+		return change, err
+	}
+	commits, err := pullrequest.ParseCommits(out)
+	if err != nil {
+		return change, err
+	}
+	change.Commits = commits
+	change.CommitsRead = true
+
+	out, err = git("diff", "--numstat", "-z", span)
+	if err != nil {
+		return change, err
+	}
+	lines, uncounted, err := pullrequest.ParseLines(out)
+	if err != nil {
+		return change, err
+	}
+	change.ChangedLines = lines
+	change.Uncounted = uncounted
+	change.LinesCounted = true
+
+	return change, nil
+}
+
+// looksLikeAnObjectName says whether a string is the shape git prints for a
+// commit. Nothing here asks whether the object exists, which is git's answer
+// and arrives as a failure from the command that needed it.
+func looksLikeAnObjectName(name string) bool {
+	if len(name) < 7 || len(name) > 64 {
+		return false
+	}
+	for _, r := range name {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// eventFromTheEnvironment reads the payload the platform wrote for this run.
+func eventFromTheEnvironment() ([]byte, error) {
+	path := os.Getenv("GITHUB_EVENT_PATH")
+	if path == "" {
+		return nil, fmt.Errorf("there is no GITHUB_EVENT_PATH in this environment, and this check reads a pull request out of the event the platform writes")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read the event at %s: %w", path, err)
+	}
+	return data, nil
+}
+
+// gitInThisCheckout runs git with the arguments it is given and nothing else.
+//
+// The arguments are a list rather than a string, so nothing here is parsed by a
+// shell and a value holding a space is one argument whatever it holds. That is
+// the whole of why this is a function and not a line in a workflow: the scope
+// gate that word-split its input and refused valid work is the failure this
+// shape does not have.
+func gitInThisCheckout(args ...string) ([]byte, error) {
+	command := exec.Command("git", args...)
+	out, err := command.Output()
+	if err != nil {
+		var stderr string
+		if exit, ok := err.(*exec.ExitError); ok {
+			stderr = strings.TrimSpace(string(exit.Stderr))
+		}
+		return nil, fmt.Errorf("git %s failed: %v: %s", strings.Join(args, " "), err, stderr)
+	}
+	return out, nil
+}

--- a/cmd/pullrequest/main_test.go
+++ b/cmd/pullrequest/main_test.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// The whole command, exercised without a pull request, a platform or a
+// repository, because both of its edges are parameters. What a test cannot
+// prove this way is that the real git prints what the fixtures below say it
+// prints, and that is proved in internal/pullrequest against output copied out
+// of a run, with the commands written next to it.
+
+// event is a payload in the shape the platform writes, with the two ends of the
+// range and a body.
+func event(body string) []byte {
+	return []byte(fmt.Sprintf(
+		`{"pull_request":{"body":%q,"base":{"sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"head":{"sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}}`,
+		body))
+}
+
+// gitSaying answers the three questions the command asks, in whatever order it
+// asks them, and records what it was asked so a test can hold the range to its
+// shape.
+func gitSaying(files, log, numstat string, asked *[][]string) func(...string) ([]byte, error) {
+	return func(args ...string) ([]byte, error) {
+		if asked != nil {
+			*asked = append(*asked, args)
+		}
+		switch {
+		case args[0] == "log":
+			return []byte(log), nil
+		case contains(args, "--numstat"):
+			return []byte(numstat), nil
+		default:
+			return []byte(files), nil
+		}
+	}
+}
+
+func contains(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
+}
+
+const cleanLog = "1111111111111111111111111111111111111111\x1fAdd the check\n\nCloses #24.\n\x00"
+
+// TestTheCommandReachesEveryCodeItCanReturn is record 0011's third clause for
+// this command. A code that exists only in the comment above it is a promise,
+// and the one that would be discovered by an operator is the one nothing here
+// produces.
+func TestTheCommandReachesEveryCodeItCanReturn(t *testing.T) {
+	tests := []struct {
+		name string
+		e    edges
+		want int
+	}{
+		{
+			name: "a pull request that breaks nothing",
+			e: edges{
+				event: func() ([]byte, error) { return event("Closes #24."), nil },
+				git: gitSaying(
+					"M\x00internal/pullrequest/pullrequest.go\x00",
+					cleanLog,
+					"12\t3\tinternal/pullrequest/pullrequest.go\x00", nil),
+			},
+			want: exitClean,
+		},
+		{
+			name: "a pull request that changes an experiment and not its record",
+			e: edges{
+				event: func() ([]byte, error) { return event("Closes #24."), nil },
+				git: gitSaying(
+					"M\x00experiments/one/measure.go\x00",
+					cleanLog,
+					"12\t3\texperiments/one/measure.go\x00", nil),
+			},
+			want: exitRefused,
+		},
+		{
+			name: "an environment with no event in it",
+			e: edges{
+				event: func() ([]byte, error) { return nil, fmt.Errorf("no event here") },
+				git:   gitSaying("", "", "", nil),
+			},
+			want: exitCannot,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var out, errOut bytes.Buffer
+			if got := run(&out, &errOut, tc.e); got != tc.want {
+				t.Fatalf("returned %d, want %d, having printed %q and %q", got, tc.want, out.String(), errOut.String())
+			}
+		})
+	}
+}
+
+// TestTheRecordRuleIsRedAndGreenWhereIssue24SaysItShouldBe is the done-condition
+// of that issue at the level the command runs at. The two pull requests differ
+// in one file and in nothing else, which is what makes the pair evidence rather
+// than two runs that happen to have come out differently.
+func TestTheRecordRuleIsRedAndGreenWhereIssue24SaysItShouldBe(t *testing.T) {
+	withoutTheRecord := edges{
+		event: func() ([]byte, error) { return event("Closes #24."), nil },
+		git: gitSaying(
+			"M\x00experiments/one/measure.go\x00",
+			cleanLog,
+			"12\t3\texperiments/one/measure.go\x00", nil),
+	}
+	withTheRecord := edges{
+		event: func() ([]byte, error) { return event("Closes #24."), nil },
+		git: gitSaying(
+			"M\x00experiments/one/measure.go\x00M\x00experiments/one/EXPERIMENT.md\x00",
+			cleanLog,
+			"12\t3\texperiments/one/measure.go\x004\t0\texperiments/one/EXPERIMENT.md\x00", nil),
+	}
+
+	var red, redErr bytes.Buffer
+	if got := run(&red, &redErr, withoutTheRecord); got != exitRefused {
+		t.Fatalf("a change that edits an experiment without its record returned %d, want %d", got, exitRefused)
+	}
+	if !strings.Contains(red.String(), "experiments/one") {
+		t.Errorf("the refusal does not name the experiment: %q", red.String())
+	}
+
+	var green, greenErr bytes.Buffer
+	if got := run(&green, &greenErr, withTheRecord); got != exitClean {
+		t.Fatalf("a change that edits an experiment and its record returned %d, want %d: %q %q", got, exitClean, green.String(), greenErr.String())
+	}
+}
+
+// TestTheRangeIsAskedForThreeDots holds the command to asking about what this
+// branch added rather than about everything that happened on the base
+// meanwhile. Two dots for the files would refuse a pull request for somebody
+// else's commit, which is the failure that gets a check switched off.
+func TestTheRangeIsAskedForThreeDots(t *testing.T) {
+	var asked [][]string
+	e := edges{
+		event: func() ([]byte, error) { return event("Closes #24."), nil },
+		git:   gitSaying("", cleanLog, "", &asked),
+	}
+
+	var out, errOut bytes.Buffer
+	if got := run(&out, &errOut, e); got != exitClean {
+		t.Fatalf("returned %d: %q %q", got, out.String(), errOut.String())
+	}
+	if len(asked) != 3 {
+		t.Fatalf("git was asked %d questions, want 3: %v", len(asked), asked)
+	}
+
+	base, head := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	for _, args := range asked {
+		last := args[len(args)-1]
+		want := base + "..." + head
+		if args[0] == "log" {
+			want = base + ".." + head
+		}
+		if last != want {
+			t.Errorf("git %s was asked about %q, want %q", args[0], last, want)
+		}
+	}
+}
+
+// TestARangeEndThatIsNotAnObjectNameIsRefusedBeforeGitIsAsked is the near miss
+// worth the fixture. A value beginning with a dash is read by git as a flag,
+// and a check whose behaviour a payload decides is not a check.
+func TestARangeEndThatIsNotAnObjectNameIsRefusedBeforeGitIsAsked(t *testing.T) {
+	payload := []byte(`{"pull_request":{"body":"Closes #24.","base":{"sha":"--output=/tmp/x"},"head":{"sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}}`)
+
+	asked := 0
+	e := edges{
+		event: func() ([]byte, error) { return payload, nil },
+		git: func(args ...string) ([]byte, error) {
+			asked++
+			return nil, nil
+		},
+	}
+
+	var out, errOut bytes.Buffer
+	if got := run(&out, &errOut, e); got != exitCannot {
+		t.Fatalf("returned %d, want %d", got, exitCannot)
+	}
+	if asked != 0 {
+		t.Errorf("git was asked %d questions about a range end that is not an object name", asked)
+	}
+}
+
+// TestAnEventThatIsNotAPullRequestCannotBeGreen holds the command to saying it
+// could not do its job rather than to reporting a clean pull request it never
+// saw. A green tick on a gate pointed at the wrong event is the shape a
+// misconfiguration hides behind.
+func TestAnEventThatIsNotAPullRequestCannotBeGreen(t *testing.T) {
+	e := edges{
+		event: func() ([]byte, error) { return []byte(`{"ref":"refs/heads/main"}`), nil },
+		git:   gitSaying("", "", "", nil),
+	}
+
+	var out, errOut bytes.Buffer
+	if got := run(&out, &errOut, e); got != exitCannot {
+		t.Fatalf("returned %d, want %d", got, exitCannot)
+	}
+	if !strings.Contains(errOut.String(), "not a pull request") {
+		t.Errorf("the run does not say why it stopped: %q", errOut.String())
+	}
+}
+
+// TestGitFailingIsNotACleanRun holds the command to stopping at the first
+// question git will not answer. A shallow checkout has no merge base, and a run
+// that judged the two questions it could answer would report a clean pull
+// request having read a third of it.
+func TestGitFailingIsNotACleanRun(t *testing.T) {
+	e := edges{
+		event: func() ([]byte, error) { return event("Closes #24."), nil },
+		git: func(args ...string) ([]byte, error) {
+			return nil, fmt.Errorf("fatal: no merge base")
+		},
+	}
+
+	var out, errOut bytes.Buffer
+	if got := run(&out, &errOut, e); got != exitCannot {
+		t.Fatalf("returned %d, want %d", got, exitCannot)
+	}
+	if strings.Contains(out.String(), "0 refusal(s)") {
+		t.Error("a run that could not read the range printed a clean verdict")
+	}
+}
+
+// TestTheReportSaysWhatItExamined holds the run that found nothing wrong to
+// saying what it read. A green tick that printed nothing and a green tick over a
+// whole pull request are the same tick, and only the report separates them.
+func TestTheReportSaysWhatItExamined(t *testing.T) {
+	e := edges{
+		event: func() ([]byte, error) { return event("Closes #24."), nil },
+		git: gitSaying(
+			"M\x00internal/pullrequest/pullrequest.go\x00",
+			cleanLog,
+			"12\t3\tinternal/pullrequest/pullrequest.go\x00", nil),
+	}
+
+	var out, errOut bytes.Buffer
+	if got := run(&out, &errOut, e); got != exitClean {
+		t.Fatalf("returned %d: %q %q", got, out.String(), errOut.String())
+	}
+	for _, want := range []string{"examined the pull request", "commits: 1", "files: 1", "lines: 15"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("the report does not say %q:\n%s", want, out.String())
+		}
+	}
+}

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -56,7 +56,7 @@ today no tick does.
 | `CodeQL` | Kept, retargeted | Static analysis of the runner's own source, in the language record `0001` chose rather than in C#. |
 | `Analyze (csharp)` | Dropped as a name | The language-specific analysis job is replaced by the equivalent for this language rather than carried across under a name that describes nothing here. |
 | `DCO sign-off` | Kept unchanged | Already in the tree, asserting the text at `DCO` on every non-merge commit. |
-| `Deterministic PR-hygiene checks` | Kept, adapted | The class the other checks miss is the pull request itself, and one of the three refusals is this board's own invariant about a record moving with the code it describes. Issue #24 builds it and nothing in this tree reasons about a pull request today. |
+| `Deterministic PR-hygiene checks` | Kept, adapted | The class the other checks miss is the pull request itself, and one of the three refusals is this board's own invariant about a record moving with the code it describes. It is in the tree as the `pull request` job, judged in `internal/pullrequest/` and run from `.github/workflows/pull-request.yml`. |
 | `Enforce greppable invariants` | Kept, different invariants | The invariants are properties of this repository's own tracked text, which is a different set from the target's, and they are in `internal/invariants/`. |
 | `Reject Trojan Source Unicode` | Kept unchanged | Already in the tree, and the attack it refuses is a property of source rather than of a language. |
 | `Audit workflows (zizmor)` | Kept unchanged | Already in the tree. The workflow YAML is the other executable thing here and it runs with write scopes. |

--- a/internal/pullrequest/pullrequest.go
+++ b/internal/pullrequest/pullrequest.go
@@ -1,0 +1,519 @@
+// Package pullrequest judges a pull request rather than the tree the pull
+// request lands. Every other check here reads a checkout: the record checks
+// walk experiments/, the invariants read tracked text, the prose rules read the
+// bytes around the words. None of them can see the change itself, and the class
+// they all miss is whether the change says which problem it solves and whether
+// the record moved with the code it describes.
+//
+// THE JUDGEMENT IS A FUNCTION OVER VALUES AND IT READS NOTHING. Judge takes a
+// Change and returns a verdict. Nothing here opens a file, runs git or reads an
+// environment variable, so every rule below is proved against a value a test
+// writes out in full rather than against whatever the machine the suite runs on
+// happened to contain. Where the values come from is read.go's half, and the
+// command under cmd/pullrequest is the only place that talks to git at all.
+//
+// WHAT A GREEN VERDICT HERE DOES NOT SAY. It never says the change is good, and
+// it never says the change was read. Each rule below is a property of the shape
+// of a pull request rather than of its content: that a number was written down,
+// not that it is the right number; that two files moved together, not that what
+// they say agrees. A reviewer is what stands behind the rest, and a run that
+// found nothing prints what it examined so that a reader can see which of the
+// two they are holding.
+package pullrequest
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// ExperimentsDir and RecordName are where an experiment and its record live.
+// Record 0002 fixes both. They are written here rather than imported from the
+// checker because this package judges paths in a diff and never a tree, and an
+// import for two strings would tie a judgement about a change to a package that
+// walks a filesystem.
+const (
+	ExperimentsDir = "experiments"
+	RecordName     = "EXPERIMENT.md"
+)
+
+// ReadingBound is the number of changed lines above which the verdict carries a
+// note. It is an annotation and never a refusal, and the difference is the whole
+// design of the rule: a prototype legitimately arrives in one piece, and a size
+// cap that reddened a build would be satisfied by splitting a change into pieces
+// chosen to please a counter rather than to be read.
+//
+// The number is the one the corpus this board's rules come from uses. Nothing
+// here claims it is the right number for every change; what it buys is that a
+// reviewer meeting a large diff meets a line saying so before they start rather
+// than halfway down.
+const ReadingBound = 400
+
+// The properties this package can refuse. A property is the rule, named once
+// here and named nowhere else, so a fixture declaring what it expects and a
+// refusal the judgement produced are the same string or they are not equal.
+const (
+	// BodyNamesNoIssue refuses a pull request whose body references no issue.
+	// Every change here starts as an issue, and a body that names none leaves
+	// the reason for the change in whoever wrote it rather than in the tree.
+	// The reference is what a reader follows to find what was wrong, what the
+	// evidence was and what done meant, and none of that is reconstructable
+	// from a diff six months later.
+	BodyNamesNoIssue = "pull-request-body-names-no-issue"
+
+	// CommitMessageNamesNoIssue refuses a commit in the range whose message
+	// references no issue anywhere in it. A pull-request body is edited
+	// afterwards and the commit message is what survives into the log, so a
+	// body carrying the only reference leaves a reader running git log with a
+	// change that explains itself nowhere.
+	//
+	// THE RULE READS THE WHOLE MESSAGE AND ISSUE #24 ASKS FOR THE SUBJECT, and
+	// the departure is measured rather than a preference. On the default
+	// branch at the commit this landed on, four of forty-nine non-merge
+	// commits carry a reference in the subject and thirty-five carry one
+	// somewhere in the message:
+	//
+	//	git log --no-merges --format=%s origin/main | wc -l
+	//	49
+	//	git log --no-merges --format=%s origin/main |
+	//	  grep -cE '(^|[^A-Za-z0-9_])([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#[1-9][0-9]*'
+	//	4
+	//
+	// So the subject reading would refuse forty-five landed commits, thirty-one
+	// of which name their issue in the message body, and the same issue asks in
+	// the same paragraph that the check not red-flag reasonable work. The
+	// failure it names is a change that explains itself nowhere, and a message
+	// whose second paragraph names the issue is not that change. Tightening
+	// this to the subject is a decision about how messages are written here
+	// rather than about what this check can see.
+	//
+	// Merge commits are not judged. Their message is written by the platform
+	// rather than by an author, and refusing one would refuse text nobody in
+	// the pull request can edit.
+	CommitMessageNamesNoIssue = "commit-message-names-no-issue"
+
+	// ExperimentChangedWithoutItsRecord refuses a change that touches a file
+	// under an experiment without touching that experiment's record in the
+	// same pull request. This is the one rule of the three that is this
+	// board's own rather than ordinary hygiene, and it is why the check is
+	// worth having here instead of being copied for symmetry.
+	//
+	// The failure it prevents is the record going quietly out of date. An
+	// experiment gains a script and the record still describes the old
+	// measurement. An experiment's code is removed under record 0004, which
+	// requires the record to gain a line naming the commit that removed it,
+	// and the removal lands without that line. In both the tree is green, the
+	// record reads as complete, and what it says is no longer true.
+	//
+	// REMOVALS COUNT AS TOUCHING, and the reason is record 0004 rather than a
+	// wish to be strict. A change that deletes an experiment's prototype is
+	// exactly the change that owes the record a line, so a rule that read only
+	// additions and edits would be silent on the case the record was written
+	// for.
+	ExperimentChangedWithoutItsRecord = "experiment-changed-without-its-record"
+)
+
+// ChangeIsLargerThanOneReading is the note, and it is deliberately not one of
+// the constants above. Nothing in this package can turn it into a refusal by
+// accident: refusals and notes are different fields of the verdict and only one
+// of them decides the exit code.
+const ChangeIsLargerThanOneReading = "change-is-larger-than-one-reading"
+
+// issueReference matches a reference to an issue in this repository or in
+// another one on the same host, in either of the two spellings a person
+// actually writes.
+//
+// The leading group is what keeps a fragment out. Without it the pattern reads
+// the tail of a word ending in a hash and a number as a reference, and a body
+// that mentioned a colour or an anchor would satisfy the rule by accident. A
+// reference in the owner/repository spelling still matches, because the group
+// is asked for before the owner rather than before the hash.
+//
+// The number may not begin with a zero. An issue is numbered from one, so a
+// hash followed by a zero is not a reference to anything and the shape it
+// usually is instead is a colour.
+var issueReference = regexp.MustCompile(`(^|[^A-Za-z0-9_])(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#[1-9][0-9]*`)
+
+// issueURL matches the same reference written as a link, which is what a body
+// composed in a browser usually carries.
+var issueURL = regexp.MustCompile(`https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/(?:issues|pull)/[1-9][0-9]*`)
+
+// NamesAnIssue says whether a text references an issue.
+//
+// WHAT IT DOES NOT JUDGE, and this is the whole of the residual. Whether the
+// issue exists, whether it is open, whether it is the issue this change is
+// about, and whether the reference was added to satisfy this check. Nothing
+// that reads a string can answer any of those, and a reviewer is what stands
+// behind them. What the rule converts is the case where no issue was named at
+// all, which is the case it exists for and the only one this can separate from
+// the rest.
+func NamesAnIssue(text string) bool {
+	return issueReference.MatchString(text) || issueURL.MatchString(text)
+}
+
+// A File is one path the change touched. The path is repository-relative and
+// written with forward slashes, which is what git prints on every platform this
+// board builds for, so nothing here has to know which platform read the diff.
+type File struct {
+	// Path is where the file is, relative to the root of the repository.
+	Path string
+
+	// Gone says the path is not present at the head of the range. It is
+	// carried because a reader of a refusal wants to know which repair they
+	// are making, and never because a removal is judged more leniently: the
+	// record rule treats a removal as touching the experiment, for the reason
+	// written at that property.
+	Gone bool
+}
+
+// A Commit is one commit in the range, as much of it as any rule here reads.
+type Commit struct {
+	// Hash is the commit, in full. It is what a refusal names, because a
+	// subject is not unique and the repair is made against one commit.
+	Hash string
+
+	// Message is the whole message, subject and body together, as git printed
+	// it.
+	Message string
+}
+
+// Subject is the first line of the message, which is what a refusal quotes so
+// that a reader recognises the commit without going and looking it up.
+func (c Commit) Subject() string {
+	subject, _, _ := strings.Cut(strings.TrimLeft(c.Message, "\n"), "\n")
+	return strings.TrimSpace(subject)
+}
+
+// A Change is one pull request, reduced to what the rules read. Every field is
+// data, so a test can write out a pull request that has never existed.
+//
+// The two present flags are why this is not a struct of plain values. A body
+// that is empty and a body that could not be read are different statements, and
+// collapsing them would let a run that read nothing refuse a pull request for
+// carrying nothing. Where a flag is false the verdict carries a skip rather
+// than a refusal.
+type Change struct {
+	// Body is the pull-request body as it was written.
+	Body string
+
+	// BodyRead says a body was read at all. It is false where the run was
+	// given no pull request, which is not a violation of anything.
+	BodyRead bool
+
+	// Commits are the commits in the range, oldest first, merges already
+	// dropped by whoever assembled this.
+	Commits []Commit
+
+	// CommitsRead says the range's commits were read at all.
+	CommitsRead bool
+
+	// Files are the paths the range touched.
+	Files []File
+
+	// FilesRead says the range's files were read at all. Where it is false
+	// the record rule is skipped rather than passed, because a rule that
+	// found no experiment in a diff it never read is a rule that says nothing.
+	FilesRead bool
+
+	// ChangedLines is how many lines the range added and removed together.
+	ChangedLines int
+
+	// LinesCounted says the count above was read. A diff whose files are all
+	// binary produces no count, and reporting that as zero would print the
+	// smallest possible change against the one input where the number is
+	// unknown.
+	LinesCounted bool
+
+	// Uncounted names the files whose lines git could not count, which are
+	// the binary ones. The count above is a lower bound whenever this is not
+	// empty, and the note says so rather than quoting a total that is short by
+	// an unknown amount.
+	Uncounted []string
+}
+
+// A Refusal is one rule refusing one subject. The subject is carried separately
+// from the detail so that a message can never be written without it, which is
+// the shape the rest of this repository's checks already use.
+type Refusal struct {
+	Property string
+	Subject  string
+	Detail   string
+}
+
+// String leads with the subject, because somebody reading a red run is looking
+// for the thing to open first.
+func (r Refusal) String() string {
+	return fmt.Sprintf("%s: %s (%s)", r.Subject, r.Detail, r.Property)
+}
+
+// A Note is something worth saying that is not a refusal. It never decides an
+// exit code.
+type Note struct {
+	Property string
+	Detail   string
+}
+
+// A Skip is a rule that was not applied and why. It exists so that a run which
+// verified nothing cannot print the same thing as a run that verified
+// everything and found it clean, which is the failure every green tick on a
+// misconfigured gate is made of.
+type Skip struct {
+	// Rule is what was not applied, in the words the rule is named by.
+	Rule string
+
+	// Why is what was missing. It names the input rather than the mechanism,
+	// because whoever reads it is deciding whether the gap matters to them.
+	Why string
+}
+
+// A Verdict is what one judgement found. The three lists are separate because
+// they are read by different people for different reasons, and only the first
+// of them is a failure.
+type Verdict struct {
+	Refusals []Refusal
+	Notes    []Note
+	Skips    []Skip
+}
+
+// Properties returns the set of properties this verdict refused, which is what
+// a case declares and what the tests compare. A property refused twice is one
+// entry, so a fixture tripping one rule at two places still refuses exactly
+// that rule.
+func (v Verdict) Properties() []string {
+	seen := make(map[string]bool, len(v.Refusals))
+	var props []string
+	for _, refusal := range v.Refusals {
+		if !seen[refusal.Property] {
+			seen[refusal.Property] = true
+			props = append(props, refusal.Property)
+		}
+	}
+	return props
+}
+
+// Judge holds a change to the rules above and returns what it found.
+//
+// The order the rules run in is the order a reader meets the change: the body
+// first, because it is what a reviewer opens, then the commits, then the tree
+// the change touched. Nothing depends on that order and no rule reads another
+// rule's verdict, which is why a fixture can trip exactly one of them.
+func Judge(change Change) Verdict {
+	var verdict Verdict
+
+	verdict.add(judgeBody(change))
+	verdict.add(judgeCommits(change))
+	verdict.add(judgeExperiments(change))
+	verdict.add(judgeSize(change))
+
+	return verdict
+}
+
+// add folds one rule's verdict into the whole.
+func (v *Verdict) add(other Verdict) {
+	v.Refusals = append(v.Refusals, other.Refusals...)
+	v.Notes = append(v.Notes, other.Notes...)
+	v.Skips = append(v.Skips, other.Skips...)
+}
+
+// judgeBody holds the pull-request body to naming an issue.
+func judgeBody(change Change) Verdict {
+	if !change.BodyRead {
+		return Verdict{Skips: []Skip{{
+			Rule: BodyNamesNoIssue,
+			Why:  "this run was given no pull-request body, so nothing was read to look for a reference in",
+		}}}
+	}
+	if NamesAnIssue(change.Body) {
+		return Verdict{}
+	}
+	return Verdict{Refusals: []Refusal{{
+		Property: BodyNamesNoIssue,
+		Subject:  "the pull-request body",
+		Detail:   "it references no issue, so the reason for this change is not written anywhere a reader can follow",
+	}}}
+}
+
+// judgeCommits holds every commit message in the range to naming an issue. It
+// refuses once per commit rather than once for the range, because the repair is
+// made against a particular message and a reader given one line saying some
+// commit is wrong has to go and find which.
+func judgeCommits(change Change) Verdict {
+	if !change.CommitsRead {
+		return Verdict{Skips: []Skip{{
+			Rule: CommitMessageNamesNoIssue,
+			Why:  "this run was given no commits, so no message was read",
+		}}}
+	}
+
+	var verdict Verdict
+	for _, commit := range change.Commits {
+		if NamesAnIssue(commit.Message) {
+			continue
+		}
+		verdict.Refusals = append(verdict.Refusals, Refusal{
+			Property: CommitMessageNamesNoIssue,
+			Subject:  commit.Hash,
+			Detail:   fmt.Sprintf("its message references no issue, and a message is what survives into the log after a pull-request body has been edited, so this change explains itself nowhere afterwards. Its subject is %q", commit.Subject()),
+		})
+	}
+	return verdict
+}
+
+// judgeExperiments holds a change that touches an experiment to touching that
+// experiment's record.
+//
+// TWO BOUNDARIES, WRITTEN HERE RATHER THAN DISCOVERED.
+//
+// A file directly under experiments/ belongs to no experiment, so nothing here
+// reads it. Whether such a file may exist at all is a rule about a tree and the
+// checker holds it, which is the right place: this package sees a list of paths
+// and never the directory they came from.
+//
+// A change that removes an experiment's record along with its files satisfies
+// this rule, because the record is in the set of paths the change touched. That
+// a landed record may not be removed at all is a different rule about a
+// different failure, and it is issue #69's rather than this one's. Nothing here
+// should be read as permitting it.
+func judgeExperiments(change Change) Verdict {
+	if !change.FilesRead {
+		return Verdict{Skips: []Skip{{
+			Rule: ExperimentChangedWithoutItsRecord,
+			Why:  "this run was given no changed paths, so no experiment was looked for",
+		}}}
+	}
+
+	touched := make(map[string]bool)
+	records := make(map[string]bool)
+	for _, file := range change.Files {
+		slug, isRecord, ok := experimentOf(file.Path)
+		if !ok {
+			continue
+		}
+		if isRecord {
+			records[slug] = true
+			continue
+		}
+		touched[slug] = true
+	}
+
+	slugs := make([]string, 0, len(touched))
+	for slug := range touched {
+		if !records[slug] {
+			slugs = append(slugs, slug)
+		}
+	}
+	// Sorted so that two runs over the same change print the same thing. A map
+	// is walked in whatever order it is walked in, and a report that reordered
+	// itself between runs would show as a change nobody made.
+	sort.Strings(slugs)
+
+	var verdict Verdict
+	for _, slug := range slugs {
+		record := strings.Join([]string{ExperimentsDir, slug, RecordName}, "/")
+		verdict.Refusals = append(verdict.Refusals, Refusal{
+			Property: ExperimentChangedWithoutItsRecord,
+			Subject:  strings.Join([]string{ExperimentsDir, slug}, "/"),
+			Detail:   fmt.Sprintf("this change touches files in it and does not touch %s, so the record still describes the experiment as it was before", record),
+		})
+	}
+	return verdict
+}
+
+// experimentOf places a path inside an experiment. It returns the slug, whether
+// the path is that experiment's record, and whether the path is inside an
+// experiment at all.
+//
+// It reads the path as git prints it, which is forward slashes on every
+// platform, so a run on Windows places a path exactly as a run on Linux does.
+func experimentOf(path string) (slug string, isRecord bool, ok bool) {
+	segments := strings.Split(path, "/")
+	if len(segments) < 3 || segments[0] != ExperimentsDir {
+		return "", false, false
+	}
+	return segments[1], len(segments) == 3 && segments[2] == RecordName, true
+}
+
+// judgeSize annotates a change that is larger than one reading. It never
+// refuses, for the reason written at ReadingBound.
+func judgeSize(change Change) Verdict {
+	if !change.LinesCounted {
+		return Verdict{Skips: []Skip{{
+			Rule: ChangeIsLargerThanOneReading,
+			Why:  "this run was given no line counts, so the size of the change is unknown rather than small",
+		}}}
+	}
+
+	var verdict Verdict
+	if len(change.Uncounted) > 0 {
+		verdict.Skips = append(verdict.Skips, Skip{
+			Rule: ChangeIsLargerThanOneReading,
+			Why: fmt.Sprintf("git counts no lines in %s, so %d is a lower bound rather than the size of this change",
+				strings.Join(change.Uncounted, ", "), change.ChangedLines),
+		})
+	}
+	if change.ChangedLines > ReadingBound {
+		verdict.Notes = append(verdict.Notes, Note{
+			Property: ChangeIsLargerThanOneReading,
+			Detail: fmt.Sprintf("this change moves %d lines and %d is where one reading stops being one reading, which is worth knowing before the review starts rather than halfway down",
+				change.ChangedLines, ReadingBound),
+		})
+	}
+	return verdict
+}
+
+// Report is what the run prints. It says what it examined before it says what
+// it found, whatever it found, because zero refusals over a change nobody read
+// and zero refusals over a change that was read are the same line otherwise.
+func (v Verdict) Report(change Change) string {
+	out := "examined the pull request\n"
+	out += fmt.Sprintf("  body: %s\n", describeBody(change))
+	out += fmt.Sprintf("  commits: %s\n", describeCommits(change))
+	out += fmt.Sprintf("  files: %s\n", describeFiles(change))
+	out += fmt.Sprintf("  lines: %s\n", describeLines(change))
+
+	for _, skip := range v.Skips {
+		out += fmt.Sprintf("not judged: %s, because %s\n", skip.Rule, skip.Why)
+	}
+	for _, note := range v.Notes {
+		out += fmt.Sprintf("note: %s (%s)\n", note.Detail, note.Property)
+	}
+	for _, refusal := range v.Refusals {
+		out += "refused: " + refusal.String() + "\n"
+	}
+
+	out += fmt.Sprintf("%d refusal(s), %d note(s), %d rule(s) not judged\n",
+		len(v.Refusals), len(v.Notes), len(v.Skips))
+	return out
+}
+
+func describeBody(change Change) string {
+	if !change.BodyRead {
+		return "none was read"
+	}
+	return fmt.Sprintf("%d character(s)", len([]rune(change.Body)))
+}
+
+func describeCommits(change Change) string {
+	if !change.CommitsRead {
+		return "none were read"
+	}
+	return fmt.Sprintf("%d, merges excluded", len(change.Commits))
+}
+
+func describeFiles(change Change) string {
+	if !change.FilesRead {
+		return "none were read"
+	}
+	return fmt.Sprintf("%d", len(change.Files))
+}
+
+func describeLines(change Change) string {
+	if !change.LinesCounted {
+		return "not counted"
+	}
+	if len(change.Uncounted) > 0 {
+		return fmt.Sprintf("%d or more, because git counts no lines in %d of them", change.ChangedLines, len(change.Uncounted))
+	}
+	return fmt.Sprintf("%d", change.ChangedLines)
+}

--- a/internal/pullrequest/pullrequest.go
+++ b/internal/pullrequest/pullrequest.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode"
 )
 
 // ExperimentsDir and RecordName are where an experiment and its record live.
@@ -135,9 +136,43 @@ const ChangeIsLargerThanOneReading = "change-is-larger-than-one-reading"
 // usually is instead is a colour.
 var issueReference = regexp.MustCompile(`(^|[^A-Za-z0-9_])(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#[1-9][0-9]*`)
 
-// issueURL matches the same reference written as a link, which is what a body
-// composed in a browser usually carries.
-var issueURL = regexp.MustCompile(`https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/(?:issues|pull)/[1-9][0-9]*`)
+// The same reference written as a link, which is what a body composed in a
+// browser usually carries.
+//
+// THE HOST IS COMPARED AND NOT MATCHED, and the pattern below holds the path
+// only. A regular expression carrying a host name matches anywhere in a string
+// unless it is anchored, so a link to somewhere else that happens to carry this
+// host inside its own path would satisfy the rule, and the reader who followed
+// it would arrive somewhere nobody meant. Comparing the beginning of a field
+// against a fixed string cannot do that, and the pattern that is left is
+// anchored at the front and has no host in it at all.
+const issueLinkHost = "https://github.com/"
+
+var issueLinkPath = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/(?:issues|pull)/[1-9][0-9]*`)
+
+// namesAnIssueLink says whether a text carries a link to an issue.
+//
+// The text is cut into fields at whitespace and at the characters prose wraps a
+// link in, because a link inside brackets or followed by a full stop is a link
+// somebody wrote and a check that missed it would be met by a body that
+// references its issue perfectly well.
+func namesAnIssueLink(text string) bool {
+	for _, field := range strings.FieldsFunc(text, isLinkDelimiter) {
+		rest, found := strings.CutPrefix(field, issueLinkHost)
+		if !found {
+			continue
+		}
+		if issueLinkPath.MatchString(rest) {
+			return true
+		}
+	}
+	return false
+}
+
+// isLinkDelimiter says whether a rune ends a link written inside prose.
+func isLinkDelimiter(r rune) bool {
+	return unicode.IsSpace(r) || strings.ContainsRune("()<>[]{}\"'`,", r)
+}
 
 // NamesAnIssue says whether a text references an issue.
 //
@@ -149,7 +184,7 @@ var issueURL = regexp.MustCompile(`https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-
 // all, which is the case it exists for and the only one this can separate from
 // the rest.
 func NamesAnIssue(text string) bool {
-	return issueReference.MatchString(text) || issueURL.MatchString(text)
+	return issueReference.MatchString(text) || namesAnIssueLink(text)
 }
 
 // A File is one path the change touched. The path is repository-relative and

--- a/internal/pullrequest/pullrequest_test.go
+++ b/internal/pullrequest/pullrequest_test.go
@@ -1,0 +1,423 @@
+package pullrequest
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// A case is one pull request and the whole set of properties judging it must
+// refuse. The set is compared rather than searched, for the reason the record
+// checks already compare theirs: asking only whether the expected refusal is
+// present passes a fixture that trips its own rule and one other, and a fixture
+// that trips two rules proves neither of them.
+type judgeCase struct {
+	name   string
+	change Change
+	want   []string
+	notes  []string
+	skips  []string
+}
+
+// clean is a pull request that breaks nothing, which every refusing case below
+// is one change away from. Building the cases from it is what makes each of
+// them a near miss rather than a tree that trips several rules at once and
+// proves nothing about which.
+func clean() Change {
+	return Change{
+		Body:        "This closes #24 and nothing else.",
+		BodyRead:    true,
+		CommitsRead: true,
+		Commits: []Commit{
+			{
+				Hash:    "1111111111111111111111111111111111111111",
+				Message: "Add the deterministic pull-request check\n\nThe class the other checks miss is the pull request itself. Closes #24.\n",
+			},
+		},
+		FilesRead:    true,
+		Files:        []File{{Path: "internal/pullrequest/pullrequest.go"}},
+		ChangedLines: 12,
+		LinesCounted: true,
+	}
+}
+
+func TestJudge(t *testing.T) {
+	for _, tc := range judgeCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			verdict := Judge(tc.change)
+
+			for _, diff := range diffSets("refusal", tc.want, verdict.Properties()) {
+				t.Error(diff)
+			}
+
+			var notes []string
+			for _, note := range verdict.Notes {
+				notes = append(notes, note.Property)
+			}
+			for _, diff := range diffSets("note", tc.notes, notes) {
+				t.Error(diff)
+			}
+
+			var skips []string
+			for _, skip := range verdict.Skips {
+				skips = append(skips, skip.Rule)
+			}
+			for _, diff := range diffSets("skip", tc.skips, skips) {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+// judgeCases is the table both tests over it read, so a case removed from here
+// is removed from the coverage proof below as well. A list of cases kept beside
+// the cases is the shape where a fixture is deleted and the test that counted
+// it goes on counting.
+func judgeCases() []judgeCase {
+	return []judgeCase{
+		{
+			name:   "a change that names its issue and touches no experiment",
+			change: clean(),
+		},
+		{
+			name: "a body that references no issue",
+			change: func() Change {
+				c := clean()
+				c.Body = "This tidies up the check and makes the message clearer."
+				return c
+			}(),
+			want: []string{BodyNamesNoIssue},
+		},
+		{
+			name: "a body that names a number without the reference",
+			change: func() Change {
+				c := clean()
+				c.Body = "This closes issue 24."
+				return c
+			}(),
+			// The near miss worth the fixture. It reads as a reference to
+			// somebody skimming and there is nothing in it a reader can
+			// follow, which is the whole of what the rule is for.
+			want: []string{BodyNamesNoIssue},
+		},
+		{
+			name: "a body whose reference is a link",
+			change: func() Change {
+				c := clean()
+				c.Body = "Closes https://github.com/Flowfin/lab/issues/24."
+				return c
+			}(),
+		},
+		{
+			name: "a body whose reference names the repository",
+			change: func() Change {
+				c := clean()
+				c.Body = "Closes Flowfin/lab#24."
+				return c
+			}(),
+		},
+		{
+			name: "a body carrying a colour rather than a reference",
+			change: func() Change {
+				c := clean()
+				c.Body = "The swatch in the screenshot is #0f0f0f and nothing else changed."
+				return c
+			}(),
+			// A number beginning with a zero is not an issue number, and this
+			// is the string that would otherwise let a body satisfy the rule
+			// by accident.
+			want: []string{BodyNamesNoIssue},
+		},
+		{
+			name: "a commit message that references no issue",
+			change: func() Change {
+				c := clean()
+				c.Commits = append(c.Commits, Commit{
+					Hash:    "2222222222222222222222222222222222222222",
+					Message: "Fix the message\n\nIt read badly and now it does not.\n",
+				})
+				return c
+			}(),
+			want: []string{CommitMessageNamesNoIssue},
+		},
+		{
+			name: "a commit naming its issue in the message and not in the subject",
+			change: func() Change {
+				c := clean()
+				c.Commits = append(c.Commits, Commit{
+					Hash:    "4444444444444444444444444444444444444444",
+					Message: "Refuse a header whose dates disagree with themselves\n\nThe listing sorts on a field nothing parsed. Closes #54.\n\nSigned-off-by: A Contributor <nobody@example.invalid>\n",
+				})
+				return c
+			}(),
+			// The shape forty-nine landed commits are mostly written in, and
+			// the reason the rule reads the whole message. A subject reading
+			// would refuse this and the change explains itself perfectly well.
+		},
+		{
+			name: "an experiment changed without its record",
+			change: func() Change {
+				c := clean()
+				c.Files = []File{{Path: "experiments/one/measure.go"}}
+				return c
+			}(),
+			want: []string{ExperimentChangedWithoutItsRecord},
+		},
+		{
+			name: "an experiment changed with its record",
+			change: func() Change {
+				c := clean()
+				c.Files = []File{
+					{Path: "experiments/one/measure.go"},
+					{Path: "experiments/one/EXPERIMENT.md"},
+				}
+				return c
+			}(),
+		},
+		{
+			name: "one experiment moving with its record and another without",
+			change: func() Change {
+				c := clean()
+				c.Files = []File{
+					{Path: "experiments/one/measure.go"},
+					{Path: "experiments/one/EXPERIMENT.md"},
+					{Path: "experiments/two/measure.go"},
+				}
+				return c
+			}(),
+			want: []string{ExperimentChangedWithoutItsRecord},
+		},
+		{
+			name: "an experiment's file removed without its record",
+			change: func() Change {
+				c := clean()
+				c.Files = []File{{Path: "experiments/one/measure.go", Gone: true}}
+				return c
+			}(),
+			// Record 0004 lets an answered experiment's code be removed and
+			// requires the record to gain a line naming the commit that
+			// removed it. A rule reading only additions and edits would be
+			// silent on exactly that change.
+			want: []string{ExperimentChangedWithoutItsRecord},
+		},
+		{
+			name: "a record's own change, with nothing else in the experiment",
+			change: func() Change {
+				c := clean()
+				c.Files = []File{{Path: "experiments/one/EXPERIMENT.md"}}
+				return c
+			}(),
+		},
+		{
+			name: "a file directly under experiments and in no experiment",
+			change: func() Change {
+				c := clean()
+				c.Files = []File{{Path: "experiments/README.md"}}
+				return c
+			}(),
+			// Whether such a file may be there at all is a rule about a tree,
+			// and the checker holds it. This package sees paths and never the
+			// directory they came from.
+		},
+		{
+			name: "a file deep inside an experiment",
+			change: func() Change {
+				c := clean()
+				c.Files = []File{{Path: "experiments/one/cmd/measure/main.go"}}
+				return c
+			}(),
+			want: []string{ExperimentChangedWithoutItsRecord},
+		},
+		{
+			name: "a change one line above the reading bound",
+			change: func() Change {
+				c := clean()
+				c.ChangedLines = ReadingBound + 1
+				return c
+			}(),
+			notes: []string{ChangeIsLargerThanOneReading},
+		},
+		{
+			name: "a change exactly at the reading bound",
+			change: func() Change {
+				c := clean()
+				c.ChangedLines = ReadingBound
+				return c
+			}(),
+		},
+		{
+			name: "a change whose lines git could not count",
+			change: func() Change {
+				c := clean()
+				c.Uncounted = []string{"docs/diagram.png"}
+				return c
+			}(),
+			skips: []string{ChangeIsLargerThanOneReading},
+		},
+		{
+			name:   "a run given nothing at all",
+			change: Change{},
+			// Every rule says it was not applied. Nothing is refused, because
+			// a run that read no pull request has found no violation in one.
+			skips: []string{
+				BodyNamesNoIssue,
+				CommitMessageNamesNoIssue,
+				ExperimentChangedWithoutItsRecord,
+				ChangeIsLargerThanOneReading,
+			},
+		},
+	}
+}
+
+// TestEveryPropertyHasACaseThatRefusesIt refuses a property no case in the
+// table trips. A rule with no fixture is a rule nobody has seen bite, and it is
+// the quietest way this package could grow a branch that never runs while the
+// suite stays green.
+//
+// It reads the same table the cases run from, and it asks the judgement rather
+// than the declarations in it, so a case whose want list drifted from what it
+// actually refuses is counted by what it refuses.
+func TestEveryPropertyHasACaseThatRefusesIt(t *testing.T) {
+	properties := []string{
+		BodyNamesNoIssue,
+		CommitMessageNamesNoIssue,
+		ExperimentChangedWithoutItsRecord,
+	}
+
+	refused := make(map[string]bool)
+	for _, tc := range judgeCases() {
+		for _, property := range Judge(tc.change).Properties() {
+			refused[property] = true
+		}
+	}
+	for _, property := range properties {
+		if !refused[property] {
+			t.Errorf("no case refuses %s, so nothing in this suite has seen it bite", property)
+		}
+	}
+}
+
+// TestARefusalNamesItsSubject holds every refusal to carrying the thing whoever
+// hit it has to go and open. A message saying a rule was broken and not saying
+// where sends a reader to search the diff, which is what the check was supposed
+// to save them.
+func TestARefusalNamesItsSubject(t *testing.T) {
+	change := Change{
+		BodyRead:    true,
+		Body:        "nothing here",
+		CommitsRead: true,
+		Commits:     []Commit{{Hash: "3333333333333333333333333333333333333333", Message: "no reference anywhere in this one"}},
+		FilesRead:   true,
+		Files:       []File{{Path: "experiments/one/measure.go"}},
+	}
+
+	verdict := Judge(change)
+	if len(verdict.Refusals) != 3 {
+		t.Fatalf("this change breaks three rules and %d were refused", len(verdict.Refusals))
+	}
+	for _, refusal := range verdict.Refusals {
+		if strings.TrimSpace(refusal.Subject) == "" {
+			t.Errorf("%s refused with no subject", refusal.Property)
+		}
+		if strings.TrimSpace(refusal.Detail) == "" {
+			t.Errorf("%s refused with no detail", refusal.Property)
+		}
+	}
+}
+
+// TestTheReportSaysWhatItExamined is the proof that a run which judged nothing
+// does not print what a run that judged everything prints. The two verdicts
+// below are both clean, and a reader has to be able to tell them apart.
+func TestTheReportSaysWhatItExamined(t *testing.T) {
+	nothing := Change{}
+	everything := clean()
+
+	quiet := Judge(nothing).Report(nothing)
+	full := Judge(everything).Report(everything)
+
+	if quiet == full {
+		t.Fatal("a run that read no pull request printed the same report as one that read a whole pull request")
+	}
+	for _, want := range []string{"not judged", "none was read", "none were read", "not counted"} {
+		if !strings.Contains(quiet, want) {
+			t.Errorf("the report of a run that read nothing does not say %q", want)
+		}
+	}
+	if strings.Contains(full, "not judged:") {
+		t.Error("the report of a run that read a whole pull request says a rule was not judged")
+	}
+	if !strings.Contains(full, "0 rule(s) not judged") {
+		t.Error("the report of a run that read a whole pull request does not count the rules it did not judge")
+	}
+}
+
+// TestTheSizeAnnotationNeverRefuses is the property the bound exists for. A
+// size cap that reddened a build would be met by splitting a change into pieces
+// chosen to satisfy a counter, so this holds the note to being a note however
+// large the change gets.
+func TestTheSizeAnnotationNeverRefuses(t *testing.T) {
+	change := clean()
+	change.ChangedLines = 100 * ReadingBound
+
+	verdict := Judge(change)
+	if len(verdict.Refusals) != 0 {
+		t.Fatalf("a change of %d lines was refused: %v", change.ChangedLines, verdict.Refusals)
+	}
+	if len(verdict.Notes) != 1 {
+		t.Fatalf("a change of %d lines produced %d notes and one was expected", change.ChangedLines, len(verdict.Notes))
+	}
+}
+
+// TestSetsAreComparedAsSets proves the comparison every case above rests on
+// bites, over the combinations the cases themselves do not reach.
+func TestSetsAreComparedAsSets(t *testing.T) {
+	tests := []struct {
+		name      string
+		want, got []string
+		diffs     int
+	}{
+		{name: "nothing expected and nothing produced", diffs: 0},
+		{name: "the expected one and one more", want: []string{"a"}, got: []string{"a", "b"}, diffs: 1},
+		{name: "the expected one is missing", want: []string{"a"}, diffs: 1},
+		{name: "one nobody expected", got: []string{"a"}, diffs: 1},
+		{name: "the same set in another order", want: []string{"a", "b"}, got: []string{"b", "a"}, diffs: 0},
+		{name: "one expected and a different one produced", want: []string{"a"}, got: []string{"b"}, diffs: 2},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			diffs := diffSets("refusal", tc.want, tc.got)
+			if len(diffs) != tc.diffs {
+				t.Fatalf("got %d differences %v, want %d", len(diffs), diffs, tc.diffs)
+			}
+		})
+	}
+}
+
+// diffSets compares two sets of names and returns one line per difference, in
+// both directions. A name expected and not produced and a name produced and not
+// expected are different failures and are reported as different lines.
+func diffSets(kind string, want, got []string) []string {
+	expected := make(map[string]bool, len(want))
+	for _, name := range want {
+		expected[name] = true
+	}
+	produced := make(map[string]bool, len(got))
+	for _, name := range got {
+		produced[name] = true
+	}
+
+	var diffs []string
+	for name := range expected {
+		if !produced[name] {
+			diffs = append(diffs, kind+" expected and not produced: "+name)
+		}
+	}
+	for name := range produced {
+		if !expected[name] {
+			diffs = append(diffs, kind+" produced that no case expected: "+name)
+		}
+	}
+	sort.Strings(diffs)
+	return diffs
+}

--- a/internal/pullrequest/pullrequest_test.go
+++ b/internal/pullrequest/pullrequest_test.go
@@ -109,6 +109,26 @@ func judgeCases() []judgeCase {
 			}(),
 		},
 		{
+			name: "a body whose link carries this host inside somebody else's path",
+			change: func() Change {
+				c := clean()
+				c.Body = "See https://example.invalid/https://github.com/Flowfin/lab/issues/24 for the details."
+				return c
+			}(),
+			// The near miss the link rule exists in this shape for. A reader
+			// following it arrives somewhere nobody meant, and a pattern
+			// carrying the host rather than comparing it would pass this.
+			want: []string{BodyNamesNoIssue},
+		},
+		{
+			name: "a body whose link is wrapped in brackets and ends in a full stop",
+			change: func() Change {
+				c := clean()
+				c.Body = "The argument is there (https://github.com/Flowfin/lab/issues/24)."
+				return c
+			}(),
+		},
+		{
 			name: "a body whose reference names the repository",
 			change: func() Change {
 				c := clean()

--- a/internal/pullrequest/read.go
+++ b/internal/pullrequest/read.go
@@ -1,0 +1,227 @@
+package pullrequest
+
+// The other half of this package: turning what git and the platform print into
+// the values Judge reads. Every function here takes bytes and returns a value,
+// so a test can hand it the exact output a real command produced without the
+// command being run, and the judgement can be proved against a pull request
+// nobody has to open.
+//
+// WHY THE PARSING IS SEPARATED FROM THE JUDGEMENT AT ALL. A rule proved against
+// a value somebody typed into a test is proved against a shape somebody
+// imagined. These functions are where a real diff enters, and the fixtures
+// below them are copies of what git actually prints, including the two forms
+// that are easy to get wrong and that no honest change produces often enough to
+// find by accident: a rename, which prints two paths for one entry, and a
+// binary file, which prints no line count at all.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// fieldSeparator is what the commit format below puts between the hash and the
+// subject. It is a control character rather than a space or a tab because a
+// subject may hold either of those and may not hold this, so the split cannot
+// be made at the wrong place by an ordinary message.
+const fieldSeparator = "\x1f"
+
+// CommitFormat is the format string the command passes to git log. It lives
+// here, next to the function that reads its output, because a format changed in
+// one place and read in another is a parser that goes wrong quietly on the
+// first commit whose message contains whatever the two now disagree about.
+//
+// It asks for the whole message rather than the subject, which is what the rule
+// over commits reads and why. A message holds newlines, and that is the reason
+// the entries are separated by a null byte rather than by one.
+const CommitFormat = "%H" + fieldSeparator + "%B"
+
+// An Event is what the platform said about the run, reduced to what this
+// package reads.
+type Event struct {
+	// IsPullRequest says the payload described a pull request at all. A run
+	// on anything else is not a violation of anything and produces skips
+	// rather than refusals.
+	IsPullRequest bool
+
+	// Body is the pull-request body. An author who wrote none gives an empty
+	// string here, which is a body that references no issue rather than a body
+	// that was not read.
+	Body string
+
+	// Base and Head are the two ends of the range, as the platform reported
+	// them. The range is read three-dot from base to head, so what is judged
+	// is what the head added since the two last agreed rather than everything
+	// that happened on the base meanwhile.
+	Base string
+	Head string
+}
+
+// ParseEvent reads a webhook payload.
+//
+// It reads four fields out of a document with hundreds and ignores the rest,
+// which is deliberate: every field this does not read is a field the platform
+// may rename without breaking the check, and a parser that insisted on the
+// whole shape would be a parser that fails on a payload it does not need to
+// understand.
+func ParseEvent(data []byte) (Event, error) {
+	var payload struct {
+		PullRequest *struct {
+			Body *string `json:"body"`
+			Base struct {
+				SHA string `json:"sha"`
+			} `json:"base"`
+			Head struct {
+				SHA string `json:"sha"`
+			} `json:"head"`
+		} `json:"pull_request"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return Event{}, fmt.Errorf("cannot read the event payload: %w", err)
+	}
+	if payload.PullRequest == nil {
+		return Event{}, nil
+	}
+
+	event := Event{
+		IsPullRequest: true,
+		Base:          payload.PullRequest.Base.SHA,
+		Head:          payload.PullRequest.Head.SHA,
+	}
+	// A body nobody wrote arrives as null rather than as an empty string, and
+	// the two mean the same thing here: nothing was written, so nothing
+	// references an issue.
+	if payload.PullRequest.Body != nil {
+		event.Body = *payload.PullRequest.Body
+	}
+	return event, nil
+}
+
+// ParseFiles reads the output of git diff --name-status -z.
+//
+// The separator is a null byte rather than a newline because git quotes a path
+// holding an unusual character when it prints one per line, and a check that
+// unquoted it would have to be right about git's quoting rules on every
+// platform. Under -z nothing is quoted and a path is exactly its bytes.
+//
+// A rename produces two paths for one entry, and both are returned. The old one
+// is gone at the head and the new one is not, which is what the record rule
+// needs: moving a file out of an experiment is a change to that experiment
+// whichever end of the move a reader looks at.
+func ParseFiles(data []byte) ([]File, error) {
+	fields := splitNul(data)
+	var files []File
+
+	for i := 0; i < len(fields); i++ {
+		status := fields[i]
+		if status == "" {
+			continue
+		}
+		paths := 1
+		if status[0] == 'R' || status[0] == 'C' {
+			paths = 2
+		}
+		if i+paths > len(fields)-1 {
+			return nil, fmt.Errorf("the diff ends after the status %q with no path after it", status)
+		}
+		switch paths {
+		case 1:
+			files = append(files, File{Path: fields[i+1], Gone: status[0] == 'D'})
+		case 2:
+			files = append(files,
+				File{Path: fields[i+1], Gone: true},
+				File{Path: fields[i+2], Gone: false})
+		}
+		i += paths
+	}
+	return files, nil
+}
+
+// ParseCommits reads the output of git log -z with CommitFormat.
+//
+// Merges are dropped by the command that runs git rather than here, because
+// which commits are in the range is a question about the range and this
+// function's whole job is reading what it was given.
+func ParseCommits(data []byte) ([]Commit, error) {
+	var commits []Commit
+
+	for _, entry := range splitNul(data) {
+		if strings.TrimSpace(entry) == "" {
+			continue
+		}
+		// git puts a newline after each message under this format, so the
+		// entry is trimmed at its ends rather than assumed clean. Nothing
+		// inside the message is touched: what a rule reads has to be what the
+		// author wrote.
+		entry = strings.Trim(entry, "\n")
+		hash, message, found := strings.Cut(entry, fieldSeparator)
+		if !found {
+			return nil, fmt.Errorf("a commit entry carries no separator: %q", entry)
+		}
+		commits = append(commits, Commit{Hash: hash, Message: message})
+	}
+	return commits, nil
+}
+
+// ParseLines reads the output of git diff --numstat -z and returns how many
+// lines the range moved, together with the paths git counted no lines in.
+//
+// A binary file prints a dash for each count. It is returned rather than
+// treated as zero, because a change of one binary blob and nothing else would
+// otherwise report a size of zero, which is the smallest possible change
+// printed against the one input whose size is unknown.
+func ParseLines(data []byte) (int, []string, error) {
+	fields := splitNul(data)
+	total := 0
+	var uncounted []string
+
+	for i := 0; i < len(fields); i++ {
+		entry := fields[i]
+		if strings.TrimSpace(entry) == "" {
+			continue
+		}
+		added, rest, found := strings.Cut(entry, "\t")
+		if !found {
+			return 0, nil, fmt.Errorf("a numstat entry carries no tab: %q", entry)
+		}
+		removed, path, found := strings.Cut(rest, "\t")
+		if !found {
+			return 0, nil, fmt.Errorf("a numstat entry carries one tab and needs two: %q", entry)
+		}
+		// A renamed file prints its two paths as the two fields after the
+		// counts, so the entry itself ends at the second tab.
+		if path == "" {
+			if i+2 > len(fields)-1 {
+				return 0, nil, fmt.Errorf("a renamed numstat entry ends before its paths: %q", entry)
+			}
+			path = fields[i+2]
+			i += 2
+		}
+
+		if added == "-" || removed == "-" {
+			uncounted = append(uncounted, path)
+			continue
+		}
+		a, err := strconv.Atoi(added)
+		if err != nil {
+			return 0, nil, fmt.Errorf("cannot read the added count in %q: %w", entry, err)
+		}
+		r, err := strconv.Atoi(removed)
+		if err != nil {
+			return 0, nil, fmt.Errorf("cannot read the removed count in %q: %w", entry, err)
+		}
+		total += a + r
+	}
+	return total, uncounted, nil
+}
+
+// splitNul splits on the null byte and drops a trailing empty field, which is
+// what a stream ending in a separator leaves behind.
+func splitNul(data []byte) []string {
+	fields := strings.Split(string(data), "\x00")
+	for len(fields) > 0 && fields[len(fields)-1] == "" {
+		fields = fields[:len(fields)-1]
+	}
+	return fields
+}

--- a/internal/pullrequest/read_test.go
+++ b/internal/pullrequest/read_test.go
@@ -1,0 +1,260 @@
+package pullrequest
+
+import (
+	"strings"
+	"testing"
+)
+
+// The fixtures below are what git actually prints rather than what a reader of
+// its documentation would expect it to print. The first two were copied out of
+// a run against this repository, and the command and the range are written next
+// to each so that anybody can produce them again:
+//
+//	git diff --name-status -z e9a798d...c0a1f23
+//	git diff --numstat -z e9a798d...c0a1f23
+//
+// The commit fixtures are written out here rather than copied, because a real
+// message in this repository is forty lines and what these prove is the
+// separator rather than the prose. The format string they are written against
+// is CommitFormat, which the command passes to git, so a change to one is a
+// change to the other.
+//
+// Nothing in this file runs git. A test that shelled out would prove the parser
+// against whatever version of git the machine happened to carry, and would need
+// a repository to exist before it could run at all.
+
+func TestParseFiles(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want []File
+	}{
+		{
+			name: "an empty diff",
+			out:  "",
+		},
+		{
+			name: "four modified files, copied from a real range",
+			out:  "M\x00.github/workflows/build.yml\x00M\x00.github/workflows/headless.yml\x00M\x00CONTRIBUTING.md\x00M\x00README.md\x00",
+			want: []File{
+				{Path: ".github/workflows/build.yml"},
+				{Path: ".github/workflows/headless.yml"},
+				{Path: "CONTRIBUTING.md"},
+				{Path: "README.md"},
+			},
+		},
+		{
+			name: "an addition and a removal",
+			out:  "A\x00experiments/one/EXPERIMENT.md\x00D\x00experiments/one/measure.go\x00",
+			want: []File{
+				{Path: "experiments/one/EXPERIMENT.md"},
+				{Path: "experiments/one/measure.go", Gone: true},
+			},
+		},
+		{
+			// The shape a reader of the flag would get wrong. One entry, two
+			// paths, and the file is gone at one end of the move and present at
+			// the other. A parser reading one path per status would take the
+			// new path as the next status and produce nonsense from there on.
+			name: "a rename, which prints two paths for one entry",
+			out:  "R100\x00experiments/one/measure.go\x00experiments/two/measure.go\x00",
+			want: []File{
+				{Path: "experiments/one/measure.go", Gone: true},
+				{Path: "experiments/two/measure.go"},
+			},
+		},
+		{
+			name: "a path holding a space, which is not quoted under -z",
+			out:  "M\x00docs/a document.md\x00",
+			want: []File{{Path: "docs/a document.md"}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseFiles([]byte(tc.out))
+			if err != nil {
+				t.Fatalf("cannot read the diff: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("read %d files %v, want %d", len(got), got, len(tc.want))
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("file %d is %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestParseFilesRefusesATruncatedDiff holds the parser to saying it could not
+// read rather than to returning what it managed. A status with no path after it
+// is a stream that was cut, and returning three of four files from it would be
+// a run that judged less than the change and reported nothing about the
+// difference.
+func TestParseFilesRefusesATruncatedDiff(t *testing.T) {
+	if _, err := ParseFiles([]byte("M\x00CONTRIBUTING.md\x00M\x00")); err == nil {
+		t.Fatal("a diff ending after a status with no path was read without complaint")
+	}
+	if _, err := ParseFiles([]byte("R100\x00experiments/one/measure.go\x00")); err == nil {
+		t.Fatal("a rename missing its second path was read without complaint")
+	}
+}
+
+func TestParseLines(t *testing.T) {
+	tests := []struct {
+		name          string
+		out           string
+		want          int
+		wantUncounted []string
+	}{
+		{
+			name: "an empty diff",
+		},
+		{
+			name: "four modified files, copied from a real range",
+			out:  "14\t0\t.github/workflows/build.yml\x009\t0\t.github/workflows/headless.yml\x0011\t1\tCONTRIBUTING.md\x0054\t30\tREADME.md\x00",
+			want: 14 + 0 + 9 + 0 + 11 + 1 + 54 + 30,
+		},
+		{
+			// A binary file prints a dash for each count. Treating that as zero
+			// would report the smallest possible change against the one input
+			// whose size is unknown.
+			name:          "a binary file, which git counts no lines in",
+			out:           "-\t-\tdocs/diagram.png\x0012\t3\tREADME.md\x00",
+			want:          15,
+			wantUncounted: []string{"docs/diagram.png"},
+		},
+		{
+			// Under -z a rename prints its counts, then an empty field, then
+			// the two paths as separate fields.
+			name: "a rename, whose paths follow the counts",
+			out:  "2\t1\t\x00experiments/one/measure.go\x00experiments/two/measure.go\x00",
+			want: 3,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, uncounted, err := ParseLines([]byte(tc.out))
+			if err != nil {
+				t.Fatalf("cannot read the counts: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("counted %d lines, want %d", got, tc.want)
+			}
+			if strings.Join(uncounted, ",") != strings.Join(tc.wantUncounted, ",") {
+				t.Errorf("uncounted is %v, want %v", uncounted, tc.wantUncounted)
+			}
+		})
+	}
+}
+
+func TestParseCommits(t *testing.T) {
+	out := "1111111111111111111111111111111111111111\x1fRefuse a header whose dates disagree with themselves\n" +
+		"\nThe listing sorts on a field nothing parsed. Closes #54.\n\n" +
+		"Signed-off-by: A Contributor <nobody@example.invalid>\n\x00" +
+		"2222222222222222222222222222222222222222\x1fFix the message\n\x00"
+
+	commits, err := ParseCommits([]byte(out))
+	if err != nil {
+		t.Fatalf("cannot read the commits: %v", err)
+	}
+	if len(commits) != 2 {
+		t.Fatalf("read %d commits, want 2", len(commits))
+	}
+	if commits[0].Hash != "1111111111111111111111111111111111111111" {
+		t.Errorf("the first hash is %q", commits[0].Hash)
+	}
+	// The subject stops at the first newline and the message does not, which is
+	// the whole reason both exist.
+	if commits[0].Subject() != "Refuse a header whose dates disagree with themselves" {
+		t.Errorf("the first subject is %q", commits[0].Subject())
+	}
+	if !strings.Contains(commits[0].Message, "Closes #54") {
+		t.Error("the first message lost its body, which is where the reference is")
+	}
+	if commits[1].Subject() != "Fix the message" {
+		t.Errorf("the second subject is %q", commits[1].Subject())
+	}
+}
+
+func TestParseEvent(t *testing.T) {
+	tests := []struct {
+		name          string
+		payload       string
+		isPullRequest bool
+		body          string
+		base, head    string
+	}{
+		{
+			name:    "an event that is not a pull request",
+			payload: `{"ref":"refs/heads/main"}`,
+		},
+		{
+			name:          "a pull request with a body",
+			payload:       `{"pull_request":{"body":"Closes #24.","base":{"sha":"aaa"},"head":{"sha":"bbb"}},"number":7}`,
+			isPullRequest: true,
+			body:          "Closes #24.",
+			base:          "aaa",
+			head:          "bbb",
+		},
+		{
+			// An author who wrote no body at all gives null rather than an
+			// empty string. It is a body that references no issue rather than a
+			// body that was not read, and reading it as the second would let
+			// the emptiest pull request pass.
+			name:          "a pull request whose body is null",
+			payload:       `{"pull_request":{"body":null,"base":{"sha":"aaa"},"head":{"sha":"bbb"}}}`,
+			isPullRequest: true,
+			base:          "aaa",
+			head:          "bbb",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			event, err := ParseEvent([]byte(tc.payload))
+			if err != nil {
+				t.Fatalf("cannot read the payload: %v", err)
+			}
+			if event.IsPullRequest != tc.isPullRequest {
+				t.Errorf("is a pull request is %v, want %v", event.IsPullRequest, tc.isPullRequest)
+			}
+			if event.Body != tc.body {
+				t.Errorf("the body is %q, want %q", event.Body, tc.body)
+			}
+			if event.Base != tc.base || event.Head != tc.head {
+				t.Errorf("the range is %q...%q, want %q...%q", event.Base, event.Head, tc.base, tc.head)
+			}
+		})
+	}
+}
+
+// TestParseEventRefusesSomethingThatIsNotAPayload holds the reader to saying it
+// could not read rather than to returning an empty event. An empty event is a
+// run that judges nothing and reports success, which is the one outcome a gate
+// may never produce by accident.
+func TestParseEventRefusesSomethingThatIsNotAPayload(t *testing.T) {
+	if _, err := ParseEvent([]byte("this is not a payload")); err == nil {
+		t.Fatal("a payload that is not JSON was read without complaint")
+	}
+}
+
+// TestABodyThatNamesNoIssueIsNotRescuedByTheEvent is the join between the two
+// halves of this package: what the platform said, judged by the rule. It exists
+// because the two are proved separately everywhere else, and a reader is
+// entitled to see them meet once.
+func TestABodyThatNamesNoIssueIsNotRescuedByTheEvent(t *testing.T) {
+	event, err := ParseEvent([]byte(`{"pull_request":{"body":"Tidies the check up.","base":{"sha":"aaa"},"head":{"sha":"bbb"}}}`))
+	if err != nil {
+		t.Fatalf("cannot read the payload: %v", err)
+	}
+
+	verdict := Judge(Change{Body: event.Body, BodyRead: event.IsPullRequest})
+	properties := verdict.Properties()
+	if len(properties) != 1 || properties[0] != BodyNamesNoIssue {
+		t.Fatalf("the verdict is %v, want exactly %s", properties, BodyNamesNoIssue)
+	}
+}


### PR DESCRIPTION
Closes #24

## What this changes

Adds the deterministic pull-request check: a workflow that runs one first-party
command on every pull request, and the package that command judges with.

Three refusals, at the confidence the issue asks for. A pull-request body that
references no issue. A commit message in the range that references none. A
change that touches a file under an experiment without touching that
experiment's record in the same pull request. One annotation that never
refuses: above four hundred changed lines the verdict carries a note, because a
size cap that reddened a build would be met by splitting a change into pieces
chosen to please a counter rather than to be read.

The judgement is a function over values. It opens no file, reads no environment
and runs nothing, so every rule is proved against a pull request that has never
existed. Reading the event the platform wrote and asking git about the range is
the command's half, and both of its edges are parameters, so what it prints and
what it returns are read by a test without a platform, a pull request or a
repository.

The means is Go, in this tree, because the three rules this organisation's
contributing guide is built on are the ones a shell block inside a workflow
file cannot carry: a property here is refusable by name, each one has a proof
that was executed, and every number below carries the command that produced it.
The tree already builds, vets, formats and tests Go, so this adds no language,
no runtime and no dependency.

## What failure it prevents

A change that explains itself nowhere. A body is edited afterwards and a commit
message is what survives into the log, so a reader running `git log` on a
change whose reference lived only in a body finds nothing to follow.

A record going quietly out of date. An experiment gains a script and the record
still describes the old measurement; an experiment's code is removed under
record 0004 and the record does not gain the line naming the commit that
removed it. In both the tree is green, the record reads as complete, and what
it says is no longer true. That rule is this board's own and is the reason the
check is worth having here rather than being copied for symmetry.

A gate pointed at the wrong event reporting a clean pull request it never saw.
An event that is not a pull request returns the code for a job that could not be
done, and a run that read nothing prints something a run that read everything
does not.

## What was run

At the commit being pushed, `92f01c2b325ad794ad3a3a4f38a0c512f77bdce3`.

```
go build ./...
go vet ./...
gofmt -l .
(no output)
go test -count=1 ./...
ok  	github.com/Flowfin/lab/cmd/lab	12.091s
ok  	github.com/Flowfin/lab/cmd/pullrequest	3.674s
ok  	github.com/Flowfin/lab/internal/check	4.438s
ok  	github.com/Flowfin/lab/internal/hardware	4.223s
ok  	github.com/Flowfin/lab/internal/invariants	3.905s
ok  	github.com/Flowfin/lab/internal/prose	3.724s
ok  	github.com/Flowfin/lab/internal/pullrequest	4.449s

go run ./cmd/lab check .
examined .
no experiments directory in this tree
0 experiment directories walked, 0 records read
16 decision records read
the time this run read is 2026-08-11T17:43:24Z
0 refused
```

Each of the three refusals was deleted in turn and the suite was run against
the same fixtures, so the block below is what the guard is worth rather than
what it is called. The fourth is the bound on what reaches git.

```
guard deleted: the body rule refuses nothing
--- FAIL: TestJudge
--- FAIL: TestEveryPropertyHasACaseThatRefusesIt
--- FAIL: TestARefusalNamesItsSubject
--- FAIL: TestABodyThatNamesNoIssueIsNotRescuedByTheEvent

guard deleted: the commit rule refuses nothing
--- FAIL: TestJudge
--- FAIL: TestEveryPropertyHasACaseThatRefusesIt
--- FAIL: TestARefusalNamesItsSubject

guard deleted: the record rule refuses nothing
--- FAIL: TestJudge
--- FAIL: TestEveryPropertyHasACaseThatRefusesIt
--- FAIL: TestARefusalNamesItsSubject
--- FAIL: TestTheCommandReachesEveryCodeItCanReturn
--- FAIL: TestTheRecordRuleIsRedAndGreenWhereIssue24SaysItShouldBe

guard deleted: any string is an object name
--- FAIL: TestARangeEndThatIsNotAnObjectNameIsRefusedBeforeGitIsAsked

with all four in place
ok  	github.com/Flowfin/lab/cmd/pullrequest
ok  	github.com/Flowfin/lab/internal/pullrequest
```

The red and green pair the issue asks for, run with the built command against a
real range in a scratch repository rather than against a fixture. Two states of
the same work, differing in whether the record moved with the code:

```
=== the record is not touched ===
examined the pull request
  body: 11 character(s)
  commits: 1, merges excluded
  files: 1
  lines: 2
refused: experiments/one: this change touches files in it and does not touch experiments/one/EXPERIMENT.md, so the record still describes the experiment as it was before (experiment-changed-without-its-record)
1 refusal(s), 0 note(s), 0 rule(s) not judged
exit=1

=== the record moves with it ===
examined the pull request
  body: 11 character(s)
  commits: 2, merges excluded
  files: 2
  lines: 6
0 refusal(s), 0 note(s), 0 rule(s) not judged
exit=0
```

A dry run over a real range in this repository, which is where the git plumbing
is exercised rather than the parsers. The payload named the two commits below
and carried a body:

```
git rev-parse e9a798d c0a1f23
GITHUB_EVENT_PATH=... go run ./cmd/pullrequest
examined the pull request
  body: 43 character(s)
  commits: 2, merges excluded
  files: 4
  lines: 119
0 refusal(s), 0 note(s), 0 rule(s) not judged
exit=0
```

The counts behind the departure named below:

```
git log --no-merges --format=%s origin/main | wc -l
49

git log --no-merges --format=%s origin/main |
  grep -cE '(^|[^A-Za-z0-9_])([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#[1-9][0-9]*'
4

git log --no-merges --format=%H origin/main | while read -r h; do
  git log -1 --format=%B "$h" |
    grep -qE '(^|[^A-Za-z0-9_])([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#[1-9][0-9]*' &&
    echo "$h"
done | wc -l
35
```

## What this does not do

It never says the change is good and it never says the change was read. Each
rule is a property of the shape of a pull request rather than of its content:
that a number was written down, not that it is the right number; that two files
moved together, not that what they say agrees.

The rule over commits reads the whole message where the issue asks for the
subject. The counts above are why: the subject reading would refuse forty-five
of the forty-nine commits already on the default branch, thirty-one of which
name their issue in the message body, and the same issue asks in the same
paragraph that the check not red-flag reasonable work. Tightening it to the
subject is a decision about how messages are written here rather than about what
the check can see, and it is one line if that is the answer.

It is a second entry point under `cmd/`, and record 0002 names `cmd/lab` and not
this. The reasoning is at the top of `cmd/pullrequest/main.go`: `lab` reads a
checkout and writes nothing, a claim every document here repeats, and telling a
change from the tree it lands needs both ends of a range. Whether that needs its
own decision record is the one judgement in this change to check rather than
accept.

The red case above ran against a scratch repository and not against a pull
request on this board, because no experiment record exists here yet for a real
pull request to edit. What runs live on this pull request is the green half.

Nothing holds the three exit codes equal to the runner's. Record 0011 is the
contract and this is the third producer of a code named in it, following the
shape the integration-hardware harness already set by declaring its own where
its producer is. That gap belongs to #52 rather than to this change.

No second reader tonight. The transcript above is in place of one, and every
number in it carries the command that produced it.
