### PR TITLE
Separate the fork question for the job that reads the ruleset (#62)

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -353,6 +353,75 @@ reader can take from them. None of them says anything about
 what a job does once it has started, so a context that arrives having done
 nothing is a different question and is not answered here.
 
+### One job can start and still be unable to do its work
+
+The readings above stop at the moment a job begins. One job here has a second
+failure after that moment, because half of what it compares is a live setting
+on the platform rather than a file in the checkout, so it has to ask. No other
+workflow in this tree asks anything:
+
+```
+git grep -n 'gh api' origin/main -- .github/workflows/
+origin/main:.github/workflows/contexts.yml:93:          if ! gh api "repos/${REPOSITORY}/rules/branches/${DEFAULT_BRANCH}" \
+```
+
+That reads the run blocks these files carry, so it says which workflow asks the
+platform a question in a script this repository writes. What an action reaches
+once it has started is not readable from here and the command says nothing
+about it.
+
+The job reports as `required contexts`, which the section above keeps and puts
+in the required set. What it does when the answer does not arrive is written
+into the step rather than left to the shell:
+
+```
+git show origin/main:.github/workflows/contexts.yml | sed -n '92,100p'
+          set -euo pipefail
+          if ! gh api "repos/${REPOSITORY}/rules/branches/${DEFAULT_BRANCH}" \
+                --jq '.[] | select(.type=="required_status_checks")
+                      | .parameters.required_status_checks[].context' > required.txt; then
+            echo "::error::The ruleset on ${DEFAULT_BRANCH} could not be read, so this run could not judge whether the gate and the tree agree. That is not the same as them agreeing."
+            exit 1
+          fi
+          echo "the ruleset on ${DEFAULT_BRANCH} requires $(wc -l < required.txt) context(s):"
+          cat required.txt
+```
+
+So this route ends in a red context carrying its reason rather than in a
+context that never arrives, which is the better of the two failures and is
+still a pull request held open by something other than the change on it. An
+empty answer is not that failure. The count is printed and the run carries on,
+which is the state this board is in today.
+
+One of the two things a fork run brings is measurable here already. A
+Dependabot pull request runs with a read-only token, which is what the upload
+condition quoted earlier in this section names it for, and #135 is one. On its
+head the job ran and the fetch answered:
+
+```
+gh api repos/Flowfin/lab/commits/d18d040/check-runs?per_page=100 \
+  --jq '.check_runs[] | select(.name=="required contexts")
+        | "\(.name): \(.conclusion)"'
+required contexts: success
+
+gh run view 31929377870 --log \
+  | sed -n 's/.*\(the ruleset on main requires .*\)/\1/p'
+the ruleset on main requires 0 context(s):
+```
+
+A read-only token reads this board's ruleset, so that is not what would stop a
+run from a fork. What is left is the other thing, which is that the token is
+issued against a different repository. `github.repository` names this board on
+a pull request from a fork, so the fetch asks about this board whichever side
+the branch sits on, and whether a token issued that way may read this board's
+ruleset is platform behaviour that nothing in this tree states and nothing
+above measures.
+
+`required contexts` therefore belongs in the fork clause of #62, and it is
+there for a different reason from the two names already in it. Those two are
+created by an upload and turn on a write scope. This one is a job that always
+starts, and what is open is whether the answer it needs arrives.
+
 ### What this section does not settle
 
 No pull request from a fork has been opened here. The condition above has two
@@ -360,7 +429,8 @@ arms and only the second was walked: the branch measured above is in this
 repository, and a read-only token is what the two arms have in common rather
 than what makes them one route. `CodeQL` did arrive on that pull request, so
 nothing here says whether it arrives from a fork, and the fork clause of #62 is
-open for it.
+open for it. It is open for `required contexts` as well, for the reason the
+subsection above gives rather than for this one.
 
 The required set is empty, so nothing above is a report of a required context
 that failed to arrive. Every sentence here is about which names a set could


### PR DESCRIPTION
Refs #62

## What this changes

The walk of which contexts arrive gains one subsection. Everything that walk
read before is about whether a job starts: path filters, branch and type
filters, and job-level conditions. `required contexts` can start and still be
unable to finish, because half of what it compares is the ruleset on the
platform rather than a file in the checkout, and it is the only name in the
candidate set with that shape.

The subsection names the workflow, quotes the step that stops the job when the
fetch fails rather than letting it compare against an empty list, and splits
the fork question into the part that is measured and the part that is not.

Nothing else in the document moves and no other file is touched.

## What failure it prevents

A required set assembled with `required contexts` in it, on a board whose
document beside the set has walked the fork question for two upload-derived
names and not for the one name that reads the gate itself. If that fetch cannot
be made from a fork, requiring the context closes the board to anybody who
cannot push a branch to it, which is the second of the three cases the issue is
written against, and the document a reader consults would not have raised it.

## What was run

I ran the four commands `CONTRIBUTING.md` names, at the commit being pushed,
and the checker over this tree.

```
$ go build ./cmd/... ./internal/...
$ go vet ./cmd/... ./internal/...
$ gofmt -l cmd internal
(no output)
$ go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	2.703s
ok  	github.com/Flowfin/lab/cmd/lab	5.961s
ok  	github.com/Flowfin/lab/cmd/notices	17.209s
ok  	github.com/Flowfin/lab/cmd/pullrequest	1.239s
ok  	github.com/Flowfin/lab/internal/check	2.368s
ok  	github.com/Flowfin/lab/internal/contexts	2.378s
ok  	github.com/Flowfin/lab/internal/hardware	0.891s
ok  	github.com/Flowfin/lab/internal/invariants	1.422s
ok  	github.com/Flowfin/lab/internal/notices	2.061s
ok  	github.com/Flowfin/lab/internal/prose	2.051s
ok  	github.com/Flowfin/lab/internal/pullrequest	2.080s

$ go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
18 decision records read
the time this run read is 2026-08-17T09:52:15Z
0 refused
```

Every command the subsection quotes was run before it was written and its
output pasted from that run rather than retyped. The two tracker commands were
run against `Flowfin/lab` and the two git commands against `origin/main` at
`df980aa`.

## What this does not do

It does not walk a fork. No pull request from a fork has been opened on this
board and nothing here opens one, so the second half of the token question is
unmeasured and the text says so in the place a reader would otherwise take the
first half as an answer to both.

It settles no name into the required set. That set is empty, which is the same
bound every other sentence in that section carries.

The measurement it does make is of a Dependabot pull request rather than of a
fork. Those two share a read-only token and are otherwise different routes, and
the subsection uses it for the token alone.

The means is prose in the document the issue names as where its results go. It
carries commands and their output the way the rest of that file does, and it
needs no apparatus maintained beside it.

There is no second reader for this change tonight. What stands in place of one
is the output above and the commands in the subsection, each of which
reproduces against `origin/main`.
