### PR TITLE
Restore the notices proof that reads a tree with a dependency added (#37)

### DIFF
--- a/cmd/notices/tree_test.go
+++ b/cmd/notices/tree_test.go
@@ -1,0 +1,289 @@
+// What this file proves that neither of the other two suites can.
+//
+// internal/notices proves the render, against module sets a case wrote out in
+// full. main_test.go proves that the module table inside a real binary reaches
+// that render, against a binary built from this repository. Neither of them
+// starts from a tree: this repository has no third-party dependency, so a build
+// of it exercises the empty half only, and a module set constructed in a test is
+// a statement about the test rather than about a build.
+//
+// Issue #37 asks for the other half in its own words - a run against a tree with
+// a dependency added produces a notices file that lists it - so this builds two
+// binaries from one tree, the second differing from the first by a require line
+// and an import, and holds the difference between the two documents.
+//
+// IT OPENS NO CONNECTION, which is what made this leg look unreachable. The
+// module is served out of a directory laid out as a module proxy and written by
+// this test, the checksum database is off, and the toolchain is pinned to the
+// one already installed, so nothing here resolves a name or fetches a version.
+// The module cache the build populates is a temporary directory, so the licence
+// text the document carries came from this run rather than from whatever the
+// machine happened to have downloaded before it.
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The module the tree under test depends on.
+//
+// It is invented rather than borrowed from the real ecosystem. A test that
+// depends on something real depends on that thing staying fetchable and staying
+// licensed the way it was on the day the test was written, and both of those are
+// facts about somebody else's repository.
+const (
+	dependencyPath    = "example.com/dep"
+	dependencyVersion = "v1.0.0"
+)
+
+// The go directive is well below the toolchain this repository builds with on
+// purpose. The tree here is built by whatever toolchain is running the suite,
+// and a directive naming a version newer than that one asks the toolchain to
+// fetch a different one, which is the network this file exists without.
+const dependencyGoMod = "module example.com/dep\n\ngo 1.21\n"
+
+const dependencySource = `package dep
+
+// Answer is here so that the tree under test imports this module and uses it.
+// A module that is required and never imported does not reach the binary, and
+// then the document would be correct to leave it out.
+func Answer() int { return 37 }
+`
+
+// The licence text is written to be unmistakable in a document. What the
+// assertion below has to separate is a document naming a module from a document
+// carrying the text that module shipped, and a conventional licence header
+// appears in enough places to make that a weak test.
+const dependencyLicenceText = `Copyright 2026 the author of example.com/dep
+
+Permission is granted to reproduce this text in a notices document, which is
+the whole of what this file exists to be reproduced by.
+`
+
+// TestATreeWithADependencyAddedProducesADocumentThatListsIt builds one tree
+// twice and compares the two documents.
+//
+// The comparison is the test. A tree that had the dependency from the start
+// would pass against a command that lists whatever it finds and also against one
+// that lists a module somebody hard-coded, and the difference between the two
+// runs is what separates them.
+func TestATreeWithADependencyAddedProducesADocumentThatListsIt(t *testing.T) {
+	workspace := t.TempDir()
+	proxy := writeTheModuleProxy(t, filepath.Join(workspace, "proxy"))
+	cache := filepath.Join(workspace, "modcache")
+	tree := filepath.Join(workspace, "tree")
+
+	// The cache is created here rather than left to the build. The first of the
+	// two builds needs nothing, so it populates no cache, and a command told to
+	// read a directory that is not there refuses the invocation instead of
+	// describing the binary.
+	if err := os.MkdirAll(cache, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	environment := offlineEnvironment(proxy, cache)
+	cleanTheModuleCache(t, environment)
+
+	writeTheTree(t, tree, false)
+	before, code := describe(t, buildTheTree(t, tree, environment, "before"), cache)
+	if code != exitClean {
+		t.Fatalf("describing the tree without the dependency returned %d", code)
+	}
+	if strings.Contains(before, dependencyPath) {
+		t.Fatalf("the tree without the dependency already names %s, so the comparison below proves nothing:\n%s", dependencyPath, before)
+	}
+	if !strings.Contains(before, "This binary contains no third-party module.") {
+		t.Errorf("the tree without the dependency does not say that there is nothing to disclose:\n%s", before)
+	}
+
+	writeTheTree(t, tree, true)
+	after, code := describe(t, buildTheTree(t, tree, environment, "after"), cache)
+	if code != exitClean {
+		t.Fatalf("describing the tree with the dependency returned %d rather than %d, so the licence text was not read out of the cache the build populated", code, exitClean)
+	}
+
+	named := dependencyPath + "@" + dependencyVersion
+	if !strings.Contains(after, named) {
+		t.Errorf("the document does not name %s:\n%s", named, after)
+	}
+	if !strings.Contains(after, strings.TrimSpace(dependencyLicenceText)) {
+		t.Errorf("the document names %s and does not carry the text it shipped, which is the half a link would also have failed to supply:\n%s", named, after)
+	}
+	t.Logf("adding %s moved the document from %d to %d byte(s) and carried its licence text", named, len(before), len(after))
+}
+
+// describe runs the command over one binary and returns what it wrote and the
+// code it returned.
+func describe(t *testing.T, binary, cache string) (string, int) {
+	t.Helper()
+
+	var out, errOut bytes.Buffer
+	code := run([]string{binary, cache}, &out, &errOut)
+	if errOut.Len() > 0 {
+		t.Logf("the run said: %s", strings.TrimSpace(errOut.String()))
+	}
+	return out.String(), code
+}
+
+// writeTheTree writes a module that either imports the dependency or does not.
+//
+// Both halves are written rather than the second being an edit of the first, so
+// that what the two builds differ by is stated in one place a reader can see.
+func writeTheTree(t *testing.T, dir string, withDependency bool) {
+	t.Helper()
+
+	goMod := "module example.com/tree\n\ngo 1.21\n"
+	source := "package main\n\nfunc main() { println(\"the tree ran\") }\n"
+	if withDependency {
+		goMod = "module example.com/tree\n\ngo 1.21\n\nrequire " + dependencyPath + " " + dependencyVersion + "\n"
+		source = "package main\n\nimport \"" + dependencyPath + "\"\n\nfunc main() { println(dep.Answer()) }\n"
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write(t, filepath.Join(dir, "go.mod"), goMod)
+	write(t, filepath.Join(dir, "main.go"), source)
+}
+
+// buildTheTree compiles the tree and returns the path of the binary.
+func buildTheTree(t *testing.T, dir string, environment []string, name string) string {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	binary := filepath.Join(t.TempDir(), name)
+
+	build := exec.Command("go", "build", "-o", binary, ".")
+	build.Dir = dir
+	build.Env = environment
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("cannot build the tree under test: %v\n%s", err, output)
+	}
+	return binary
+}
+
+// writeTheModuleProxy lays out the dependency the way a module proxy serves it
+// and returns the directory to point the toolchain at.
+func writeTheModuleProxy(t *testing.T, root string) string {
+	t.Helper()
+
+	dir := filepath.Join(root, filepath.FromSlash(dependencyPath), "@v")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write(t, filepath.Join(dir, "list"), dependencyVersion+"\n")
+	write(t, filepath.Join(dir, dependencyVersion+".info"), `{"Version":"`+dependencyVersion+`"}`)
+	write(t, filepath.Join(dir, dependencyVersion+".mod"), dependencyGoMod)
+
+	if err := os.WriteFile(filepath.Join(dir, dependencyVersion+".zip"), moduleArchive(t), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// moduleArchive builds the zip a module proxy serves, which is every file of the
+// module under one directory named for the module and its version.
+func moduleArchive(t *testing.T) []byte {
+	t.Helper()
+
+	var buffer bytes.Buffer
+	archive := zip.NewWriter(&buffer)
+	prefix := dependencyPath + "@" + dependencyVersion + "/"
+
+	for _, file := range []struct{ name, content string }{
+		{"go.mod", dependencyGoMod},
+		{"dep.go", dependencySource},
+		{"LICENSE", dependencyLicenceText},
+	} {
+		entry, err := archive.Create(prefix + file.name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := entry.Write([]byte(file.content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}
+
+// offlineEnvironment is what the two builds run under.
+//
+// Every entry is here to remove one route to the network or to the machine's own
+// state. The proxy is a directory. The checksum database is off, because it is a
+// service and the module it would be asked about does not exist outside this
+// test. The toolchain is the installed one, so a go directive is never a
+// download. The workspace file is off, so a go.work above the temporary
+// directory cannot pull this build into it. The module cache is a temporary
+// directory, so the licence text in the document came from this run.
+//
+// THE THREE EMPTIED VARIABLES ARE THE ONES THAT SEND A BUILD PAST THE PROXY.
+// They are inherited from whoever is running the suite, and any of them matching
+// this module makes the toolchain resolve the path as a domain and fetch over
+// https, which is a failure that only appears on a machine configured a
+// particular way. Emptying them is how this file stops depending on that
+// configuration.
+func offlineEnvironment(proxy, cache string) []string {
+	return append(os.Environ(),
+		"GOPROXY="+proxyURL(proxy),
+		"GOSUMDB=off",
+		"GOPRIVATE=",
+		"GONOPROXY=",
+		"GONOSUMDB=",
+		"GOFLAGS=-mod=mod",
+		"GOMODCACHE="+cache,
+		"GOWORK=off",
+		"GOTOOLCHAIN=local",
+	)
+}
+
+// proxyURL spells a directory as the file URL the toolchain reads a proxy from.
+// The leading slash is added where the path does not have one, which is every
+// path on Windows and no path anywhere else.
+func proxyURL(dir string) string {
+	slashed := filepath.ToSlash(dir)
+	if !strings.HasPrefix(slashed, "/") {
+		slashed = "/" + slashed
+	}
+	return "file://" + slashed
+}
+
+// cleanTheModuleCache empties the temporary cache before the directory holding
+// it is removed.
+//
+// The toolchain writes the cache read-only, and removing a read-only file is
+// refused on one of the platforms this repository supports, so the cleanup the
+// temporary directory does on its own fails there. This is registered after that
+// cleanup and therefore runs before it.
+func cleanTheModuleCache(t *testing.T, environment []string) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		clean := exec.Command("go", "clean", "-modcache")
+		clean.Env = environment
+		if output, err := clean.CombinedOutput(); err != nil {
+			t.Logf("cannot empty the temporary module cache: %v\n%s", err, output)
+		}
+	})
+}
+
+// write is os.WriteFile with the test failed rather than the error returned,
+// because every caller here would do the same three lines.
+func write(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Refs #37

## What this changes

It puts `cmd/notices/tree_test.go` back on the default branch. The file landed in
`82c245fbce624dd7c1749891702da68758345a4e` and is not in the tree today:

```
git log --diff-filter=D --format='%H %s' origin/main -- cmd/notices/tree_test.go
d3edfc95b8526033c79cb26afe48282c2c090e32 Name the version the pinned commit actually is (#151)
```

That commit is described by its message as a change to how one workflow pin is
commented, and it removes seven paths. What it did to the other six is outside
this change and is written up in #155.

The bytes here are the bytes that were on the default branch, not a rewrite of
them:

```
git rev-parse 90656ba:cmd/notices/tree_test.go
8415e80f25bda8d536e575d39f7e34330e018eae
git hash-object cmd/notices/tree_test.go
8415e80f25bda8d536e575d39f7e34330e018eae
```

The means is Go, and it is the means the artefact already had. This restores a
file the suite under `cmd/notices` already compiles, so it adds no language, no
runtime and no dependency, and it is testable by the suite that exists rather
than by a parallel one.

## What failure it prevents

A build read wrongly reaching the notices document with nothing to catch it.

`buildOf` in `cmd/notices/main.go` collects the modules the toolchain recorded
inside a binary. With line 137, `build.Deps = append(build.Deps, module)`,
replaced by a discard, the default branch as it stands runs green in all eleven
packages:

```
go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	0.709s
ok  	github.com/Flowfin/lab/cmd/lab	1.183s
ok  	github.com/Flowfin/lab/cmd/notices	4.174s
ok  	github.com/Flowfin/lab/cmd/pullrequest	2.363s
ok  	github.com/Flowfin/lab/internal/check	1.147s
ok  	github.com/Flowfin/lab/internal/contexts	1.894s
ok  	github.com/Flowfin/lab/internal/hardware	1.868s
ok  	github.com/Flowfin/lab/internal/invariants	1.717s
ok  	github.com/Flowfin/lab/internal/notices	2.062s
ok  	github.com/Flowfin/lab/internal/prose	1.189s
ok  	github.com/Flowfin/lab/internal/pullrequest	2.359s
```

Every package there is green because none of them starts from a tree. The two
neighbours in `cmd/notices` read a binary built from this repository, which has
no third-party module, so a collector that drops everything and a collector that
works produce the same document: the one saying there is nothing to disclose.
`internal/notices` writes its module sets out in full, so it never runs the
collector at all.

With the file back, the same one-line edit reddens exactly one test and leaves
its two neighbours alone:

```
go test -count=1 -v ./cmd/notices
--- PASS: TestTheModuleTableOfARealBinaryReachesTheDocument (1.61s)
--- PASS: TestABrokenInvocationIsNotARefusal (1.16s)
--- FAIL: TestATreeWithADependencyAddedProducesADocumentThatListsIt (3.32s)
```

and across the module it reddens `cmd/notices` and nothing else:

```
go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	2.002s
ok  	github.com/Flowfin/lab/cmd/lab	1.933s
--- FAIL: TestATreeWithADependencyAddedProducesADocumentThatListsIt (3.14s)
FAIL	github.com/Flowfin/lab/cmd/notices	7.923s
ok  	github.com/Flowfin/lab/cmd/pullrequest	2.609s
ok  	github.com/Flowfin/lab/internal/check	1.341s
ok  	github.com/Flowfin/lab/internal/contexts	1.702s
ok  	github.com/Flowfin/lab/internal/hardware	1.191s
ok  	github.com/Flowfin/lab/internal/invariants	1.569s
ok  	github.com/Flowfin/lab/internal/notices	2.412s
ok  	github.com/Flowfin/lab/internal/prose	1.516s
ok  	github.com/Flowfin/lab/internal/pullrequest	2.684s
```

`cmd/notices/main.go` is untouched by this change. The edit above was made to
measure the difference and reverted before the commit:

```
git diff --name-only origin/main...HEAD
cmd/notices/tree_test.go
```

There is a second failure the absence carried, and it is about what a reader is
entitled to believe. Two notes on #37 say the third leg of its done-when is
landed on the default branch. Until this merges, that is not true of the branch
a reader will check out.

## What was run

At `9f1ad61de2d27d66946e823b3d5f23546aa6e6db`, on Windows, with no graphical
session and as an ordinary user:

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	1.956s
ok  	github.com/Flowfin/lab/cmd/lab	3.130s
ok  	github.com/Flowfin/lab/cmd/notices	8.466s
ok  	github.com/Flowfin/lab/cmd/pullrequest	3.039s
ok  	github.com/Flowfin/lab/internal/check	2.306s
ok  	github.com/Flowfin/lab/internal/contexts	1.288s
ok  	github.com/Flowfin/lab/internal/hardware	2.153s
ok  	github.com/Flowfin/lab/internal/invariants	2.041s
ok  	github.com/Flowfin/lab/internal/notices	1.376s
ok  	github.com/Flowfin/lab/internal/prose	2.345s
ok  	github.com/Flowfin/lab/internal/pullrequest	2.863s
```

`go build`, `go vet` and `gofmt -l` each printed nothing, which is the passing
result for all three.

```
go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
18 decision records read
the time this run read is 2026-08-21T03:42:32Z
0 refused
```

The suite ran on one platform. The other two the build covers were not run here
and the jobs on this pull request are what covers them.

## What this does not do

It does not finish #37. That issue's two remaining legs ask for the notices and
the bill of materials to be generated by the release build and attached to the
release, and there is no release workflow in this tree and no release:

```
gh api repos/Flowfin/lab/releases --jq 'length'
0
```

Both of those sit behind #41, which is unstarted for a reason written on it.

It restores one of the seven paths that commit removed and leaves the other six
alone, because they belong to other issues and to work running beside this. What
is missing from each of them, with the commands, is #155.

It does not touch the collector the test judges, so nothing here makes the
notices document more correct. What changes is that a wrong one would be caught.

No second person has read this change. The evidence above stands in place of
that reading rather than beside it.
