### PR TITLE
Say that the prose half of the prettier row is in the tree (#26)

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -60,7 +60,7 @@ today no tick does.
 | `Enforce greppable invariants` | Kept, different invariants | The invariants are properties of this repository's own tracked text, which is a different set from the target's, and they are in `internal/invariants/`. |
 | `Reject Trojan Source Unicode` | Kept unchanged | Already in the tree, and the attack it refuses is a property of source rather than of a language. |
 | `Audit workflows (zizmor)` | Kept unchanged | Already in the tree. The workflow YAML is the other executable thing here and it runs with write scopes. The job reports under this name and the code-scanning upload reports under `zizmor`, which is a different context and does not arrive on every pull request. |
-| `prettier` | Kept, split in two | Records here are Markdown, and a whitespace diff on a record hides the sentence that changed. The runner's own source is held to `gofmt` by a job already in the tree; the prose half is issue #50 and nothing in this tree formats Markdown today. |
+| `prettier` | Kept, split in two, and both halves are in the tree | Records here are Markdown, and a whitespace diff on a record hides the sentence that changed. The runner's own source is held to `gofmt` by the `format` job and the prose half is the `prose format` job. Both are kept and both belong in the required set. Neither rewrites anything, which is where the split departs from the target: `prettier` formats and these two refuse, so a departure is a red tick here and a diff there. |
 | `dependency-review` | Kept unchanged | Already in the tree, refusing a newly introduced dependency carrying a known advisory. |
 
 ## What this board adds that the target does not have


### PR DESCRIPTION
Closes nothing. Issue #26 stays open. This is a correction to the same document
the set is assembled from, found while checking that the change before it had
covered every name.

## What was wrong

The `prettier` row said "the prose half is issue #50 and nothing in this tree
formats Markdown today". The row is one day older than the check it calls
absent:

```
git log -1 --format='%h %ad %s' --date=short --diff-filter=A \
  -- docs/quality-parity.md
28b9142 2026-08-10 Walk the sso required set and say what survives here

git log -1 --format='%h %ad %s' --date=short --diff-filter=A \
  -- .github/workflows/prose.yml
a9f3b74 2026-08-11 Refuse a whitespace change that hides the sentence next to it
```

So a sixth declared check name carried no verdict in this document. It is a
different failure from the five that were given one at `d645d4e`: those were
never written down at all, and this one was written down as absent and went
stale where it stood. That is the harder of the two to find, because a reader
searching the row for the prose half finds a sentence rather than nothing.

## How it was found

By comparing the names the tree declares against the literals the document
carries, rather than by reading the row:

```
git grep -h -oE '\{Name: "[^"]+"' origin/main \
  -- internal/contexts/contexts.go | sed 's/{Name: "//; s/"$//' | sort -u \
  | while read -r n; do
      grep -qF "$n" docs/quality-parity.md || echo "no literal in doc: $n"
    done
no literal in doc: prose format
```

Run against the head of this branch the same sweep prints nothing for
`prose format`. The six `build (...)` entries it also prints are not this case:
their verdict is in the `build` row and reaches them through
`docs/decisions/0012-the-supported-platforms.md` rather than through six
literals, which is the rule against enumerating in a document working as
intended.

## What this changes

One table row. It names the `format` job and the `prose format` job, says both
are kept and belong in the required set, and keeps the thing the old sentence
had right: neither of them rewrites anything. That is where the split departs
from the target, since `prettier` formats and these two refuse, so a departure
is a red tick here and a diff there.

## The measurements

Run at `27fb1cd`, the head of this branch:

```
go test ./internal/prose ./internal/invariants -count=1
ok  	github.com/Flowfin/lab/internal/prose	0.590s
ok  	github.com/Flowfin/lab/internal/invariants	0.827s

go run ./cmd/lab check . | tail -1
0 refused
```

## The means

One row of an existing Markdown document, because what is wrong is a sentence in
that row. No language, runtime or dependency is added.

## What this does not do

It does not assemble the required set and it does not touch the ruleset, which
is what the done-condition of #26 ends on. It moves no state in
`internal/contexts/contexts.go`, for the same reason the change before it did
not: a kept name leaves the deliberate-absence list by entering the ruleset, and
the entry for `prose format` already says exactly that.

## The reading

There is no second reader on this board tonight, so nothing here has been read
by anybody but its author. The commands above are quoted with their output in
place of one, so every claim in this body can be re-run rather than taken.

Signed-off-by: Nils Lehnen <30603423+iderex@users.noreply.github.com>
