### PR TITLE
Restore the absence entry that carries its own reason and the guard over it (#155)

### DIFF
--- a/internal/contexts/contexts.go
+++ b/internal/contexts/contexts.go
@@ -140,7 +140,12 @@ var Absences = []Absence{
 	{Name: "format", Why: theSetIsEmpty, Until: "#26"},
 	{Name: "CodeQL (go)", Why: theSetIsEmpty, Until: "#26"},
 	{Name: "CodeQL", Why: theSetIsEmpty, Until: "#26"},
-	{Name: "zizmor", Why: theSetIsEmpty, Until: "#26"},
+	{
+		Name: "zizmor",
+		Why: "this name is created by the code-scanning upload in zizmor.yml rather than by the job, and that step is skipped wherever the token cannot write security events, so requiring it would hold open every pull request the condition excludes with nothing on the pull request saying why. " +
+			"The job reports under Audit workflows (zizmor), which is a different string, arrives on those pull requests and carries the step that fails on findings",
+		Until: "",
+	},
 	{Name: "DCO sign-off", Why: theSetIsEmpty, Until: "#26"},
 	{Name: "dependency-review", Why: theSetIsEmpty, Until: "#26"},
 	{Name: "headless and unelevated", Why: theSetIsEmpty, Until: "#26"},

--- a/internal/contexts/contexts_test.go
+++ b/internal/contexts/contexts_test.go
@@ -279,6 +279,26 @@ func TestAnAbsenceCarriesAReason(t *testing.T) {
 	}
 }
 
+// TestAPermanentAbsenceDoesNotRestOnAReasonThatEnds refuses an entry that says
+// its absence is permanent and gives the reason that stops being true first.
+//
+// The two fields are read together. An empty Until says the absence survives the
+// day the required set is assembled, and theSetIsEmpty says the name is outside
+// the set because the set has no members, which is exactly the condition that day
+// ends. An entry carrying both is a decision resting on a debt, and it reads as
+// settled to whoever assembles the set.
+//
+// The near-miss this is written for is one field: an absence whose reason turns
+// out to be its own rather than the shared one is made permanent by emptying
+// Until, and the reason above it is left as it was.
+func TestAPermanentAbsenceDoesNotRestOnAReasonThatEnds(t *testing.T) {
+	for _, absence := range Absences {
+		if absence.Until == "" && absence.Why == theSetIsEmpty {
+			t.Errorf("the absence %q is written as permanent and its reason is that the required set is empty, which is the condition that ends when the set is assembled, so the entry says the absence outlives the only thing it rests on", absence.Name)
+		}
+	}
+}
+
 // TestAJobWithNoNameOfItsOwnIsNotedRatherThanRefused pins the one place this
 // package answers with a note. The platform reports the job id where a job
 // carries no name, so such a job is legal and its name is still a gate string, and


### PR DESCRIPTION
Refs #155

## What this changes

`internal/contexts/contexts.go` and `internal/contexts/contexts_test.go`, back to
the bytes the default branch held at `90656ba77a7c930d04d2205b2dd99df787853a92`.

Two things come back together. The `zizmor` entry in `Absences` carries its own
reason again, saying that the name is created by the code-scanning upload in
`zizmor.yml` rather than by the job and that the job reports under a different
string, with `Until` empty because that absence does not end when the required
set is assembled. And `TestAPermanentAbsenceDoesNotRestOnAReasonThatEnds` comes
back with it, which is the guard that refuses an entry written as permanent
whose reason is the one that stops being true.

Both are the bytes that were there rather than a retyping of them:

```
git rev-parse 90656ba:internal/contexts/contexts.go
9608b17ec822791856dd866411c1c1835079e1d9
git hash-object internal/contexts/contexts.go
9608b17ec822791856dd866411c1c1835079e1d9
git rev-parse 90656ba:internal/contexts/contexts_test.go
9bdd8745837bdbaf21d41915d537fbafaab61cff
git hash-object internal/contexts/contexts_test.go
9bdd8745837bdbaf21d41915d537fbafaab61cff
```

The means is Go in the package that already holds the entry and the suite that
already judges it, so nothing here adds a language, a runtime, a dependency or a
place to look, and the guard is testable by the suite that exists.

## How the absence arrived

`d3edfc95b8526033c79cb26afe48282c2c090e32` took its tree from an older state of
the default branch and landed on top of a newer one, under a message describing a
change to how one workflow pin is commented. Both files were among the seven
paths it replaced, and that commit is the only one to have touched this package
since:

```
git log --format='%H %s' 90656ba..origin/main -- internal/contexts/
d3edfc95b8526033c79cb26afe48282c2c090e32 Name the version the pinned commit actually is (#151)
```

Because it is the only one, taking the whole blob drops nothing that arrived
afterwards.

## What failure it prevents

An absence declared permanent while resting on a reason that ends. `Until` empty
says the entry outlives the day the required set is assembled, and the shared
reason says the name is outside the set because the set has no members, which is
exactly the condition that day ends. An entry carrying both reads as settled to
whoever assembles the set.

I proved the guard bites by making the near-miss it names, which is one field:
emptying `Until` on an entry whose reason is still the shared one. With the guard
restored, that reddens one test in the tree and nothing else:

```
go test ./... -count=1
--- FAIL: TestAPermanentAbsenceDoesNotRestOnAReasonThatEnds (0.00s)
    contexts_test.go:297: the absence "DCO sign-off" is written as permanent and its reason is that the required set is empty, which is the condition that ends when the set is assembled, so the entry says the absence outlives the only thing it rests on
FAIL	github.com/Flowfin/lab/internal/contexts	0.660s
```

The same near-miss against what the default branch holds today, with the guard
absent, runs green in all eleven packages, so nothing there separated an entry
resting on a debt from one that does not. That is what the absence cost, measured
rather than supposed.

## What was run

At `68079e9402db63c569b8f549c339e98510d08ba6`, on Windows, with no graphical
session and as an ordinary user:

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	0.423s
ok  	github.com/Flowfin/lab/cmd/lab	3.734s
ok  	github.com/Flowfin/lab/cmd/notices	13.501s
ok  	github.com/Flowfin/lab/cmd/pullrequest	0.436s
ok  	github.com/Flowfin/lab/internal/check	0.886s
ok  	github.com/Flowfin/lab/internal/contexts	0.429s
ok  	github.com/Flowfin/lab/internal/hardware	0.438s
ok  	github.com/Flowfin/lab/internal/invariants	0.914s
ok  	github.com/Flowfin/lab/internal/notices	0.625s
ok  	github.com/Flowfin/lab/internal/prose	0.643s
ok  	github.com/Flowfin/lab/internal/pullrequest	0.901s
```

`go build`, `go vet` and `gofmt -l` each printed nothing, which is the passing
result for all three.

```
go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
18 decision records read
the time this run read is 2026-08-21T13:53:59Z
0 refused
```

No test here was skipped for needing elevation, and none was run with any.

## What this does not do

It does not finish #155. Five of the six path groups that commit removed are
still missing: `LICENSE` with the `## License` section of `README.md`, two
sections of `docs/quality-parity.md`, sixteen comment lines in
`.github/workflows/codeql.yml`, the pin comment in `.github/workflows/zizmor.yml`
and fifteen lines of `docs/operator-guide.md`.

It does not touch the second question #155 raises, which is whether anything here
should refuse a merge that removes a tracked path without saying so in its body.
Restoring a file does not answer that and this change does not pretend to.

It does not move #26. The `zizmor` entry's own reason and the guard over it are
what landed for that issue and were removed; the required set on the default
branch is untouched here.

No second person has read this change. The evidence above stands in place of one,
and that is a disclosure rather than an assurance.
