### PR TITLE
List the pull-request parameter the parity table does not carry (#55)

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -141,9 +141,15 @@ requires it to stay empty, so nothing here adds a second rule about it.
 ### The pull-request rule, parameter by parameter
 
 Every parameter the third command prints, with the target's value beside it. On
-2026-08-10 all but the first held the same value on both boards. A setting left
-at its default and a setting chosen deliberately look identical afterwards,
-which is why every row carries a reason and not only a verdict.
+2026-08-10 all but the first held the same value on both boards, and that is
+still the reading on 2026-08-21. A setting left at its default and a setting
+chosen deliberately look identical afterwards, which is why every row carries a
+reason and not only a verdict.
+
+The table listed eight rows and the command prints nine names. Which of the two
+that is, a parameter the platform started printing after the table was written
+or a row the walk missed on the day, is not readable from here, and the last row
+below is the one that was absent either way.
 
 | Parameter | Here | Target | Verdict |
 | --- | --- | --- | --- |
@@ -155,6 +161,7 @@ which is why every row carries a reason and not only a verdict.
 | `require_code_owner_review` | `false` | `false` | Kept. There is no `CODEOWNERS` file in this tree, so requiring a code-owner review here would require an approval nothing can name. |
 | `dismissal_restriction` | `{"allowed_actors":[],"enabled":false}` | The same | Kept. It restricts who may dismiss a review, and there is no required review to dismiss. |
 | `required_reviewers` | `[]` | `[]` | Kept, for the reason in the row above. |
+| `require_extra_approval_for_unattributed_changes` | `true` | `true` | Kept, and it is the row to read carefully. The four rows above turn on a review being required, and this one is written to ask for an approval where a change carries commits the pull request's author is not credited with, so it is the only parameter here that could ask for one at a count of zero. Whether it does is a statement about the platform and no command in this walk answers it, so nothing is claimed. It has never been observed to hold a merge on this board. |
 
 ### Why the merge methods are not a style preference
 


### PR DESCRIPTION
Refs #55

## What this changes

One row in the table under `### The pull-request rule, parameter by parameter`
in `docs/quality-parity.md`, and two sentences above it saying what the row is.

The table opens by saying it carries every parameter the command above it
prints. It carried eight rows. The command prints nine names, and it prints the
same nine at the target:

```
gh api repos/Flowfin/lab/rules/branches/main \
  --jq '[.[] | select(.type=="pull_request") | .parameters | keys[]] | @json'
["allowed_merge_methods","dismiss_stale_reviews_on_push","dismissal_restriction","require_code_owner_review","require_extra_approval_for_unattributed_changes","require_last_push_approval","required_approving_review_count","required_review_thread_resolution","required_reviewers"]
gh api repos/Flowfin/jellyfin-plugin-sso/rules/branches/main \
  --jq '[.[] | select(.type=="pull_request") | .parameters | keys[]] | @json'
["allowed_merge_methods","dismiss_stale_reviews_on_push","dismissal_restriction","require_code_owner_review","require_extra_approval_for_unattributed_changes","require_last_push_approval","required_approving_review_count","required_review_thread_resolution","required_reviewers"]
```

`require_extra_approval_for_unattributed_changes` is the one that was absent,
and it has never appeared anywhere in this tree:

```
git grep -n 'require_extra_approval_for_unattributed_changes' origin/main ; echo "exit=$?"
exit=1
```

Both boards print `true`:

```
gh api repos/Flowfin/lab/rules/branches/main \
  --jq '.[] | select(.type=="pull_request") | .parameters.require_extra_approval_for_unattributed_changes'
true
gh api repos/Flowfin/jellyfin-plugin-sso/rules/branches/main \
  --jq '.[] | select(.type=="pull_request") | .parameters.require_extra_approval_for_unattributed_changes'
true
```

The means is Markdown in the document the walk already lives in, which is what
the issue asks for in its own words, so nothing here adds a format, a tool or a
place to look.

## What failure it prevents

A reader taking the table for the whole answer while a parameter is outside it.

The four review-adjacent rows in that table each say they bite only where a
review is required, and none is required at a review count of zero. The missing
parameter is not in that family: it is written to ask for an approval where a
change carries commits the pull request's author is not credited with, so it is
the only one in the list that could ask for one at a count of zero. Absent from
the table, it read as agreeing with the four rows that say nothing bites.

The row states what the two commands print and claims nothing beyond that.
Whether the parameter actually holds a merge at a count of zero is a statement
about the platform, no command in this walk answers it, and the row says so
rather than filling the gap. It has never been observed to hold a merge on this
board.

## What was run

At `cde3d912a9b1b945a7ea7916c1d70a828a670023`, on Windows, with no graphical
session and as an ordinary user:

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	1.501s
ok  	github.com/Flowfin/lab/cmd/lab	3.118s
ok  	github.com/Flowfin/lab/cmd/notices	9.272s
ok  	github.com/Flowfin/lab/cmd/pullrequest	3.118s
ok  	github.com/Flowfin/lab/internal/check	3.228s
ok  	github.com/Flowfin/lab/internal/contexts	2.107s
ok  	github.com/Flowfin/lab/internal/hardware	1.583s
ok  	github.com/Flowfin/lab/internal/invariants	2.265s
ok  	github.com/Flowfin/lab/internal/notices	1.550s
ok  	github.com/Flowfin/lab/internal/prose	2.019s
ok  	github.com/Flowfin/lab/internal/pullrequest	1.773s
```

`go build`, `go vet` and `gofmt -l` each printed nothing, which is the passing
result for all three.

```
go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
18 decision records read
the time this run read is 2026-08-21T03:49:45Z
0 refused
```

The three commands the section itself prints were re-run before this change was
written, and the rule-type table and the enforcement and bypass paste still hold
exactly as written:

```
gh api repos/Flowfin/lab/rules/branches/main --jq '.[].type'
deletion
non_fast_forward
pull_request
gh api repos/Flowfin/jellyfin-plugin-sso/rules/branches/main --jq '.[].type'
deletion
non_fast_forward
required_status_checks
pull_request
gh api "repos/Flowfin/lab/rulesets/$(gh api repos/Flowfin/lab/rulesets \
  --jq '.[] | select(.name=="gate") | .id')" \
  --jq '{enforcement, bypass: .bypass_actors}'
{"bypass":[],"enforcement":"active"}
```

Every value in the other eight parameter rows still holds on both boards, read
from the same output as the key list above.

## What this does not do

It does not finish #55. The remaining leg there is that the merge methods on
this board be restricted to `["merge"]`, and that is a ruleset parameter rather
than a file in this tree, so nothing a pull request contains moves it:

```
gh api repos/Flowfin/lab/rules/branches/main \
  --jq '.[] | select(.type=="pull_request") | .parameters.allowed_merge_methods'
["merge","squash","rebase"]
```

It does not say what `require_extra_approval_for_unattributed_changes` does. It
says what both boards have it set to and that the walk does not answer the rest.

It does not restore the two sections of this same document that
`d3edfc95b8526033c79cb26afe48282c2c090e32` removed. Those belong to #26 and #62
and are #155. This change adds a row well below both of them, so putting them
back is an insertion rather than a conflict, and #155 says to insert rather than
to take the whole file.

No second person has read this change. The evidence above stands in place of
that reading rather than beside it.
