### PR TITLE
Refuse an answer that is rewritten rather than added to

### DIFF
--- a/cmd/pullrequest/main.go
+++ b/cmd/pullrequest/main.go
@@ -151,6 +151,13 @@ func readChange(event pullrequest.Event, git func(args ...string) ([]byte, error
 	change.Commits = commits
 	change.CommitsRead = true
 
+	records, err := readRecords(event, git, files)
+	if err != nil {
+		return change, err
+	}
+	change.Records = records
+	change.RecordsRead = true
+
 	out, err = git("diff", "--numstat", "-z", span)
 	if err != nil {
 		return change, err
@@ -164,6 +171,67 @@ func readChange(event pullrequest.Event, git func(args ...string) ([]byte, error
 	change.LinesCounted = true
 
 	return change, nil
+}
+
+// readRecords reads every experiment record the change touched, at both ends of
+// the range.
+//
+// It reads them out of git rather than off the disk. What is checked out on a
+// pull request is a merge of the two ends rather than either of them, so a file
+// read from the working tree is a third thing, and a rule about what a change
+// did to a record cannot be made against it.
+//
+// Presence is asked before the bytes are. A record this change creates has no
+// version at the base, and a command that read a missing path as a failure
+// would report the change this board wants most as a run that could not be
+// made.
+func readRecords(event pullrequest.Event, git func(args ...string) ([]byte, error), files []pullrequest.File) ([]pullrequest.RecordChange, error) {
+	seen := make(map[string]bool)
+	var records []pullrequest.RecordChange
+
+	for _, file := range files {
+		if !pullrequest.IsRecordPath(file.Path) || seen[file.Path] {
+			continue
+		}
+		seen[file.Path] = true
+
+		record := pullrequest.RecordChange{Path: file.Path}
+		for _, end := range []struct {
+			rev     string
+			bytes   *[]byte
+			present *bool
+		}{
+			{event.Base, &record.Before, &record.BeforePresent},
+			{event.Head, &record.After, &record.AfterPresent},
+		} {
+			present, err := pathIsAt(git, end.rev, file.Path)
+			if err != nil {
+				return nil, err
+			}
+			*end.present = present
+			if !present {
+				continue
+			}
+			data, err := git("show", end.rev+":"+file.Path)
+			if err != nil {
+				return nil, err
+			}
+			*end.bytes = data
+		}
+		records = append(records, record)
+	}
+	return records, nil
+}
+
+// pathIsAt says whether a path is in the tree at a revision. It asks a question
+// git answers with an empty list rather than with a failure, so a missing path
+// and a broken invocation stay different outcomes.
+func pathIsAt(git func(args ...string) ([]byte, error), rev, path string) (bool, error) {
+	out, err := git("ls-tree", "-z", "--name-only", rev, "--", path)
+	if err != nil {
+		return false, err
+	}
+	return len(strings.TrimSpace(string(out))) > 0, nil
 }
 
 // looksLikeAnObjectName says whether a string is the shape git prints for a

--- a/cmd/pullrequest/main_test.go
+++ b/cmd/pullrequest/main_test.go
@@ -21,10 +21,17 @@ func event(body string) []byte {
 		body))
 }
 
-// gitSaying answers the three questions the command asks, in whatever order it
-// asks them, and records what it was asked so a test can hold the range to its
-// shape.
+// gitSaying answers the questions the command asks, in whatever order it asks
+// them, and records what it was asked so a test can hold the range to its shape.
 func gitSaying(files, log, numstat string, asked *[][]string) func(...string) ([]byte, error) {
+	return gitSayingWithBlobs(files, log, numstat, nil, asked)
+}
+
+// gitSayingWithBlobs is the same with a tree behind it. The keys are what git
+// show is asked for, `<revision>:<path>`, and a key that is not there is a path
+// that is not in the tree at that revision, which is the answer ls-tree gives
+// as an empty list rather than as a failure.
+func gitSayingWithBlobs(files, log, numstat string, blobs map[string]string, asked *[][]string) func(...string) ([]byte, error) {
 	return func(args ...string) ([]byte, error) {
 		if asked != nil {
 			*asked = append(*asked, args)
@@ -32,6 +39,15 @@ func gitSaying(files, log, numstat string, asked *[][]string) func(...string) ([
 		switch {
 		case args[0] == "log":
 			return []byte(log), nil
+		case args[0] == "show":
+			return []byte(blobs[args[1]]), nil
+		case args[0] == "ls-tree":
+			// ls-tree -z --name-only <revision> -- <path>
+			revision, path := args[3], args[5]
+			if _, present := blobs[revision+":"+path]; !present {
+				return nil, nil
+			}
+			return []byte(path + "\x00"), nil
 		case contains(args, "--numstat"):
 			return []byte(numstat), nil
 		default:
@@ -253,5 +269,58 @@ func TestTheReportSaysWhatItExamined(t *testing.T) {
 		if !strings.Contains(out.String(), want) {
 			t.Errorf("the report does not say %q:\n%s", want, out.String())
 		}
+	}
+}
+
+// theLandedRecord is an experiment record in state answered, as it stands on
+// the branch a change lands on.
+const theLandedRecord = "Slug: one\nState: answered\nQuestion-Written: 2026-08-01\n\n" +
+	"## Question\n\nDoes the walk cost more than a second?\n\n" +
+	"## Method\n\nTimed it.\n\n" +
+	"## Answer\n\nNo. It took eleven seconds.\n"
+
+// TestAnAnswerAlreadyLandedIsReadFromBothEndsOfTheRange is the whole route for
+// the rule that a landed answer may grow and may not change: the command asks
+// git for the record at each end of the range, and the judgement compares them.
+// The two pull requests below differ in the answer and in nothing else.
+func TestAnAnswerAlreadyLandedIsReadFromBothEndsOfTheRange(t *testing.T) {
+	const base = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const head = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	const path = "experiments/one/EXPERIMENT.md"
+
+	rewritten := strings.Replace(theLandedRecord, "It took eleven seconds.", "It took two seconds.", 1)
+	addedTo := theLandedRecord + "\nCorrected on 2026-09-01. Eleven seconds was a cold cache.\n"
+
+	tests := []struct {
+		name string
+		at   string
+		want int
+	}{
+		{name: "the answer is rewritten", at: rewritten, want: exitRefused},
+		{name: "the answer is added to", at: addedTo, want: exitClean},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := edges{
+				event: func() ([]byte, error) { return event("Closes #58."), nil },
+				git: gitSayingWithBlobs(
+					"M\x00"+path+"\x00",
+					cleanLog,
+					"2\t2\t"+path+"\x00",
+					map[string]string{
+						base + ":" + path: theLandedRecord,
+						head + ":" + path: tc.at,
+					}, nil),
+			}
+
+			var out, errOut bytes.Buffer
+			if got := run(&out, &errOut, e); got != tc.want {
+				t.Fatalf("returned %d, want %d: %s %s", got, tc.want, out.String(), errOut.String())
+			}
+			if !strings.Contains(out.String(), "records: 1, 1 of them already on the branch this lands on") {
+				t.Errorf("the report does not say what it read:\n%s", out.String())
+			}
+		})
 	}
 }

--- a/internal/pullrequest/pullrequest.go
+++ b/internal/pullrequest/pullrequest.go
@@ -251,6 +251,15 @@ type Change struct {
 	// found no experiment in a diff it never read is a rule that says nothing.
 	FilesRead bool
 
+	// Records are the experiment records the change touched, at both ends of
+	// the range. They are separate from Files because the rules over them read
+	// bytes rather than paths, and reading the bytes at the base costs a
+	// question per record that the path rules do not need.
+	Records []RecordChange
+
+	// RecordsRead says the records were read at all.
+	RecordsRead bool
+
 	// ChangedLines is how many lines the range added and removed together.
 	ChangedLines int
 
@@ -339,6 +348,7 @@ func Judge(change Change) Verdict {
 	verdict.add(judgeBody(change))
 	verdict.add(judgeCommits(change))
 	verdict.add(judgeExperiments(change))
+	verdict.add(judgeRecords(change))
 	verdict.add(judgeSize(change))
 
 	return verdict
@@ -455,6 +465,15 @@ func judgeExperiments(change Change) Verdict {
 	return verdict
 }
 
+// IsRecordPath says whether a path is an experiment's record. It is exported
+// because whoever assembles a Change has to know which of the paths in a diff
+// are worth asking git about twice, and a second copy of that judgement in the
+// command is a second place for it to be wrong.
+func IsRecordPath(path string) bool {
+	_, isRecord, ok := experimentOf(path)
+	return ok && isRecord
+}
+
 // experimentOf places a path inside an experiment. It returns the slug, whether
 // the path is that experiment's record, and whether the path is inside an
 // experiment at all.
@@ -505,6 +524,7 @@ func (v Verdict) Report(change Change) string {
 	out += fmt.Sprintf("  body: %s\n", describeBody(change))
 	out += fmt.Sprintf("  commits: %s\n", describeCommits(change))
 	out += fmt.Sprintf("  files: %s\n", describeFiles(change))
+	out += fmt.Sprintf("  records: %s\n", describeRecords(change))
 	out += fmt.Sprintf("  lines: %s\n", describeLines(change))
 
 	for _, skip := range v.Skips {
@@ -541,6 +561,19 @@ func describeFiles(change Change) string {
 		return "none were read"
 	}
 	return fmt.Sprintf("%d", len(change.Files))
+}
+
+func describeRecords(change Change) string {
+	if !change.RecordsRead {
+		return "none were read"
+	}
+	landed := 0
+	for _, record := range change.Records {
+		if record.BeforePresent {
+			landed++
+		}
+	}
+	return fmt.Sprintf("%d, %d of them already on the branch this lands on", len(change.Records), landed)
 }
 
 func describeLines(change Change) string {

--- a/internal/pullrequest/pullrequest_test.go
+++ b/internal/pullrequest/pullrequest_test.go
@@ -36,6 +36,7 @@ func clean() Change {
 		},
 		FilesRead:    true,
 		Files:        []File{{Path: "internal/pullrequest/pullrequest.go"}},
+		RecordsRead:  true,
 		ChangedLines: 12,
 		LinesCounted: true,
 	}
@@ -73,8 +74,12 @@ func TestJudge(t *testing.T) {
 // is removed from the coverage proof below as well. A list of cases kept beside
 // the cases is the shape where a fixture is deleted and the test that counted
 // it goes on counting.
+//
+// The cases over a record at both ends of the range are in record_test.go, next
+// to the rule they are about, and they are returned into this table rather than
+// run from a second harness.
 func judgeCases() []judgeCase {
-	return []judgeCase{
+	return append(recordJudgeCases(), []judgeCase{
 		{
 			name:   "a change that names its issue and touches no experiment",
 			change: clean(),
@@ -283,10 +288,11 @@ func judgeCases() []judgeCase {
 				BodyNamesNoIssue,
 				CommitMessageNamesNoIssue,
 				ExperimentChangedWithoutItsRecord,
+				AnswerAlreadyLandedWasRewritten,
 				ChangeIsLargerThanOneReading,
 			},
 		},
-	}
+	}...)
 }
 
 // TestEveryPropertyHasACaseThatRefusesIt refuses a property no case in the
@@ -302,6 +308,7 @@ func TestEveryPropertyHasACaseThatRefusesIt(t *testing.T) {
 		BodyNamesNoIssue,
 		CommitMessageNamesNoIssue,
 		ExperimentChangedWithoutItsRecord,
+		AnswerAlreadyLandedWasRewritten,
 	}
 
 	refused := make(map[string]bool)

--- a/internal/pullrequest/record.go
+++ b/internal/pullrequest/record.go
@@ -1,0 +1,203 @@
+package pullrequest
+
+// The rule this board's central claim rests on: a record already on the default
+// branch is added to and never rewritten.
+//
+// WHY IT IS HERE AND NOT IN THE RUNNER. The runner reads a checkout, and
+// telling a rewritten answer from a new one needs the version already on the
+// default branch, which is history rather than a tree. Giving the runner a
+// history reader would cost it the near-zero dependency surface record 0001
+// chose and the claim that it opens no connection leans on. This check already
+// holds both ends of the range, so the comparison belongs here.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Flowfin/lab/internal/check"
+)
+
+// AnswerAlreadyLandedWasRewritten refuses a change that removes or alters a
+// line of an answer section in a record that was already answered at the base
+// of the range.
+//
+// The failure has a shape and it is not malicious. An experiment answered no.
+// Months later the same work is being offered somewhere, or the answer simply
+// reads worse than it felt at the time, and one line makes it read better.
+// Every other check here stays green through that edit, and the diff arrives in
+// a pull request nobody reads closely because the record is four paragraphs
+// long. A record whose answer can be quietly improved later is a record a
+// reader cannot use as evidence, because the version in front of them is the
+// version somebody was last comfortable with.
+//
+// Adding is the whole of what is allowed, and it covers every honest case
+// including the one where the first answer turned out to be wrong: the
+// correction is added underneath, saying what was wrong and how it was found.
+const AnswerAlreadyLandedWasRewritten = "answer-already-landed-was-rewritten"
+
+// A RecordChange is one experiment record at both ends of the range. It carries
+// bytes rather than a parsed record, because what parses at one end may not
+// parse at the other and that difference is itself something a rule reads.
+type RecordChange struct {
+	// Path is where the record is, relative to the root of the repository.
+	Path string
+
+	// Before is the record as it was at the base of the range, and
+	// BeforePresent says there was one. A record this change creates has no
+	// before, which is not a violation of anything and is the case the board
+	// wants most.
+	Before        []byte
+	BeforePresent bool
+
+	// After is the record at the head of the range, and AfterPresent says it
+	// is still there. A record this change removes has no after. That a landed
+	// record may not be removed at all is a different rule about a different
+	// failure, and it is issue #69's rather than this one's.
+	After        []byte
+	AfterPresent bool
+}
+
+// judgeRecords holds every record in the change to the rule above.
+//
+// TWO BOUNDARIES, WRITTEN HERE RATHER THAN DISCOVERED.
+//
+// A record whose state at the base of the range was not answered is not
+// covered. Writing an answer for the first time is the thing this board wants,
+// and a check that made the first draft permanent would teach people to commit
+// nothing until they were certain, which is how an experiment ends up with no
+// written answer at all. The same reasoning covers a record that did not exist
+// at the base.
+//
+// Nothing here judges whether an added correction is honest. A correction that
+// contradicts the original without saying so passes this. What the check buys is
+// that the original is still there to be read next to it, which is the
+// difference between a record and a current opinion, and review is where the
+// rest is caught.
+func judgeRecords(change Change) Verdict {
+	if !change.RecordsRead {
+		return Verdict{Skips: []Skip{{
+			Rule: AnswerAlreadyLandedWasRewritten,
+			Why:  "this run was given no records, so no answer was compared against the one already landed",
+		}}}
+	}
+
+	var verdict Verdict
+	for _, record := range change.Records {
+		verdict.add(judgeOneRecord(record))
+	}
+	return verdict
+}
+
+func judgeOneRecord(record RecordChange) Verdict {
+	if !record.BeforePresent || !record.AfterPresent {
+		return Verdict{}
+	}
+
+	before, err := check.ParseRecord(record.Before)
+	if err != nil {
+		// Nothing can read a section out of bytes that are not a record. The
+		// state at the base decides whether this rule applies at all, so a
+		// base that cannot be read is a base this rule has nothing to say
+		// about, and the checker is what refuses a record that is not one.
+		return Verdict{}
+	}
+	if state, present := before.Field(check.FieldState); !present || state != check.StateAnswered {
+		return Verdict{}
+	}
+	landed, present := before.Section(check.SectionAnswer)
+	if !present {
+		return Verdict{}
+	}
+
+	after, err := check.ParseRecord(record.After)
+	if err != nil {
+		// The head no longer parses as a record, so the answer cannot be shown
+		// to be intact. It is refused here rather than passed to the checker,
+		// because the checker walks the tree and would report a record it
+		// cannot read without ever saying that an answer already landed went
+		// missing inside it.
+		return Verdict{Refusals: []Refusal{{
+			Property: AnswerAlreadyLandedWasRewritten,
+			Subject:  record.Path,
+			Detail:   fmt.Sprintf("it was answered at the base of this range and no longer parses as a record, so its %s section cannot be shown to still carry what it carried", check.SectionAnswer),
+		}}}
+	}
+	current, present := after.Section(check.SectionAnswer)
+	if !present {
+		return Verdict{Refusals: []Refusal{{
+			Property: AnswerAlreadyLandedWasRewritten,
+			Subject:  record.Path,
+			Detail:   fmt.Sprintf("its %s section is gone and it carried an answer at the base of this range", check.SectionAnswer),
+		}}}
+	}
+
+	missing, found := firstLineLost(landed, current)
+	if !found {
+		return Verdict{}
+	}
+	return Verdict{Refusals: []Refusal{{
+		Property: AnswerAlreadyLandedWasRewritten,
+		Subject:  record.Path,
+		Detail: fmt.Sprintf("its %s section no longer carries %q, and an answer already landed may grow and may not change, so a correction goes underneath saying what was wrong and how it was found",
+			check.SectionAnswer, shorten(missing)),
+	}}}
+}
+
+// firstLineLost says whether every line the landed section carried is still in
+// the current one, in the order it was written, and returns the first that is
+// not.
+//
+// It is a subsequence rather than a prefix, so a line added between two that
+// were already there is allowed. Adding is the whole of what the rule permits
+// and where the addition sits is the author's judgement.
+//
+// Blank lines are not compared. A blank line carries no words, and a paragraph
+// separated differently is not an answer that was rewritten. Every other
+// difference is: a line reflowed, a word changed, a sentence softened.
+func firstLineLost(landed, current string) (string, bool) {
+	want := meaningfulLines(landed)
+	have := meaningfulLines(current)
+
+	at := 0
+	for _, line := range want {
+		found := false
+		for at < len(have) {
+			if have[at] == line {
+				at++
+				found = true
+				break
+			}
+			at++
+		}
+		if !found {
+			return line, true
+		}
+	}
+	return "", false
+}
+
+// meaningfulLines is the lines of a section that carry words, with the
+// whitespace at their ends removed so that a trailing space is not the whole of
+// what a check refuses. The formatting rules refuse such a space anyway, and
+// this rule is about what an answer says.
+func meaningfulLines(text string) []string {
+	var lines []string
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimRight(line, " \t\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+// shorten cuts a quoted line to something a message can carry. A refusal naming
+// a whole paragraph is a refusal nobody reads to the end of.
+func shorten(line string) string {
+	const bound = 72
+	if len([]rune(line)) <= bound {
+		return line
+	}
+	return string([]rune(line)[:bound]) + "..."
+}

--- a/internal/pullrequest/record_test.go
+++ b/internal/pullrequest/record_test.go
@@ -1,0 +1,227 @@
+package pullrequest
+
+import (
+	"strings"
+	"testing"
+)
+
+// recordAt builds a record in the shape docs/experiment-template.md carries,
+// with the state and the answer a case needs. Building it from one function is
+// what keeps every case below a near miss: two records in a case differ in the
+// answer and in nothing else, so a refusal is about the answer.
+func recordAt(state, answer string) []byte {
+	return []byte("Slug: one\n" +
+		"State: " + state + "\n" +
+		"Question-Written: 2026-08-01\n" +
+		"Needs-Hardware: none\n" +
+		"\n" +
+		"## Question\n" +
+		"\n" +
+		"Does the walk cost more than a second on a tree of a thousand records?\n" +
+		"\n" +
+		"## Method\n" +
+		"\n" +
+		"Built the tree and timed the walk.\n" +
+		"\n" +
+		"## Answer\n" +
+		"\n" +
+		answer + "\n")
+}
+
+// theLandedAnswer is what every case below starts from at the base of the
+// range.
+const theLandedAnswer = "No. The walk took eleven seconds, and the cost is in\n" +
+	"reading the records rather than in walking the tree."
+
+// recordJudgeCases are the cases over the rule that an answer already landed
+// may grow and may not change. They are returned into the one table so that the
+// proof that every property has a case reads them too.
+func recordJudgeCases() []judgeCase {
+	landed := recordAt("answered", theLandedAnswer)
+
+	withRecords := func(records ...RecordChange) Change {
+		c := clean()
+		c.Files = []File{{Path: "experiments/one/EXPERIMENT.md"}}
+		c.Records = records
+		return c
+	}
+
+	return []judgeCase{
+		{
+			name: "an answer already landed, with a correction added underneath",
+			change: withRecords(RecordChange{
+				Path:          "experiments/one/EXPERIMENT.md",
+				Before:        landed,
+				BeforePresent: true,
+				After: recordAt("answered", theLandedAnswer+"\n\n"+
+					"Corrected on 2026-09-01. The eleven seconds were a cold cache,\n"+
+					"and a warm one takes two. Found by running it twice."),
+				AfterPresent: true,
+			}),
+		},
+		{
+			name: "an answer already landed, with one line altered",
+			change: withRecords(RecordChange{
+				Path:          "experiments/one/EXPERIMENT.md",
+				Before:        landed,
+				BeforePresent: true,
+				After: recordAt("answered", "No. The walk took two seconds, and the cost is in\n"+
+					"reading the records rather than in walking the tree."),
+				AfterPresent: true,
+			}),
+			// The whole failure in one line. The record now says something
+			// nobody measured on the day it was written, and every other check
+			// here stays green through it.
+			want: []string{AnswerAlreadyLandedWasRewritten},
+		},
+		{
+			name: "an answer already landed, with one line removed",
+			change: withRecords(RecordChange{
+				Path:          "experiments/one/EXPERIMENT.md",
+				Before:        landed,
+				BeforePresent: true,
+				After:         recordAt("answered", "No. The walk took eleven seconds, and the cost is in"),
+				AfterPresent:  true,
+			}),
+			want: []string{AnswerAlreadyLandedWasRewritten},
+		},
+		{
+			name: "an answer already landed, with its blank lines moved",
+			change: withRecords(RecordChange{
+				Path:          "experiments/one/EXPERIMENT.md",
+				Before:        landed,
+				BeforePresent: true,
+				After:         recordAt("answered", "\n"+theLandedAnswer+"\n"),
+				AfterPresent:  true,
+			}),
+			// A blank line carries no words. Refusing this would be a rule
+			// about layout wearing the name of a rule about honesty.
+		},
+		{
+			name: "an answer written for the first time",
+			change: withRecords(RecordChange{
+				Path:          "experiments/one/EXPERIMENT.md",
+				Before:        recordAt("asking", ""),
+				BeforePresent: true,
+				After:         recordAt("answered", theLandedAnswer),
+				AfterPresent:  true,
+			}),
+			// The boundary the issue asks for at the check. A rule that made
+			// the first draft permanent would teach people to commit nothing
+			// until they were certain, which is how an experiment ends up with
+			// no written answer at all.
+		},
+		{
+			name: "a draft answer redrafted while the record is still asking",
+			change: withRecords(RecordChange{
+				Path:          "experiments/one/EXPERIMENT.md",
+				Before:        recordAt("asking", "So far it looks like eleven seconds, and that is not measured yet."),
+				BeforePresent: true,
+				After:         recordAt("answered", theLandedAnswer),
+				AfterPresent:  true,
+			}),
+			// The boundary, in the shape that proves it. A record still asking
+			// carries whatever its author is working on, and holding a draft
+			// to the rule for a landed answer would teach people to write
+			// nothing down until they were certain. Without the state at the
+			// base being read, this is refused.
+		},
+		{
+			name: "a record this change creates",
+			change: withRecords(RecordChange{
+				Path:         "experiments/one/EXPERIMENT.md",
+				After:        recordAt("asking", ""),
+				AfterPresent: true,
+			}),
+		},
+		{
+			name: "an answered record whose answer heading is gone",
+			change: withRecords(RecordChange{
+				Path:          "experiments/one/EXPERIMENT.md",
+				Before:        landed,
+				BeforePresent: true,
+				After: []byte("Slug: one\nState: answered\nQuestion-Written: 2026-08-01\n\n" +
+					"## Question\n\nDoes it?\n"),
+				AfterPresent: true,
+			}),
+			want: []string{AnswerAlreadyLandedWasRewritten},
+		},
+		{
+			name: "an answered record that no longer parses as a record",
+			change: withRecords(RecordChange{
+				Path:          "experiments/one/EXPERIMENT.md",
+				Before:        landed,
+				BeforePresent: true,
+				After:         []byte("Just prose now, with no header at all.\n"),
+				AfterPresent:  true,
+			}),
+			// The evasion worth closing. Removing the header takes the answer
+			// out of reach of every rule that reads a section, and the checker
+			// walking the tree would report a record it cannot read without
+			// ever saying an answer went missing inside it.
+			want: []string{AnswerAlreadyLandedWasRewritten},
+		},
+	}
+}
+
+// TestARewrittenAnswerNamesTheRecordAndTheSection holds the refusal to carrying
+// both things whoever hit it needs. A message saying an answer changed, without
+// saying in which record or which section, sends a reader to search a diff.
+func TestARewrittenAnswerNamesTheRecordAndTheSection(t *testing.T) {
+	change := clean()
+	change.Files = []File{{Path: "experiments/one/EXPERIMENT.md"}}
+	change.Records = []RecordChange{{
+		Path:          "experiments/one/EXPERIMENT.md",
+		Before:        recordAt("answered", theLandedAnswer),
+		BeforePresent: true,
+		After:         recordAt("answered", "Yes, and it was quick."),
+		AfterPresent:  true,
+	}}
+
+	verdict := Judge(change)
+	if len(verdict.Refusals) != 1 {
+		t.Fatalf("%d refusals, want 1: %v", len(verdict.Refusals), verdict.Refusals)
+	}
+	refusal := verdict.Refusals[0]
+	if refusal.Subject != "experiments/one/EXPERIMENT.md" {
+		t.Errorf("the refusal names %q as its subject", refusal.Subject)
+	}
+	if !strings.Contains(refusal.Detail, "Answer") {
+		t.Errorf("the refusal does not name the section: %q", refusal.Detail)
+	}
+	if !strings.Contains(refusal.Detail, "No. The walk took eleven seconds") {
+		t.Errorf("the refusal does not quote the line that went missing: %q", refusal.Detail)
+	}
+}
+
+// TestALineIsFoundLostWhereverItWas proves the comparison the rule rests on,
+// over the shapes the cases do not reach. It is a subsequence rather than a
+// prefix, because where an addition sits is the author's judgement and only
+// what was removed or altered is this rule's business.
+func TestALineIsFoundLostWhereverItWas(t *testing.T) {
+	tests := []struct {
+		name            string
+		landed, current string
+		lost            bool
+	}{
+		{name: "nothing landed", current: "anything"},
+		{name: "unchanged", landed: "one\ntwo", current: "one\ntwo"},
+		{name: "added underneath", landed: "one\ntwo", current: "one\ntwo\nthree"},
+		{name: "added in the middle", landed: "one\ntwo", current: "one\nand a half\ntwo"},
+		{name: "added above", landed: "one\ntwo", current: "nought\none\ntwo"},
+		{name: "reordered", landed: "one\ntwo", current: "two\none", lost: true},
+		{name: "one word changed", landed: "one\ntwo", current: "one\ntoo", lost: true},
+		{name: "one line removed", landed: "one\ntwo", current: "one", lost: true},
+		{name: "everything removed", landed: "one\ntwo", current: "", lost: true},
+		{name: "reflowed onto one line", landed: "one\ntwo", current: "one two", lost: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, lost := firstLineLost(tc.landed, tc.current)
+			if lost != tc.lost {
+				t.Fatalf("a line lost is %v, want %v", lost, tc.lost)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #58

## What this changes

An answer section that was already `answered` at the base of the range may grow
and may not change. Every line it carried has to still be there, in the order it
was written; a correction goes underneath, saying what was wrong and how it was
found.

The rule sits with the deterministic pull-request check rather than in the
runner, which is where the issue puts it and for the reason it gives: telling a
rewritten answer from a new one needs the version already on the branch, which
is history rather than a checkout, and giving the runner a history reader would
cost it the dependency surface record 0001 chose and the claim that it opens no
connection leans on. The check already holds both ends of the range.

The command reads each touched record at both ends out of git rather than off
the disk. What is checked out on a pull request is a merge of the two ends
rather than either of them, so a file read from the working tree is a third
thing and a rule about what a change did to a record cannot be made against it.

Lines may be added anywhere in the section rather than only at the end, because
where an addition sits is the author's judgement and only what was removed or
altered is this rule's business. Blank lines are not compared: a blank line
carries no words, and refusing a paragraph separated differently would be a rule
about layout wearing the name of a rule about honesty.

A head that no longer parses as a record is refused too. Removing the header
would otherwise take the answer out of reach of every rule that reads a section,
and the checker walking the tree would report a record it cannot read without
ever saying that an answer already landed went missing inside it.

## What failure it prevents

An answer quietly improved after the fact. The failure is not malicious: an
experiment answered no, months later the same work is being offered somewhere or
the answer simply reads worse than it felt at the time, and one line makes it
read better. Every other check here stays green through that edit, and the diff
arrives in a pull request nobody reads closely because the record is four
paragraphs long.

What it protects is the only thing that makes a record evidence: that the
version in front of a reader is the version that was written, rather than the
version somebody was last comfortable with.

## What was run

At the commit being pushed, `496d01742aacff5a9e7fa857dba51087630d1751`.

```
go build ./...
go vet ./...
gofmt -l .
(no output)
go test -count=1 ./...
ok  	github.com/Flowfin/lab/cmd/lab	7.446s
ok  	github.com/Flowfin/lab/cmd/pullrequest	2.539s
ok  	github.com/Flowfin/lab/internal/check	2.255s
ok  	github.com/Flowfin/lab/internal/hardware	2.640s
ok  	github.com/Flowfin/lab/internal/invariants	2.880s
ok  	github.com/Flowfin/lab/internal/prose	2.477s
ok  	github.com/Flowfin/lab/internal/pullrequest	3.568s

go run ./cmd/lab check .
16 decision records read
the time this run read is 2026-08-11T18:15:02Z
0 refused
```

Both guards were deleted in turn and the suite run against the same fixtures, so
what is below is what each is worth rather than what it is called. The second is
the boundary, and the case that proves it is a draft answer redrafted while the
record is still `asking`.

```
guard deleted: no line is ever found lost
--- FAIL: TestJudge
--- FAIL: TestARewrittenAnswerNamesTheRecordAndTheSection
--- FAIL: TestALineIsFoundLostWhereverItWas
--- FAIL: TestAnAnswerAlreadyLandedIsReadFromBothEndsOfTheRange

guard deleted: the state at the base is not read
--- FAIL: TestJudge

with both in place
ok  	github.com/Flowfin/lab/internal/pullrequest
ok  	github.com/Flowfin/lab/cmd/pullrequest
```

The red and green pair, run with the built command against a real range in a
scratch repository. Two changes to the same landed record, differing in whether
the answer was rewritten or added to:

```
=== the answer is rewritten ===
examined the pull request
  body: 11 character(s)
  commits: 1, merges excluded
  files: 1
  records: 1, 1 of them already on the branch this lands on
  lines: 2
refused: experiments/one/EXPERIMENT.md: its Answer section no longer carries "No. The walk took eleven seconds, and the cost is in reading the records", and an answer already landed may grow and may not change, so a correction goes underneath saying what was wrong and how it was found (answer-already-landed-was-rewritten)
1 refusal(s), 0 note(s), 0 rule(s) not judged
exit=1

=== the answer is added to ===
examined the pull request
  body: 11 character(s)
  commits: 1, merges excluded
  files: 1
  records: 1, 1 of them already on the branch this lands on
  lines: 3
0 refusal(s), 0 note(s), 0 rule(s) not judged
exit=0
```

## What this does not do

It judges nothing about whether an added correction is honest. A correction that
contradicts the original without saying so passes. What the rule buys is that
the original is still there to be read next to it, which is the difference
between a record and a current opinion, and review is where the rest is caught.

A record whose state at the base of the range was not `answered` is not covered.
Writing an answer for the first time is the thing this board wants, and a check
that made the first draft permanent would teach people to commit nothing until
they were certain, which is how an experiment ends up with no written answer at
all.

A record removed along with its files satisfies this rule, because its path is
in the change. That a landed record may not be removed at all is a different
rule about a different failure and it is #69's.

The red case above ran against a scratch repository rather than against a pull
request on this board, because there is no experiment record here yet for a real
pull request to edit. What runs live on this pull request is the half where the
rule finds nothing, and the report line saying how many records it read is in
that run.

No second reader tonight. The transcript above is in place of one, and every
number in it carries the command that produced it.
