### PR TITLE
Walk the first real experiment through the whole lifecycle

### DIFF
--- a/experiments/reading-a-tree-of-records/EXPERIMENT.md
+++ b/experiments/reading-a-tree-of-records/EXPERIMENT.md
@@ -10,17 +10,29 @@ record cost more wall-clock time than walking the directories that hold them?
 
 ## Method
 
-Not run yet. The plan is a program that builds a tree of a thousand experiment
-directories in a temporary directory, each holding a record of about the size
-the records in this repository are, and then times two passes over it: one that
-only walks the directories and reads their names, and one that also opens every
-record and reads its bytes. Both passes run several times in one process, the
-tree is built once and reused, and the numbers reported are the fastest of the
-runs rather than the mean, because the fastest is the one least contaminated by
-whatever else the machine was doing.
+`experiments/reading-a-tree-of-records/main.go` builds a thousand experiment
+directories in a temporary directory, each holding a record of about a kilobyte,
+which is the size most records in this repository are. It then times two passes
+over that tree and removes it.
 
-The measurement is about the machine it runs on. The platform, the processor
-architecture and the toolchain version are reported next to the numbers, and no
+The first pass reads the directory, and for each experiment asks the filesystem
+about the record without opening it. That is what the runner does before it
+decides whether a record is inside the size bound. The second pass reads the
+directory and opens every record. So the comparison is between asking about a
+thousand files and reading a thousand files, rather than between walking and
+doing nothing, and the difference between the two is the cost of the bytes.
+
+Both passes run seven times in one process against one tree, and the number
+reported is the fastest round rather than the mean. The fastest is the one least
+contaminated by whatever else the machine was doing, and a mean over a busy
+machine measures the other things.
+
+Run it with:
+
+    go run ./experiments/reading-a-tree-of-records
+
+The measurement is about the machine it ran on. The platform, the processor
+architecture and the toolchain version are printed next to the numbers, and no
 number here is a claim about anybody else's machine.
 
 ## Answer

--- a/experiments/reading-a-tree-of-records/EXPERIMENT.md
+++ b/experiments/reading-a-tree-of-records/EXPERIMENT.md
@@ -1,6 +1,7 @@
 Slug: reading-a-tree-of-records
-State: asking
+State: answered
 Question-Written: 2026-08-11
+Answer-Written: 2026-08-11
 Needs-Hardware: none
 
 ## Question
@@ -36,3 +37,30 @@ architecture and the toolchain version are printed next to the numbers, and no
 number here is a claim about anybody else's machine.
 
 ## Answer
+
+Yes, and by about three times. Reading the records is where the time goes.
+
+    go run ./experiments/reading-a-tree-of-records
+    windows/amd64, go1.26.5
+    1000 experiments, 1108000 bytes of records, 7 rounds
+    walking the directories:        16.6888ms
+    walking and reading every file: 50.5875ms
+    reading costs 3.03 times the walk
+
+Two more runs of the same command on the same machine gave 3.04 and 2.93, so
+the ratio is stable to about a tenth and the absolute numbers move by a few
+milliseconds between runs. Those two runs are not pasted, and their numbers are
+quoted from the same command as the one above.
+
+What it does not say. This is one machine, one filesystem and one platform, and
+the cost of asking a filesystem about a file rather than opening it is exactly
+the sort of thing that differs between them. A tree of a thousand records is
+also fifty times the size of this repository's own tree today, so the whole
+measurement is milliseconds either way and none of it is a reason to change
+anything yet. What it settles is which of the two numbers is worth watching if a
+walk ever does get slow: the bytes, not the directories.
+
+The question was a fair one to have asked, and it could have gone the other way.
+A directory walk that has to open each directory in turn is not obviously
+cheaper than reading a kilobyte out of a file the walk has already found, and on
+a filesystem with a slower directory layer it may not be.

