### PR TITLE
Refuse a question that is rewritten after the work started

### DIFF
--- a/internal/pullrequest/pullrequest_test.go
+++ b/internal/pullrequest/pullrequest_test.go
@@ -289,6 +289,7 @@ func judgeCases() []judgeCase {
 				CommitMessageNamesNoIssue,
 				ExperimentChangedWithoutItsRecord,
 				AnswerAlreadyLandedWasRewritten,
+				QuestionAlreadyAskedWasRewritten,
 				ChangeIsLargerThanOneReading,
 			},
 		},
@@ -309,6 +310,7 @@ func TestEveryPropertyHasACaseThatRefusesIt(t *testing.T) {
 		CommitMessageNamesNoIssue,
 		ExperimentChangedWithoutItsRecord,
 		AnswerAlreadyLandedWasRewritten,
+		QuestionAlreadyAskedWasRewritten,
 	}
 
 	refused := make(map[string]bool)

--- a/internal/pullrequest/record.go
+++ b/internal/pullrequest/record.go
@@ -35,6 +35,30 @@ import (
 // correction is added underneath, saying what was wrong and how it was found.
 const AnswerAlreadyLandedWasRewritten = "answer-already-landed-was-rewritten"
 
+// QuestionAlreadyAskedWasRewritten refuses a change that removes or alters a
+// line of the question section of a record that was already on the branch this
+// change lands on.
+//
+// An experiment states its question before it starts, and the whole value of
+// that sentence is the ordering: a question written before the work is a
+// question the result cannot have been chosen to fit. Nothing held the question
+// to that ordering after the commit that wrote it. It was checked for being
+// non-empty on the day it landed and for nothing at all afterwards.
+//
+// The failure needs no bad faith and it is the most likely dishonest edit here,
+// because it is the one that makes a record read better rather than worse. An
+// experiment asked whether one approach was faster than another. The
+// measurement came back saying something adjacent and more interesting. Editing
+// the question to name what was measured turns a result nobody predicted into a
+// result the record claims was the point, and every other check stays green
+// through it. The edit arrives in the same pull request as the answer, which is
+// the change a reader is reading for something else.
+//
+// Where the question turned out to be the wrong question, that is itself an
+// answer and the lifecycle already names it: the answer section says so, the
+// question stays as it was asked, and the record is finished rather than tidied.
+const QuestionAlreadyAskedWasRewritten = "question-already-asked-was-rewritten"
+
 // A RecordChange is one experiment record at both ends of the range. It carries
 // bytes rather than a parsed record, because what parses at one end may not
 // parse at the other and that difference is itself something a rule reads.
@@ -57,28 +81,44 @@ type RecordChange struct {
 	AfterPresent bool
 }
 
-// judgeRecords holds every record in the change to the rule above.
+// judgeRecords holds every record in the change to the two rules above.
 //
-// TWO BOUNDARIES, WRITTEN HERE RATHER THAN DISCOVERED.
+// THE BOUNDARIES, WRITTEN HERE RATHER THAN DISCOVERED.
 //
-// A record whose state at the base of the range was not answered is not
-// covered. Writing an answer for the first time is the thing this board wants,
-// and a check that made the first draft permanent would teach people to commit
-// nothing until they were certain, which is how an experiment ends up with no
-// written answer at all. The same reasoning covers a record that did not exist
-// at the base.
+// A record that did not exist at the base of the range is not covered, and
+// neither is a section that was not there. Writing the question for the first
+// time is the thing this board wants most, and writing an answer for the first
+// time is the second; a check that made a first draft permanent would teach
+// people to commit nothing until they were sure, which is how an experiment
+// ends up with nothing written down at all. The answer rule adds one more
+// condition, at the rule itself, because a draft answer under a record that is
+// still asking is the same case one step further on.
 //
-// Nothing here judges whether an added correction is honest. A correction that
-// contradicts the original without saying so passes this. What the check buys is
-// that the original is still there to be read next to it, which is the
-// difference between a record and a current opinion, and review is where the
+// Nothing here judges whether what was added is honest. A correction that
+// contradicts the original without saying so passes, and so does a clarification
+// that is a second question wearing a hat. What the rules buy is that the
+// original words are still on the page next to whatever arrived later, which is
+// the difference between a record and a current opinion, and review is where the
 // rest is caught.
+//
+// NOTHING REQUIRES AN ADDITION TO SAY THAT IT WAS ADDED LATER. Issue #70
+// describes a clarification as sitting under a line saying it arrived after the
+// work started, and record 0008 fixes no such line, so there is no marker in
+// the format for a check to read. A rule invented here would be a format
+// decision taken inside a checker, which is the shape the record for the
+// format would then have to be written around.
 func judgeRecords(change Change) Verdict {
 	if !change.RecordsRead {
-		return Verdict{Skips: []Skip{{
-			Rule: AnswerAlreadyLandedWasRewritten,
-			Why:  "this run was given no records, so no answer was compared against the one already landed",
-		}}}
+		return Verdict{Skips: []Skip{
+			{
+				Rule: AnswerAlreadyLandedWasRewritten,
+				Why:  "this run was given no records, so no answer was compared against the one already landed",
+			},
+			{
+				Rule: QuestionAlreadyAskedWasRewritten,
+				Why:  "this run was given no records, so no question was compared against the one the work began from",
+			},
+		}}
 	}
 
 	var verdict Verdict
@@ -95,39 +135,99 @@ func judgeOneRecord(record RecordChange) Verdict {
 
 	before, err := check.ParseRecord(record.Before)
 	if err != nil {
-		// Nothing can read a section out of bytes that are not a record. The
-		// state at the base decides whether this rule applies at all, so a
-		// base that cannot be read is a base this rule has nothing to say
-		// about, and the checker is what refuses a record that is not one.
+		// Nothing can read a section out of bytes that are not a record. What
+		// the record said at the base decides whether either rule applies at
+		// all, so a base that cannot be read is a base they have nothing to
+		// say about, and the checker is what refuses a record that is not one.
 		return Verdict{}
 	}
-	if state, present := before.Field(check.FieldState); !present || state != check.StateAnswered {
+	after, afterErr := check.ParseRecord(record.After)
+
+	var verdict Verdict
+	for _, rule := range sectionRules {
+		verdict.add(rule.judge(record, before, after, afterErr))
+	}
+	return verdict
+}
+
+// A sectionRule is one section of a record held to growing rather than
+// changing. The two rules differ in which section they read, in what makes a
+// record covered at the base, and in what the message tells the author to do
+// instead. Everything else is the same comparison, which is why it is one
+// function: two copies of it would drift, and the drift would be a rule that is
+// stricter about one section than about the other for no reason anybody wrote
+// down.
+type sectionRule struct {
+	property string
+	heading  string
+
+	// covered says whether the record at the base is one this rule applies
+	// to. It is the boundary each issue asks to be written at the check.
+	covered func(before check.Record) bool
+
+	// instead is what the refusal tells the author to do with the words they
+	// wanted to change.
+	instead string
+}
+
+var sectionRules = []sectionRule{
+	{
+		property: AnswerAlreadyLandedWasRewritten,
+		heading:  check.SectionAnswer,
+		// A record whose state at the base was not answered is not covered.
+		// Writing an answer for the first time is the thing this board wants,
+		// and a check that made the first draft permanent would teach people
+		// to commit nothing until they were certain, which is how an
+		// experiment ends up with no written answer at all.
+		covered: func(before check.Record) bool {
+			state, present := before.Field(check.FieldState)
+			return present && state == check.StateAnswered
+		},
+		instead: "an answer already landed may grow and may not change, so a correction goes underneath saying what was wrong and how it was found",
+	},
+	{
+		property: QuestionAlreadyAskedWasRewritten,
+		heading:  check.SectionQuestion,
+		// Every record that carried a question at the base is covered,
+		// whatever state it is in. The question is what the work began from,
+		// and it does not become editable because the work is unfinished.
+		covered: func(check.Record) bool { return true },
+		instead: "the question is what the work began from, so a clarification goes underneath rather than over the words the work started with",
+	},
+}
+
+// judge holds one section of one record to the rule.
+func (r sectionRule) judge(record RecordChange, before, after check.Record, afterErr error) Verdict {
+	landed, present := before.Section(r.heading)
+	if !present || !r.covered(before) {
 		return Verdict{}
 	}
-	landed, present := before.Section(check.SectionAnswer)
-	if !present {
+	// A section that was there and empty carries nothing to lose, and the
+	// rules that refuse an empty question and an answer claimed but not
+	// carried are the checker's. Reading it here would put a second judgement
+	// about emptiness in a rule about editing.
+	if len(meaningfulLines(landed)) == 0 {
 		return Verdict{}
 	}
 
-	after, err := check.ParseRecord(record.After)
-	if err != nil {
-		// The head no longer parses as a record, so the answer cannot be shown
-		// to be intact. It is refused here rather than passed to the checker,
+	if afterErr != nil {
+		// The head no longer parses as a record, so nothing can be shown to
+		// still be there. It is refused here rather than left to the checker,
 		// because the checker walks the tree and would report a record it
-		// cannot read without ever saying that an answer already landed went
-		// missing inside it.
+		// cannot read without ever saying that words already on the branch
+		// went missing inside it.
 		return Verdict{Refusals: []Refusal{{
-			Property: AnswerAlreadyLandedWasRewritten,
+			Property: r.property,
 			Subject:  record.Path,
-			Detail:   fmt.Sprintf("it was answered at the base of this range and no longer parses as a record, so its %s section cannot be shown to still carry what it carried", check.SectionAnswer),
+			Detail:   fmt.Sprintf("it no longer parses as a record, so its %s section cannot be shown to still carry what it carried at the base of this range", r.heading),
 		}}}
 	}
-	current, present := after.Section(check.SectionAnswer)
+	current, present := after.Section(r.heading)
 	if !present {
 		return Verdict{Refusals: []Refusal{{
-			Property: AnswerAlreadyLandedWasRewritten,
+			Property: r.property,
 			Subject:  record.Path,
-			Detail:   fmt.Sprintf("its %s section is gone and it carried an answer at the base of this range", check.SectionAnswer),
+			Detail:   fmt.Sprintf("its %s section is gone and it carried one at the base of this range", r.heading),
 		}}}
 	}
 
@@ -136,10 +236,9 @@ func judgeOneRecord(record RecordChange) Verdict {
 		return Verdict{}
 	}
 	return Verdict{Refusals: []Refusal{{
-		Property: AnswerAlreadyLandedWasRewritten,
+		Property: r.property,
 		Subject:  record.Path,
-		Detail: fmt.Sprintf("its %s section no longer carries %q, and an answer already landed may grow and may not change, so a correction goes underneath saying what was wrong and how it was found",
-			check.SectionAnswer, shorten(missing)),
+		Detail:   fmt.Sprintf("its %s section no longer carries %q, and %s", r.heading, shorten(missing), r.instead),
 	}}}
 }
 

--- a/internal/pullrequest/record_test.go
+++ b/internal/pullrequest/record_test.go
@@ -5,11 +5,19 @@ import (
 	"testing"
 )
 
+// theQuestion is what the work in every case below began from.
+const theQuestion = "Does the walk cost more than a second on a tree of a thousand records?"
+
 // recordAt builds a record in the shape docs/experiment-template.md carries,
-// with the state and the answer a case needs. Building it from one function is
-// what keeps every case below a near miss: two records in a case differ in the
-// answer and in nothing else, so a refusal is about the answer.
-func recordAt(state, answer string) []byte {
+// with the state, the answer and where a case needs it the question. Building
+// it from one function is what keeps every case a near miss: two records in a
+// case differ in one section and in nothing else, so a refusal is about that
+// section.
+func recordAt(state, answer string, options ...func(*recordFixture)) []byte {
+	fixture := recordFixture{question: theQuestion}
+	for _, option := range options {
+		option(&fixture)
+	}
 	return []byte("Slug: one\n" +
 		"State: " + state + "\n" +
 		"Question-Written: 2026-08-01\n" +
@@ -17,7 +25,7 @@ func recordAt(state, answer string) []byte {
 		"\n" +
 		"## Question\n" +
 		"\n" +
-		"Does the walk cost more than a second on a tree of a thousand records?\n" +
+		fixture.question + "\n" +
 		"\n" +
 		"## Method\n" +
 		"\n" +
@@ -26,6 +34,16 @@ func recordAt(state, answer string) []byte {
 		"## Answer\n" +
 		"\n" +
 		answer + "\n")
+}
+
+// A recordFixture is what a case changed about the record it built.
+type recordFixture struct {
+	question string
+}
+
+// withQuestion replaces what the record asks.
+func withQuestion(question string) func(*recordFixture) {
+	return func(fixture *recordFixture) { fixture.question = question }
 }
 
 // theLandedAnswer is what every case below starts from at the base of the
@@ -141,9 +159,13 @@ func recordJudgeCases() []judgeCase {
 				Before:        landed,
 				BeforePresent: true,
 				After: []byte("Slug: one\nState: answered\nQuestion-Written: 2026-08-01\n\n" +
-					"## Question\n\nDoes it?\n"),
+					"## Question\n\n" +
+					"Does the walk cost more than a second on a tree of a thousand records?\n"),
 				AfterPresent: true,
 			}),
+			// The question is carried across unchanged, so this case refuses
+			// the one rule it is about. A fixture that tripped both would
+			// prove neither.
 			want: []string{AnswerAlreadyLandedWasRewritten},
 		},
 		{
@@ -155,11 +177,70 @@ func recordJudgeCases() []judgeCase {
 				After:         []byte("Just prose now, with no header at all.\n"),
 				AfterPresent:  true,
 			}),
-			// The evasion worth closing. Removing the header takes the answer
-			// out of reach of every rule that reads a section, and the checker
-			// walking the tree would report a record it cannot read without
-			// ever saying an answer went missing inside it.
-			want: []string{AnswerAlreadyLandedWasRewritten},
+			// The evasion worth closing. Removing the header takes every
+			// section out of reach of every rule that reads one, and the
+			// checker walking the tree would report a record it cannot read
+			// without ever saying that words went missing inside it. Both
+			// rules refuse it, because both of their sections went out of
+			// reach in the same edit.
+			want: []string{AnswerAlreadyLandedWasRewritten, QuestionAlreadyAskedWasRewritten},
+		},
+		{
+			name: "a question altered after the work started",
+			change: withRecords(RecordChange{
+				Path:          "experiments/one/EXPERIMENT.md",
+				Before:        landed,
+				BeforePresent: true,
+				After: recordAt("answered", theLandedAnswer, withQuestion(
+					"Where does the cost of the walk sit on a tree of a thousand records?")),
+				AfterPresent: true,
+			}),
+			// The edit this rule exists for. The measurement came back saying
+			// something adjacent and more interesting, and rewriting the
+			// question to name it turns a result nobody predicted into a
+			// result the record claims was the point.
+			want: []string{QuestionAlreadyAskedWasRewritten},
+		},
+		{
+			name: "a question clarified underneath, while it is still asking",
+			change: withRecords(RecordChange{
+				Path:          "experiments/one/EXPERIMENT.md",
+				Before:        recordAt("asking", ""),
+				BeforePresent: true,
+				After: recordAt("asking", "", withQuestion(
+					theQuestion+"\n\nAdded after the work started: a record here means an\n"+
+						"EXPERIMENT.md and not a directory.")),
+				AfterPresent: true,
+			}),
+		},
+		{
+			name: "a question written for the first time",
+			change: withRecords(RecordChange{
+				Path:          "experiments/one/EXPERIMENT.md",
+				Before:        []byte("Slug: one\nState: asking\nQuestion-Written: 2026-08-01\n\n## Answer\n\n"),
+				BeforePresent: true,
+				After:         recordAt("asking", ""),
+				AfterPresent:  true,
+			}),
+			// The boundary this rule asks for. A record whose question section
+			// was not there at the base is not covered, because making a first
+			// draft permanent would teach people to commit nothing until they
+			// were sure, which is how an experiment ends up with no written
+			// question at all.
+		},
+		{
+			name: "a question section that was there and empty at the base",
+			change: withRecords(RecordChange{
+				Path:          "experiments/one/EXPERIMENT.md",
+				Before:        recordAt("asking", "", withQuestion("")),
+				BeforePresent: true,
+				After:         recordAt("asking", ""),
+				AfterPresent:  true,
+			}),
+			// A heading with nothing under it carries nothing to lose. That it
+			// states no question at all is a refusal the checker already makes
+			// when it walks the tree, and repeating the judgement here would
+			// send whoever hit it to the wrong repair.
 		},
 	}
 }
@@ -191,6 +272,39 @@ func TestARewrittenAnswerNamesTheRecordAndTheSection(t *testing.T) {
 	}
 	if !strings.Contains(refusal.Detail, "No. The walk took eleven seconds") {
 		t.Errorf("the refusal does not quote the line that went missing: %q", refusal.Detail)
+	}
+}
+
+// TestARewrittenQuestionNamesTheRecordAndTheSection is the same obligation for
+// the other rule. The two refusals are produced by one function, and the fixture
+// here is what says so rather than a comment claiming it.
+func TestARewrittenQuestionNamesTheRecordAndTheSection(t *testing.T) {
+	change := clean()
+	change.Files = []File{{Path: "experiments/one/EXPERIMENT.md"}}
+	change.Records = []RecordChange{{
+		Path:          "experiments/one/EXPERIMENT.md",
+		Before:        recordAt("asking", ""),
+		BeforePresent: true,
+		After:         recordAt("asking", "", withQuestion("Where does the cost of the walk sit?")),
+		AfterPresent:  true,
+	}}
+
+	verdict := Judge(change)
+	if len(verdict.Refusals) != 1 {
+		t.Fatalf("%d refusals, want 1: %v", len(verdict.Refusals), verdict.Refusals)
+	}
+	refusal := verdict.Refusals[0]
+	if refusal.Property != QuestionAlreadyAskedWasRewritten {
+		t.Errorf("the refusal is %s", refusal.Property)
+	}
+	if refusal.Subject != "experiments/one/EXPERIMENT.md" {
+		t.Errorf("the refusal names %q as its subject", refusal.Subject)
+	}
+	if !strings.Contains(refusal.Detail, "Question") {
+		t.Errorf("the refusal does not name the section: %q", refusal.Detail)
+	}
+	if !strings.Contains(refusal.Detail, "Does the walk cost more than a second") {
+		t.Errorf("the refusal does not quote the words the work began from: %q", refusal.Detail)
 	}
 }
 


### PR DESCRIPTION
Closes #70

## What this changes

A question section already on the branch a change lands on may not lose or alter
a line. A clarification is added underneath, so the words the work began from
stay on the page next to whatever arrived later.

The rule sits beside the one over the answer, in the deterministic pull-request
check, and the two are now one function with a table of two entries rather than
two copies of one comparison. They differ in the section they read, in what
makes a record covered at the base of the range, and in what the message tells
an author to do instead. Everything else was going to drift, and the drift would
have been a rule stricter about one section than about the other for no reason
anybody wrote down.

## What failure it prevents

The most likely dishonest edit on this board, and the one that needs no bad
faith, because it makes a record read better rather than worse. An experiment
asked whether one approach was faster than another. The measurement came back
saying something adjacent and more interesting. Rewriting the question to name
what was measured turns a result nobody predicted into a result the record
claims was the point, and the edit arrives in the same pull request as the
answer, which is the change a reader is reading for something else.

Where the question turned out to be the wrong question, the lifecycle already
names that. The answer says so, the question stays as it was asked, and the
record is finished rather than tidied.

## What was run

At the commit being pushed, `cd979ab30abe1b1954a76c79ee0a0fe79a074d8f`.

```
go build ./...
go vet ./...
gofmt -l .
(no output)
go test -count=1 ./...
ok  	github.com/Flowfin/lab/cmd/lab	11.344s
ok  	github.com/Flowfin/lab/cmd/pullrequest	1.425s
ok  	github.com/Flowfin/lab/internal/check	1.649s
ok  	github.com/Flowfin/lab/internal/hardware	1.625s
ok  	github.com/Flowfin/lab/internal/invariants	2.382s
ok  	github.com/Flowfin/lab/internal/prose	1.641s
ok  	github.com/Flowfin/lab/internal/pullrequest	2.213s

go run ./cmd/lab check .
the time this run read is 2026-08-11T18:26:54Z
0 refused
```

Both guards deleted in turn, against the same fixtures. The second is the
boundary, and what reddens on it is the case where a question is written for the
first time.

```
guard deleted: the question rule covers nothing
--- FAIL: TestJudge
--- FAIL: TestEveryPropertyHasACaseThatRefusesIt
--- FAIL: TestARewrittenQuestionNamesTheRecordAndTheSection

guard deleted: a section absent at the base is judged anyway
--- FAIL: TestJudge

with both in place
ok  	github.com/Flowfin/lab/internal/pullrequest
ok  	github.com/Flowfin/lab/cmd/pullrequest
```

The red and green pair, run with the built command against a real range in a
scratch repository. Both changes answer the same experiment in the same commit;
one rewrites the question to name what was measured and the other leaves it
alone and clarifies underneath:

```
=== the question is rewritten in the change that answers it ===
examined the pull request
  body: 11 character(s)
  commits: 1, merges excluded
  files: 1
  records: 1, 1 of them already on the branch this lands on
  lines: 7
refused: experiments/one/EXPERIMENT.md: its Question section no longer carries "Is reading a record with one pass faster than reading it with two on a t...", and the question is what the work began from, so a clarification goes underneath rather than over the words the work started with (question-already-asked-was-rewritten)
1 refusal(s), 0 note(s), 0 rule(s) not judged
exit=1

=== the question keeps its words and gains a clarification ===
examined the pull request
  body: 11 character(s)
  commits: 1, merges excluded
  files: 1
  records: 1, 1 of them already on the branch this lands on
  lines: 8
0 refusal(s), 0 note(s), 0 rule(s) not judged
exit=0
```

## What this does not do

Nothing requires an addition to say that it arrived after the work started. The
issue describes a clarification as sitting under a line that says so, record
0008 fixes no such line, and inventing one inside a checker would be a format
decision taken in the wrong place, which the record for the format would then
have to be written around. A clarification added with no marker passes this
check, and what stands behind that today is a reader.

Nothing judges whether an added clarification is a second question wearing a
hat. One that quietly replaces the original in a reader's mind passes. What the
rule buys is that the original words are still on the page next to it.

A record whose question section was not there at the base of the range is not
covered, and neither is one that was there and empty. That a record states no
question at all is a refusal the checker already makes when it walks the tree,
and repeating that judgement here would send whoever hit it to the wrong repair.

The red case above ran against a scratch repository rather than against a pull
request on this board, because there is no experiment record here yet for a real
pull request to edit. What runs live on this pull request is the half where the
rules find nothing.

No second reader tonight. The transcript above is in place of one, and every
number in it carries the command that produced it.
