### PR TITLE
Say that one kept name is reported twice on one commit (#26)

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -217,6 +217,86 @@ contexts that every pull request reports, and it offers one that no pull
 request can report. Which commit that command is run against decides what the
 gate gets.
 
+### One name is reported twice on the same commit
+
+Every command in this document that lists check names deduplicates, and one of
+the names they print once was produced by two runs. On `bd861cf`, the head of
+pull request #145:
+
+```
+gh api repos/Flowfin/lab/commits/bd861cf/check-runs?per_page=100 \
+  --jq '.check_runs[].name' | sort | uniq -d
+Reject Trojan Source Unicode
+
+gh api repos/Flowfin/lab/commits/bd861cf/check-runs?per_page=100 \
+  --jq '.check_runs[] | select(.name=="Reject Trojan Source Unicode")
+        | "suite \(.check_suite.id), \(.conclusion)"'
+suite 86798670354, success
+suite 86798547856, success
+```
+
+The cause is one trigger. Every push trigger in these files names the default
+branch except one:
+
+```
+for f in $(git ls-tree --name-only origin/main .github/workflows/); do
+  s=$(git show "origin/main:$f" | sed -n '/^  push:/{n;s/^ *//;p;}')
+  [ -n "$s" ] && printf '%s %s\n' "$f" "$s"
+done
+.github/workflows/build.yml branches: [main]
+.github/workflows/codeql.yml branches: [main]
+.github/workflows/contexts.yml branches: [main]
+.github/workflows/headless.yml branches: [main]
+.github/workflows/invariants.yml branches: [main]
+.github/workflows/prose.yml branches: [main]
+.github/workflows/records.yml branches: [main]
+.github/workflows/scorecard.yml branches: [main]
+.github/workflows/unicode-guard.yml branches: ["**"]
+.github/workflows/zizmor.yml branches: [ main ]
+```
+
+A branch pushed for a pull request therefore starts that one workflow twice,
+and both runs report under its job name. The file gives the reason its trigger
+is wide, and the reason is about which branches the guard covers rather than
+about the gate:
+
+```
+git show origin/main:.github/workflows/unicode-guard.yml | sed -n '3,11p'
+on:
+  # Every branch and every PR: the guard is a cheap read-only scan, so there is no
+  # reason to narrow it to main, and it covers whatever branches this repository
+  # grows later without being edited again.
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+```
+
+The two runs do not read the same tree, and that is what makes this more than a
+repeated line. Each checkout says what it took, and the answers differ:
+
+```
+gh run view 32017539721 --log \
+  | sed -n 's/.*\(git checkout --progress --force .*\)/\1/p'
+git checkout --progress --force -B parity/one-job-asks-the-platform-and-the-fork-half-is-unwalked refs/remotes/origin/parity/one-job-asks-the-platform-and-the-fork-half-is-unwalked
+
+gh run view 32017585271 --log \
+  | sed -n 's/.*\(git checkout --progress --force .*\)/\1/p'
+git checkout --progress --force refs/remotes/pull/145/merge
+```
+
+The first read the branch and the second read the branch merged into the base.
+A tree that carries none of these characters on the branch and carries one once
+merged separates the two runs, which is the case this particular guard exists
+for one merge earlier.
+
+`Reject Trojan Source Unicode` is a row the table above keeps, so it is a
+candidate for the required set. What a merge does when two check runs answer to
+one name is platform behaviour that nothing in this tree states, and the set
+here is empty, so it cannot be measured on this board today either. Issue #26
+assembles the set and its first clause meets this, because the command it
+assembles from prints one line for the two.
+
 ### Two of the names come from an upload rather than from a job
 
 The names on that same pull request head that no job in this tree produced:


### PR DESCRIPTION
Refs #26

## What this changes

The walk of which contexts arrive gains a subsection saying that one kept name
is reported twice on the same commit, and why. `Reject Trojan Source Unicode`
is produced by two runs of one workflow, because `unicode-guard.yml` is the
only file here whose push trigger reads every branch, so a branch pushed for a
pull request starts it for the push and for the pull request.

Four commands and their output: the duplicate itself and the two check suites
behind it, the push branch scope of every workflow in the tree, the trigger
block with the reason its author wrote for it, and the checkout line from each
of the two runs.

Nothing else in the document moves and no other file is touched.

## What failure it prevents

This issue assembles the required set from the names a completed run reported,
and every command in that document which lists them deduplicates. One name
where the gate would meet two check runs is therefore invisible at the moment
the set is written, and the two runs read different trees: one takes the
branch, the other takes the branch merged into the base. A change that carries
none of these characters on the branch and carries one once merged separates
them, which is the case this guard exists for one merge earlier.

## What was run

I ran the four commands `CONTRIBUTING.md` names, at the commit being pushed,
and the checker over this tree.

```
$ go build ./cmd/... ./internal/...
$ go vet ./cmd/... ./internal/...
$ gofmt -l cmd internal
(no output)
$ go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	3.164s
ok  	github.com/Flowfin/lab/cmd/lab	4.582s
ok  	github.com/Flowfin/lab/cmd/notices	15.221s
ok  	github.com/Flowfin/lab/cmd/pullrequest	1.970s
ok  	github.com/Flowfin/lab/internal/check	1.969s
ok  	github.com/Flowfin/lab/internal/contexts	0.635s
ok  	github.com/Flowfin/lab/internal/hardware	1.413s
ok  	github.com/Flowfin/lab/internal/invariants	2.466s
ok  	github.com/Flowfin/lab/internal/notices	1.247s
ok  	github.com/Flowfin/lab/internal/prose	0.639s
ok  	github.com/Flowfin/lab/internal/pullrequest	0.976s

$ go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
18 decision records read
the time this run read is 2026-08-17T10:02:08Z
0 refused
```

Every command the subsection quotes was run before it was written and its
output pasted from that run rather than retyped. The tracker commands were run
against `Flowfin/lab` and the git commands against `origin/main` at `1ef2267`.
The two log extracts are piped through `sed` in the quoted command itself,
because the raw log is tab separated and `prose-carries-a-tab` refuses a tab in
tracked Markdown.

## What this does not do

It assembles no set and changes no ruleset, so every clause of this issue's
done-condition still stands where it stood.

It does not say what the platform does when two check runs answer to one
required name. That is behaviour this tree does not state, the set here is
empty so it cannot be measured on this board, and the subsection says both
rather than reasoning to an answer.

It proposes no repair. Narrowing the push trigger, renaming one of the two jobs
and leaving it as it is are all available, and which one is right depends on
what the set is meant to hold, which is this issue rather than this change.

The measurement is of one pull request on this board. Another workflow gaining
a push trigger over every branch would add a second doubled name, and the
command that derives the branch scopes is in the subsection so a reader can
re-run it rather than trust the list.

There is no second reader for this change tonight. What stands in place of one
is the output above and the commands in the subsection, each of which
reproduces against `origin/main`.
