### PR TITLE
Restore the operator-guide pastes that reproduce (#155)

### DIFF
--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -148,16 +148,27 @@ anything in the tree. Three ways to reach it, each printing to standard error:
 
     ./lab frobnicate
     lab: unknown verb "frobnicate"
+    (and then the help text, because the verb is not one it has)
 
     ./lab
     (the help text, because no verb was given)
+
+The help text is described rather than pasted in both of those, because a copy
+of it here drifts against the runner that prints it, and the runner is the
+thing a reader is checking.
 
 `3` is not a code this command returns. It belongs to the integration-hardware
 harness under `internal/hardware`, which is asked for separately, and it is
 declared where its only producer is:
 
-    git grep -n 'ExitAskedAndDeliveredNothing = ' -- internal/hardware
-    internal/hardware/hardware.go:45:const ExitAskedAndDeliveredNothing = 3
+    git grep 'ExitAskedAndDeliveredNothing = ' -- internal/hardware
+    internal/hardware/hardware.go:const ExitAskedAndDeliveredNothing = 3
+
+That command carries no line number on purpose. With `-n` the paste names a
+line rather than a declaration, and an edit anywhere above the constant moves
+the line without changing anything the sentence claims, so the quotation goes
+stale while the claim it supports stays true. The file and the declaration are
+what the claim rests on and neither of them moves.
 
 So the record fixes four codes, `lab` returns three of them, and a caller
 keyed on any of the four is reading that record whether or not anybody said so.


### PR DESCRIPTION
Refs #155

## What this changes

`docs/operator-guide.md`, back to the bytes the default branch held at
`90656ba77a7c930d04d2205b2dd99df787853a92`:

```
git rev-parse 90656ba:docs/operator-guide.md
6775f1473b6af20969eb75003d6bc96854e0aca7
git hash-object docs/operator-guide.md
6775f1473b6af20969eb75003d6bc96854e0aca7
```

Two pastes in that file had been repaired once and the repair is what came off.

## How the absence arrived

`d3edfc95b8526033c79cb26afe48282c2c090e32` took its tree from an older state of
the default branch and landed on top of a newer one, under a message describing
a change to how one workflow pin is commented. This file was among the seven
paths it replaced, and it is the only commit to have touched it since, so
nothing arrived afterwards that taking the whole blob would drop:

```
git log --format='%H %s' 90656ba..origin/main -- docs/operator-guide.md
d3edfc95b8526033c79cb26afe48282c2c090e32 Name the version the pinned commit actually is (#151)
```

## What failure it prevents

An operator reading a quotation in the guide that no longer reproduces, and
concluding the runner rather than the document has moved.

The first paste is the one that has already gone stale, which makes this
measurable rather than argued. The document on the default branch quotes a
`git grep -n` and pastes line 45. Run today it prints 54:

```
git grep -n 'ExitAskedAndDeliveredNothing = ' -- internal/hardware
internal/hardware/hardware.go:54:const ExitAskedAndDeliveredNothing = 3
```

Nothing about the constant changed. An edit above it moved the line, which is
exactly what the removed paragraph says will happen, and why the command it
restores carries no `-n`. That form still reproduces:

```
git grep 'ExitAskedAndDeliveredNothing = ' -- internal/hardware
internal/hardware/hardware.go:const ExitAskedAndDeliveredNothing = 3
```

The second is the unknown-verb example, cut off after its one error line. The
runner prints the help text after that line:

```
go run ./cmd/lab frobnicate
lab: unknown verb "frobnicate"

lab reads this repository and reports what it examined.

    lab check [path]   walk the tree at path, default ".", and report
    lab list [path]    list the experiments at path, default ".", oldest
                       unanswered first
    lab help           print this text

lab writes nothing to the tree it reads.
exit status 2
```

The restored line describes that text rather than pasting it, and the restored
paragraph gives the reason: a copy of the help text in this document drifts
against the runner that prints it, and the runner is the thing a reader is
checking.

Nothing in this tree refuses either drift. `lab check` reads records and
decision records, not the prose of this guide, so what stands behind these two
pastes is the repair and the reason written beside it. That is a disclosure, not
a mechanism.

## What was run

At `9f0c6b3ca30cf4154e58de8ba72c9fa3b11431f7`, on Windows, with no graphical
session and as an ordinary user:

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	0.449s
ok  	github.com/Flowfin/lab/cmd/lab	2.805s
ok  	github.com/Flowfin/lab/cmd/notices	10.895s
ok  	github.com/Flowfin/lab/cmd/pullrequest	0.702s
ok  	github.com/Flowfin/lab/internal/check	0.957s
ok  	github.com/Flowfin/lab/internal/contexts	0.409s
ok  	github.com/Flowfin/lab/internal/hardware	0.710s
ok  	github.com/Flowfin/lab/internal/invariants	0.736s
ok  	github.com/Flowfin/lab/internal/notices	0.406s
ok  	github.com/Flowfin/lab/internal/prose	0.727s
ok  	github.com/Flowfin/lab/internal/pullrequest	0.713s
```

`go build`, `go vet` and `gofmt -l` each printed nothing, which is the passing
result for all three.

```
go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
18 decision records read
the time this run read is 2026-08-21T14:03:24Z
0 refused
```

The suite does not read this document, so a green run here says nothing broke
rather than that the pastes are right. The two commands above are what say that.

No test was skipped for needing elevation, and none was run with any.

## What this does not do

It does not finish #155. Two path groups that commit removed are still missing:
`LICENSE` with the `## License` section of `README.md`, and two sections of
`docs/quality-parity.md`.

It does not touch the second question #155 raises, which is whether anything
here should refuse a merge that removes a tracked path without saying so in its
body.

It does not move #42. What that issue landed is this file; what was missing is a
repair to two of its quotations.

No second person has read this change. The evidence above stands in place of
one, and that is a disclosure rather than an assurance.
