### PR TITLE
Take out the readme paragraph saying there is no licence file

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,6 @@ directory is a history of the argument rather than a description of today.
 [docs/privacy.md](docs/privacy.md) is the privacy position, including what it
 does not cover.
 
-There is no licence file. That is not a neutral state, since without one nobody
-has permission to reuse anything here, and it is the first entry of the open
-question that collects the decisions this plan does not take. Until it is
-answered, treat everything on this board as readable and not as reusable.
-
 ## License
 
 AGPL-3.0, copyright 2026 Nils Lehnen.


### PR DESCRIPTION
Closes #148.

## What this changes

`README.md` loses the paragraph saying there is no licence file. Five lines go
and nothing else in the tree moves.

The `## License` section that names AGPL-3.0 and links `LICENSE` is untouched,
and it is now the only thing the page says about the licence.

## What failure it prevents

The page carried both statements at once. Four lines above the section naming
AGPL-3.0, it told a reader there is no licence file and to treat everything here
as readable and not as reusable. Which of the two a visitor believed depended on
how far down they read, and the one they meet first is the wrong one: it tells
somebody who wants to fork this board, run an experiment in their own checkout
and send a change back that they may do none of it, while the tree carries terms
that say they may.

The paragraph was inside the blob a restoration put back after a commit had taken
the licence section out. The restoration was the bytes that were there rather
than a retyping of them, so it returned the paragraph with the rest, and its own
message said that taking the paragraph out is a change with its own reason. This
is that change.

`LICENSE` is on the default branch, which is what makes the paragraph wrong
rather than merely out of date:

```
git rev-parse origin/main:LICENSE
fadd1f611bdae23852c5afe8ee6ba9f03617b34a
```

## What was run

Everything CONTRIBUTING.md names, at `d4d10e236485ce1ce7fdbc092ac929b1bd086588`.

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
(no output from any of the three)

go test -count=1 ./cmd/... ./internal/...
ok  github.com/Flowfin/lab/cmd/contexts     0.533s
ok  github.com/Flowfin/lab/cmd/lab          2.652s
ok  github.com/Flowfin/lab/cmd/notices      10.159s
ok  github.com/Flowfin/lab/cmd/pullrequest  0.674s
ok  github.com/Flowfin/lab/internal/check   1.101s
ok  github.com/Flowfin/lab/internal/contexts        0.668s
ok  github.com/Flowfin/lab/internal/hardware        0.831s
ok  github.com/Flowfin/lab/internal/invariants      1.017s
ok  github.com/Flowfin/lab/internal/notices 0.572s
ok  github.com/Flowfin/lab/internal/prose   0.575s
ok  github.com/Flowfin/lab/internal/pullrequest     0.560s

go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
18 decision records read
the time this run read is 2026-08-22T03:54:21Z
0 refused
```

The suite was also run with `-v`, which is what makes it say what it did not
cover. Two of those lines matter to this change and neither moved:

```
go test -count=1 -v ./internal/hardware ./internal/invariants
the integration-hardware harness was not asked for and nothing in it ran.
the licence: NOT ASKED, no licence is declared, so there is nothing to compare LICENSE against. asking costs answering entry one of the open questions issue and landing the file, the repository metadata and the decision record that names it, which is issue #47
```

## Read by one pair of eyes

This board has no second reader for this change tonight. The evidence above
stands in place of one, and the change is five deleted lines of prose with the
whole file diff visible in one screen.

## What this does not do

It declares nothing to a check. `DeclaredLicence` in
`internal/invariants/invariants.go` is still the empty string, so the licence leg
still reports that it was not asked rather than that it was satisfied. That leg,
the repository metadata and the decision record naming the licence are #47, and
this change moves none of them.

It also repairs one document out of five. Four others on the default branch still
say in the present tense that this repository has no licence file, in
`docs/operator-guide.md`, `docs/promotion.md`, `SECURITY.md` and the triage prose
under `License, 0` in `docs/supply-chain.md`. Those are #163 and are deliberately
untouched here, because #148 asks for the readme and the readme only.
