### PR TITLE
Prove a dependency added to a tree reaches the notices document

### DIFF
--- a/cmd/notices/tree_test.go
+++ b/cmd/notices/tree_test.go
@@ -1,0 +1,289 @@
+// What this file proves that neither of the other two suites can.
+//
+// internal/notices proves the render, against module sets a case wrote out in
+// full. main_test.go proves that the module table inside a real binary reaches
+// that render, against a binary built from this repository. Neither of them
+// starts from a tree: this repository has no third-party dependency, so a build
+// of it exercises the empty half only, and a module set constructed in a test is
+// a statement about the test rather than about a build.
+//
+// Issue #37 asks for the other half in its own words - a run against a tree with
+// a dependency added produces a notices file that lists it - so this builds two
+// binaries from one tree, the second differing from the first by a require line
+// and an import, and holds the difference between the two documents.
+//
+// IT OPENS NO CONNECTION, which is what made this leg look unreachable. The
+// module is served out of a directory laid out as a module proxy and written by
+// this test, the checksum database is off, and the toolchain is pinned to the
+// one already installed, so nothing here resolves a name or fetches a version.
+// The module cache the build populates is a temporary directory, so the licence
+// text the document carries came from this run rather than from whatever the
+// machine happened to have downloaded before it.
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The module the tree under test depends on.
+//
+// It is invented rather than borrowed from the real ecosystem. A test that
+// depends on something real depends on that thing staying fetchable and staying
+// licensed the way it was on the day the test was written, and both of those are
+// facts about somebody else's repository.
+const (
+	dependencyPath    = "example.com/dep"
+	dependencyVersion = "v1.0.0"
+)
+
+// The go directive is well below the toolchain this repository builds with on
+// purpose. The tree here is built by whatever toolchain is running the suite,
+// and a directive naming a version newer than that one asks the toolchain to
+// fetch a different one, which is the network this file exists without.
+const dependencyGoMod = "module example.com/dep\n\ngo 1.21\n"
+
+const dependencySource = `package dep
+
+// Answer is here so that the tree under test imports this module and uses it.
+// A module that is required and never imported does not reach the binary, and
+// then the document would be correct to leave it out.
+func Answer() int { return 37 }
+`
+
+// The licence text is written to be unmistakable in a document. What the
+// assertion below has to separate is a document naming a module from a document
+// carrying the text that module shipped, and a conventional licence header
+// appears in enough places to make that a weak test.
+const dependencyLicenceText = `Copyright 2026 the author of example.com/dep
+
+Permission is granted to reproduce this text in a notices document, which is
+the whole of what this file exists to be reproduced by.
+`
+
+// TestATreeWithADependencyAddedProducesADocumentThatListsIt builds one tree
+// twice and compares the two documents.
+//
+// The comparison is the test. A tree that had the dependency from the start
+// would pass against a command that lists whatever it finds and also against one
+// that lists a module somebody hard-coded, and the difference between the two
+// runs is what separates them.
+func TestATreeWithADependencyAddedProducesADocumentThatListsIt(t *testing.T) {
+	workspace := t.TempDir()
+	proxy := writeTheModuleProxy(t, filepath.Join(workspace, "proxy"))
+	cache := filepath.Join(workspace, "modcache")
+	tree := filepath.Join(workspace, "tree")
+
+	// The cache is created here rather than left to the build. The first of the
+	// two builds needs nothing, so it populates no cache, and a command told to
+	// read a directory that is not there refuses the invocation instead of
+	// describing the binary.
+	if err := os.MkdirAll(cache, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	environment := offlineEnvironment(proxy, cache)
+	cleanTheModuleCache(t, environment)
+
+	writeTheTree(t, tree, false)
+	before, code := describe(t, buildTheTree(t, tree, environment, "before"), cache)
+	if code != exitClean {
+		t.Fatalf("describing the tree without the dependency returned %d", code)
+	}
+	if strings.Contains(before, dependencyPath) {
+		t.Fatalf("the tree without the dependency already names %s, so the comparison below proves nothing:\n%s", dependencyPath, before)
+	}
+	if !strings.Contains(before, "This binary contains no third-party module.") {
+		t.Errorf("the tree without the dependency does not say that there is nothing to disclose:\n%s", before)
+	}
+
+	writeTheTree(t, tree, true)
+	after, code := describe(t, buildTheTree(t, tree, environment, "after"), cache)
+	if code != exitClean {
+		t.Fatalf("describing the tree with the dependency returned %d rather than %d, so the licence text was not read out of the cache the build populated", code, exitClean)
+	}
+
+	named := dependencyPath + "@" + dependencyVersion
+	if !strings.Contains(after, named) {
+		t.Errorf("the document does not name %s:\n%s", named, after)
+	}
+	if !strings.Contains(after, strings.TrimSpace(dependencyLicenceText)) {
+		t.Errorf("the document names %s and does not carry the text it shipped, which is the half a link would also have failed to supply:\n%s", named, after)
+	}
+	t.Logf("adding %s moved the document from %d to %d byte(s) and carried its licence text", named, len(before), len(after))
+}
+
+// describe runs the command over one binary and returns what it wrote and the
+// code it returned.
+func describe(t *testing.T, binary, cache string) (string, int) {
+	t.Helper()
+
+	var out, errOut bytes.Buffer
+	code := run([]string{binary, cache}, &out, &errOut)
+	if errOut.Len() > 0 {
+		t.Logf("the run said: %s", strings.TrimSpace(errOut.String()))
+	}
+	return out.String(), code
+}
+
+// writeTheTree writes a module that either imports the dependency or does not.
+//
+// Both halves are written rather than the second being an edit of the first, so
+// that what the two builds differ by is stated in one place a reader can see.
+func writeTheTree(t *testing.T, dir string, withDependency bool) {
+	t.Helper()
+
+	goMod := "module example.com/tree\n\ngo 1.21\n"
+	source := "package main\n\nfunc main() { println(\"the tree ran\") }\n"
+	if withDependency {
+		goMod = "module example.com/tree\n\ngo 1.21\n\nrequire " + dependencyPath + " " + dependencyVersion + "\n"
+		source = "package main\n\nimport \"" + dependencyPath + "\"\n\nfunc main() { println(dep.Answer()) }\n"
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write(t, filepath.Join(dir, "go.mod"), goMod)
+	write(t, filepath.Join(dir, "main.go"), source)
+}
+
+// buildTheTree compiles the tree and returns the path of the binary.
+func buildTheTree(t *testing.T, dir string, environment []string, name string) string {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	binary := filepath.Join(t.TempDir(), name)
+
+	build := exec.Command("go", "build", "-o", binary, ".")
+	build.Dir = dir
+	build.Env = environment
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("cannot build the tree under test: %v\n%s", err, output)
+	}
+	return binary
+}
+
+// writeTheModuleProxy lays out the dependency the way a module proxy serves it
+// and returns the directory to point the toolchain at.
+func writeTheModuleProxy(t *testing.T, root string) string {
+	t.Helper()
+
+	dir := filepath.Join(root, filepath.FromSlash(dependencyPath), "@v")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write(t, filepath.Join(dir, "list"), dependencyVersion+"\n")
+	write(t, filepath.Join(dir, dependencyVersion+".info"), `{"Version":"`+dependencyVersion+`"}`)
+	write(t, filepath.Join(dir, dependencyVersion+".mod"), dependencyGoMod)
+
+	if err := os.WriteFile(filepath.Join(dir, dependencyVersion+".zip"), moduleArchive(t), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// moduleArchive builds the zip a module proxy serves, which is every file of the
+// module under one directory named for the module and its version.
+func moduleArchive(t *testing.T) []byte {
+	t.Helper()
+
+	var buffer bytes.Buffer
+	archive := zip.NewWriter(&buffer)
+	prefix := dependencyPath + "@" + dependencyVersion + "/"
+
+	for _, file := range []struct{ name, content string }{
+		{"go.mod", dependencyGoMod},
+		{"dep.go", dependencySource},
+		{"LICENSE", dependencyLicenceText},
+	} {
+		entry, err := archive.Create(prefix + file.name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := entry.Write([]byte(file.content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}
+
+// offlineEnvironment is what the two builds run under.
+//
+// Every entry is here to remove one route to the network or to the machine's own
+// state. The proxy is a directory. The checksum database is off, because it is a
+// service and the module it would be asked about does not exist outside this
+// test. The toolchain is the installed one, so a go directive is never a
+// download. The workspace file is off, so a go.work above the temporary
+// directory cannot pull this build into it. The module cache is a temporary
+// directory, so the licence text in the document came from this run.
+//
+// THE THREE EMPTIED VARIABLES ARE THE ONES THAT SEND A BUILD PAST THE PROXY.
+// They are inherited from whoever is running the suite, and any of them matching
+// this module makes the toolchain resolve the path as a domain and fetch over
+// https, which is a failure that only appears on a machine configured a
+// particular way. Emptying them is how this file stops depending on that
+// configuration.
+func offlineEnvironment(proxy, cache string) []string {
+	return append(os.Environ(),
+		"GOPROXY="+proxyURL(proxy),
+		"GOSUMDB=off",
+		"GOPRIVATE=",
+		"GONOPROXY=",
+		"GONOSUMDB=",
+		"GOFLAGS=-mod=mod",
+		"GOMODCACHE="+cache,
+		"GOWORK=off",
+		"GOTOOLCHAIN=local",
+	)
+}
+
+// proxyURL spells a directory as the file URL the toolchain reads a proxy from.
+// The leading slash is added where the path does not have one, which is every
+// path on Windows and no path anywhere else.
+func proxyURL(dir string) string {
+	slashed := filepath.ToSlash(dir)
+	if !strings.HasPrefix(slashed, "/") {
+		slashed = "/" + slashed
+	}
+	return "file://" + slashed
+}
+
+// cleanTheModuleCache empties the temporary cache before the directory holding
+// it is removed.
+//
+// The toolchain writes the cache read-only, and removing a read-only file is
+// refused on one of the platforms this repository supports, so the cleanup the
+// temporary directory does on its own fails there. This is registered after that
+// cleanup and therefore runs before it.
+func cleanTheModuleCache(t *testing.T, environment []string) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		clean := exec.Command("go", "clean", "-modcache")
+		clean.Env = environment
+		if output, err := clean.CombinedOutput(); err != nil {
+			t.Logf("cannot empty the temporary module cache: %v\n%s", err, output)
+		}
+	})
+}
+
+// write is os.WriteFile with the test failed rather than the error returned,
+// because every caller here would do the same three lines.
+func write(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Refs #37

## What this changes

It adds `cmd/notices/tree_test.go`, which builds one tree twice and holds the
difference between the two notices documents. The second tree differs from the
first by a require line and an import. The first document must not name the
module and must carry the sentence saying there is nothing to disclose; the
second must name it and reproduce the text it shipped.

It changes nothing that ships. The only file is a test.

The module the tree depends on is invented and served out of a directory the
test lays out as a module proxy. A test that borrowed something real would
depend on that thing staying fetchable and staying licensed the way it was on
the day the test was written, and both of those are facts about somebody else's
repository.

## What failure it prevents

A notices document that describes nothing while reading as finished.

`buildOf` reads the module table out of the binary and turns it into what the
render consumes. A version of it that reads the table and drops what it finds
produces a document saying the binary contains no third-party module, which is
the sentence an operator would take as an answer rather than as a gap.

Nothing here measured that before. `internal/notices` proves the render against
module sets its cases write out in full, so a defect between the binary and the
render leaves every case green. The neighbouring test in this package reads a
binary built from this repository, which has no third-party dependency, so it
exercises only the empty half.

## What was run

I proved the new test bites by deleting the line that collects the modules,
replacing `build.Deps = append(build.Deps, module)` in `cmd/notices/main.go`
with a discard, and running the whole suite:

```
$ go test -count=1 ./cmd/... ./internal/...
FAIL	github.com/Flowfin/lab/cmd/notices	7.336s
ok  	github.com/Flowfin/lab/cmd/pullrequest	0.505s
ok  	github.com/Flowfin/lab/internal/check	1.734s
ok  	github.com/Flowfin/lab/internal/contexts	0.651s
ok  	github.com/Flowfin/lab/internal/hardware	0.528s
ok  	github.com/Flowfin/lab/internal/invariants	1.095s
ok  	github.com/Flowfin/lab/internal/notices	0.649s
ok  	github.com/Flowfin/lab/internal/prose	0.791s
ok  	github.com/Flowfin/lab/internal/pullrequest	0.489s
```

Named, that run reddens one test and no other:

```
$ go test -count=1 -v ./cmd/notices
--- PASS: TestTheModuleTableOfARealBinaryReachesTheDocument (1.69s)
--- PASS: TestABrokenInvocationIsNotARefusal (1.49s)
--- FAIL: TestATreeWithADependencyAddedProducesADocumentThatListsIt (3.98s)
```

The line was restored and the commands CONTRIBUTING.md names were run at the
commit being pushed:

```
$ go build ./cmd/... ./internal/...
$ go vet ./cmd/... ./internal/...
$ gofmt -l cmd internal
$ go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	0.364s
ok  	github.com/Flowfin/lab/cmd/lab	0.851s
ok  	github.com/Flowfin/lab/cmd/notices	6.839s
ok  	github.com/Flowfin/lab/cmd/pullrequest	0.384s
ok  	github.com/Flowfin/lab/internal/check	0.624s
ok  	github.com/Flowfin/lab/internal/contexts	0.371s
ok  	github.com/Flowfin/lab/internal/hardware	0.381s
ok  	github.com/Flowfin/lab/internal/invariants	0.650s
ok  	github.com/Flowfin/lab/internal/notices	0.368s
ok  	github.com/Flowfin/lab/internal/prose	0.390s
ok  	github.com/Flowfin/lab/internal/pullrequest	0.395s

$ go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
18 decision records read
the time this run read is 2026-08-16T19:50:46Z
0 refused
```

`gofmt -l` printed nothing, which is its passing result.

## What this does not do

It does not close #37. Two of that issue's three legs ask for both artefacts to
be generated by the release build and attached to the release, and there is no
release workflow in this tree and no release. This retires the third leg only.

It adds no bill of materials. That artefact belongs with the release build for
the reason #37 gives, which is that it is generated at build time from the
build.

It opens no connection, and that is a property of how the test is written rather
than something watched. The proxy is a directory, the checksum database is off,
the toolchain is pinned to the installed one so a go directive is never a
download, and the module cache is a temporary directory. The three variables
that send a build past a proxy are emptied rather than inherited, because any of
them matching this module turns the module path into a domain and fetches over
https. Nothing traced the process.

It builds with whatever toolchain runs the suite, so it needs one installed.
That is already true of the test beside it, which builds this repository's
runner.

Nobody but me has read this change.

## Why this was held, and what released it

One check on the head this section was written against was red, and it was red
for a reason this change did not cause. `Audit workflows (zizmor)` reported two
findings, both in
`.github/workflows/codeql.yml`, on lines this branch does not contain:

```
$ git diff --name-only origin/main...HEAD -- .github/
$ git diff --name-only origin/main...HEAD
cmd/notices/tree_test.go
```

The branch touched one file and it was not a workflow, so the audit was
reporting the same two lines it would report on the default branch. What had
moved was the tag a pin comment names, upstream. Issue #137 carried the finding
with the commands behind it.

Every other check on that head was green, including the three `test` jobs that
run the test this change adds:

```
$ gh pr checks 136
CodeQL (go)                     pass
DCO sign-off                    pass
Reject Trojan Source Unicode    pass
build (darwin/amd64)            pass
build (darwin/arm64)            pass
build (linux/amd64)             pass
build (linux/arm64)             pass
build (windows/amd64)           pass
build (windows/arm64)           pass
dependency-review               pass
format                          pass
headless and unelevated         pass
invariants                      pass
prose format                    pass
pull request                    pass
records                         pass
required contexts               pass
test (darwin/arm64)             pass
test (linux/amd64)              pass
test (windows/amd64)            pass
vet                             pass
Audit workflows (zizmor)        fail
```

#137 has since landed, in #138, merged as
`109f78bdb7d4c7503ac44fd56ba7a3a05bede593`. It moved no pin and changed only the
comment beside two of them, so the repair stayed out of this change and this
change still carries one topic.

The default branch is green on that audit again:

```
$ gh run list --workflow=zizmor.yml --branch main --limit 1 --json conclusion --jq '.[].conclusion'
success
```

The default branch was then merged into this one rather than this one being
rebased onto it, so the history above is the history that was reviewed and no
commit was rewritten. The merge commit is `7374b6b`, and the file this change
adds is still the only file it adds:

```
$ git diff --name-only origin/main...HEAD
cmd/notices/tree_test.go
```

The suite was run again at that merge, and the section above stands as written
rather than being edited into a change that never had a red check.

