### PR TITLE
Read the triggers and the conditions into the parity document (#62)

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -281,6 +281,78 @@ condition excludes, with nothing on the pull request saying why. That absence is
 permanent rather than one issue #26 retires, and the job name beside it is
 unaffected.
 
+### None of these workflows narrows itself to some pull requests
+
+A context that arrives on some pull requests and not on others is what this
+section is written against, and three of the ways to build one are readable in
+these files rather than walked. The readings below were made at `1fc6961` and
+cover every workflow file in the tree at that commit.
+
+A path filter is the ordinary way it happens, and no workflow here carries one:
+
+```
+git grep -n 'paths:\|paths-ignore:' origin/main -- .github/workflows/ ; echo "exit=$?"
+exit=1
+```
+
+A trigger narrowed to some branches is the same failure by a second route, and
+three of these files carry no branch filter that reads every branch:
+
+```
+git grep -L 'branches: \[ *"\*\*" *\]' origin/main -- .github/workflows/
+origin/main:.github/workflows/dco.yml
+origin/main:.github/workflows/dependency-review.yml
+origin/main:.github/workflows/scorecard.yml
+```
+
+The third is the supply-chain self-audit, which declares no pull-request
+trigger at all and is outside the required set already. Neither of the other
+two narrows anything. `dependency-review.yml` writes no branch filter under any
+of its triggers, which is every branch:
+
+```
+git grep -n 'branches:' origin/main -- .github/workflows/dependency-review.yml ; echo "exit=$?"
+exit=1
+```
+
+`dco.yml` carries the only type filter in these files:
+
+```
+git grep -n 'types:' origin/main -- .github/workflows/
+origin/main:.github/workflows/dco.yml:13:    types: [opened, synchronize, reopened]
+```
+
+The claim about the three types it names is that they are the three the
+platform runs a pull-request workflow for when a file names none, so writing
+them out removes no pull request. That is the platform's documented default
+rather than something this tree says, and nothing here measures it. What sits
+beside it is that `DCO sign-off` is among the contexts the pull-request head
+compared above reported, which shows the workflow runs on an ordinary pull
+request and shows nothing about one that arrives another way.
+
+A job skipped by a condition is the third, and two of these files carry one at
+all:
+
+```
+git grep -c '^\s*if:' origin/main -- .github/workflows/
+origin/main:.github/workflows/scorecard.yml:1
+origin/main:.github/workflows/zizmor.yml:1
+```
+
+Neither reaches a name the table above keeps. The first is a job-level
+condition on the supply-chain self-audit, which the paragraph above already
+places outside the required set for a reason of its own. The second is the
+upload condition quoted earlier in this section, indented under a step rather
+than a job, and the step that fails on findings sits after it carrying no
+condition.
+
+What these commands do not reach. They read the path filters, the branch and
+type filters and the `if:` keys, which is what those three are written with in
+these files today, and a fourth route written some other way is not something a
+reader can take from them. None of them says anything about
+what a job does once it has started, so a context that arrives having done
+nothing is a different question and is not answered here.
+
 ### What this section does not settle
 
 No pull request from a fork has been opened here. The condition above has two


### PR DESCRIPTION
Refs #62

## What this changes

The document gains a section under the walk of which contexts arrive, saying
which of the ways a required context can fail to arrive are readable in the
workflow files and what those files say today. Three commands and their output:
no workflow carries a path filter, three files carry no branch filter that
reads every branch and none of the three narrows a pull request by it, and two
files carry a condition at all, neither of them on a name the table keeps.

Nothing else in the document moves and no other file is touched.

## What failure it prevents

A required set assembled from names that arrive on some pull requests only,
with the document beside the set silent about which names were read for it. The
reading that existed at all lived outside the tree and was made before one of
these workflow files was written, so a reader asking what stands behind a merge
could not find it where the rest of the walk is, and could not tell how much of
the tree it had covered.

## What was run

I ran the four commands CONTRIBUTING.md names, at the commit being pushed, and
the checker over this tree. The suite output is the tail of the run.

```
$ go build ./cmd/... ./internal/...
$ go vet ./cmd/... ./internal/...
$ gofmt -l cmd internal
(no output)
$ go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	1.563s
ok  	github.com/Flowfin/lab/cmd/lab	3.735s
ok  	github.com/Flowfin/lab/cmd/notices	16.698s
ok  	github.com/Flowfin/lab/cmd/pullrequest	3.020s
ok  	github.com/Flowfin/lab/internal/check	2.838s
ok  	github.com/Flowfin/lab/internal/contexts	1.972s
ok  	github.com/Flowfin/lab/internal/hardware	2.133s
ok  	github.com/Flowfin/lab/internal/invariants	2.738s
ok  	github.com/Flowfin/lab/internal/notices	1.925s
ok  	github.com/Flowfin/lab/internal/prose	3.157s
ok  	github.com/Flowfin/lab/internal/pullrequest	3.353s

$ go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
18 decision records read
the time this run read is 2026-08-17T05:04:44Z
0 refused
```

The invariants leg refused this change twice before it was written the way it
is now. The first draft pasted `git grep -A1` output, whose context lines end a
path with a dash, and `document-names-a-path-that-does-not-resolve` refused
both of them by name:

```
docs/quality-parity.md: it names .github/workflows/dco.yml-, which is not in this tree (document-names-a-path-that-does-not-resolve)
docs/quality-parity.md: it names .github/workflows/dependency-review.yml-, which is not in this tree (document-names-a-path-that-does-not-resolve)
```

Every command the section quotes was run at `1fc6961` and its output pasted
from that run rather than retyped.

## What this does not do

This is not the end of #62. The first clause of that issue compares what arrives
against the required set, the set on this board is empty, so there is nothing
to compare against. The fork clause is untouched: no pull request from a fork
has been opened on this board and nothing here opens one.

It says nothing about what a job does once it has started. A context that
arrives having done nothing is a different question, and the section says so
where it states its bound.

One line in it is a claim rather than a measurement, and it is written as a
claim: that the three event types `dco.yml` names are the three the platform
runs a pull-request workflow for when a file names none. That is the platform's
documented default, and nothing in this tree measures it.

There is no second reader for this change tonight. What stands in place of one
is the output above and the commands in the section, each of which reproduces
against `origin/main`.