--- a/experiments/reading-a-tree-of-records/EXPERIMENT.md
+++ b/experiments/reading-a-tree-of-records/EXPERIMENT.md
@@ -1,0 +1,26 @@
+Slug: reading-a-tree-of-records
+State: asking
+Question-Written: 2026-08-11
+Needs-Hardware: none
+
+## Question
+
+On a tree of a thousand experiment records, does opening and reading every
+record cost more wall-clock time than walking the directories that hold them?
+
+## Method
+
+Not run yet. The plan is a program that builds a tree of a thousand experiment
+directories in a temporary directory, each holding a record of about the size
+the records in this repository are, and then times two passes over it: one that
+only walks the directories and reads their names, and one that also opens every
+record and reads its bytes. Both passes run several times in one process, the
+tree is built once and reused, and the numbers reported are the fastest of the
+runs rather than the mean, because the fastest is the one least contaminated by
+whatever else the machine was doing.
+
+The measurement is about the machine it runs on. The platform, the processor
+architecture and the toolchain version are reported next to the numbers, and no
+number here is a claim about anybody else's machine.
+
+## Answer

--- a/experiments/reading-a-tree-of-records/main.go
+++ b/experiments/reading-a-tree-of-records/main.go
@@ -1,0 +1,156 @@
+// Command main builds a tree of experiment records in a temporary directory and
+// times two passes over it: one that only walks the directories, and one that
+// also opens every record and reads its bytes.
+//
+// It is an experiment's prototype rather than part of the runner. Nothing in
+// cmd/ or internal/ imports it, it is not run by any check, and it writes only
+// inside the temporary directory it creates and removes.
+//
+// Run it from a checkout:
+//
+//	go run ./experiments/reading-a-tree-of-records
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// The shape of the tree. A thousand is the number the question names, and the
+// record is the size the records in this repository are: the longest of them is
+// under four kilobytes and most are near one.
+const (
+	experiments = 1000
+	rounds      = 7
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "measure: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	root, err := os.MkdirTemp("", "reading-a-tree-of-records-")
+	if err != nil {
+		return fmt.Errorf("cannot make a temporary directory: %w", err)
+	}
+	defer os.RemoveAll(root)
+
+	bytes, err := build(root)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s/%s, %s\n", runtime.GOOS, runtime.GOARCH, runtime.Version())
+	fmt.Printf("%d experiments, %d bytes of records, %d rounds\n", experiments, bytes, rounds)
+
+	walking, err := fastest(func() (int, error) { return walk(root, false) })
+	if err != nil {
+		return err
+	}
+	reading, err := fastest(func() (int, error) { return walk(root, true) })
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("walking the directories:        %v\n", walking)
+	fmt.Printf("walking and reading every file: %v\n", reading)
+	fmt.Printf("reading costs %.2f times the walk\n", float64(reading)/float64(walking))
+	return nil
+}
+
+// build writes the tree and returns how many bytes of records it holds.
+func build(root string) (int, error) {
+	record := recordOfAboutAKilobyte()
+	total := 0
+
+	for i := 0; i < experiments; i++ {
+		dir := filepath.Join(root, "experiments", fmt.Sprintf("experiment-%04d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return 0, fmt.Errorf("cannot make %s: %w", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "EXPERIMENT.md"), []byte(record), 0o644); err != nil {
+			return 0, fmt.Errorf("cannot write into %s: %w", dir, err)
+		}
+		total += len(record)
+	}
+	return total, nil
+}
+
+// walk makes one pass over the tree, reading the files or not, and returns how
+// many it visited. The count is returned and printed nowhere on purpose: it is
+// there so that the compiler cannot decide the reading was pointless and remove
+// it, which is the way a measurement like this reports a time for work that
+// never happened.
+func walk(root string, read bool) (int, error) {
+	seen := 0
+	dir := filepath.Join(root, "experiments")
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, fmt.Errorf("cannot read %s: %w", dir, err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		record := filepath.Join(dir, entry.Name(), "EXPERIMENT.md")
+		if !read {
+			info, err := os.Stat(record)
+			if err != nil {
+				return 0, fmt.Errorf("cannot stat %s: %w", record, err)
+			}
+			seen += int(info.Size() % 2)
+			continue
+		}
+		data, err := os.ReadFile(record)
+		if err != nil {
+			return 0, fmt.Errorf("cannot read %s: %w", record, err)
+		}
+		seen += len(data) % 2
+	}
+	return seen, nil
+}
+
+// fastest runs a pass several times and returns the shortest time it took. The
+// shortest is the one least contaminated by whatever else the machine was
+// doing, and a mean over a machine that is doing other things measures the
+// other things.
+func fastest(pass func() (int, error)) (time.Duration, error) {
+	best := time.Duration(0)
+
+	for i := 0; i < rounds; i++ {
+		start := time.Now()
+		if _, err := pass(); err != nil {
+			return 0, err
+		}
+		took := time.Since(start)
+		if best == 0 || took < best {
+			best = took
+		}
+	}
+	return best, nil
+}
+
+// recordOfAboutAKilobyte is a record the size of the ones in this repository. It
+// is prose rather than a repeated character because a filesystem that
+// compresses would otherwise be measured doing something no real tree asks of
+// it.
+func recordOfAboutAKilobyte() string {
+	var out strings.Builder
+
+	out.WriteString("Slug: experiment\nState: answered\nQuestion-Written: 2026-01-01\nAnswer-Written: 2026-01-02\n\n")
+	out.WriteString("## Question\n\nDoes this shape of record cost anything to read?\n\n")
+	out.WriteString("## Method\n\n")
+	for i := 0; out.Len() < 1024; i++ {
+		fmt.Fprintf(&out, "Line %d of a method somebody wrote out in full, at about the width the prose in this repository is written at.\n", i)
+	}
+	out.WriteString("\n## Answer\n\nNo, and this file exists to find out by how little.\n")
+	return out.String()
+}


### PR DESCRIPTION
Closes #40

## What this changes

The first experiment, walked through the whole lifecycle in the order the
lifecycle asks for. Three commits: the question, then the code, then the answer.

`experiments/reading-a-tree-of-records/` asks whether opening every record on a
tree of a thousand costs more than asking the filesystem about them without
opening them. The answer is yes, by about three times on the machine it ran on,
and the record carries the numbers, the command that produced them, the platform
and what the measurement does not say.

The question was chosen because its answer was genuinely unknown rather than
because it suited the tooling. A directory walk that opens each directory in
turn is not obviously cheaper than reading a kilobyte out of a file the walk has
already found, and on a filesystem with a slower directory layer it may not be.

## What failure it prevents

Machinery that has never carried a real load is a design. Everything in the plan
up to here is built for experiments that do not exist, and the cheapest place to
find out that the record format is annoying or that a check fires on legitimate
work is the first experiment rather than the tenth.

## What was run

At the commit being pushed, `e433a3853fe4b6e78fa79b60e9ba33fda1e26eb0`.

```
go build ./...
go vet ./...
gofmt -l .
(no output)
go test -count=1 ./...
ok  	github.com/Flowfin/lab/cmd/lab	5.400s
ok  	github.com/Flowfin/lab/cmd/pullrequest	1.314s
?   	github.com/Flowfin/lab/experiments/reading-a-tree-of-records	[no test files]
ok  	github.com/Flowfin/lab/internal/check	1.270s
ok  	github.com/Flowfin/lab/internal/hardware	1.143s
ok  	github.com/Flowfin/lab/internal/invariants	1.755s
ok  	github.com/Flowfin/lab/internal/prose	1.381s
ok  	github.com/Flowfin/lab/internal/pullrequest	1.989s

go run ./cmd/lab check .
16 decision records read
the time this run read is 2026-08-11T18:35:27Z
0 refused

go run ./cmd/lab list .
examined .
1 experiment
the time this run read is 2026-08-11T18:35:30Z
  slug                       state     question written  waiting  needs
  reading-a-tree-of-records  answered  2026-08-11        -        none

go run ./experiments/reading-a-tree-of-records
windows/amd64, go1.26.5
1000 experiments, 1108000 bytes of records, 7 rounds
walking the directories:        16.6888ms
walking and reading every file: 50.5875ms
reading costs 3.03 times the walk
```

The record was accepted from the first commit, in state `asking` with an empty
answer section, and the listing showed it waiting nought days before the code
existed. That ordering is the thing this board is built on and it is worth
saying that nothing got in the way of it.

## What this does not do

The measurement is about one machine, one filesystem and one platform. A tree of
a thousand records is fifty times the size of this repository's own tree today,
so the whole thing is milliseconds either way and none of it is a reason to
change anything. What it settles is which of the two numbers is worth watching
if a walk ever does get slow.

The prototype is not run by any check and nothing in the runner imports it. It
is compiled by `go build ./...` and read by `go vet ./...` like everything else
in the module, which is one of the things the walk found and which has its own
issue rather than a repair here.

What the walk cost as an experience, and the follow-up issues it produced, are
written into #40 rather than into the record. The record is about the question
it asked.

No second reader tonight. The transcript above is in place of one, and every
number in it carries the command that produced it.
