### PR TITLE
Superseded by #167: the same four-document change with a DCO sign-off

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -122,9 +122,11 @@ downloaded and none to have been tampered with.
 A refusal you disagree with is not a vulnerability, and neither is a check that
 is too strict about a legitimate tree, nor a supply-chain score lower than you
 expected, which `docs/supply-chain.md` already triages check by check. Those
-are issues and they are welcome as issues. Nor is the missing licence file,
-which is real and is a legal problem rather than a security one, open on issue
-#46.
+are issues and they are welcome as issues. Nor is anything about the licence.
+[LICENSE](LICENSE) at the root carries the GNU Affero General Public License
+version 3, and what this repository declares to the checks that read a licence
+is still empty and open on issue #47. Both of those are legal or housekeeping
+questions rather than security ones.
 
 ## What a reporter gets
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -201,9 +201,11 @@ is already on. Only the measurement is written down. Nothing here uploads,
 phones home, or reports usage, and there is no telemetry to turn off because
 there is none to turn on.
 
-There is no licence file in this repository. The question is open, so nothing
-here grants permission to reuse what you find, and that is the state rather than
-an oversight this page can repair.
+[LICENSE](../LICENSE) at the root of the checkout is the GNU Affero General
+Public License version 3, and those are the terms this tree carries. What is
+still open is the licence this repository declares to its own checks, which is
+empty on issue #47, so a run here that says nothing about the licence is not
+saying the file is absent.
 
 ## The record format may change
 

--- a/docs/promotion.md
+++ b/docs/promotion.md
@@ -32,13 +32,14 @@ is always the half that gets left out. A reader on the other side is deciding
 whether the result holds for their case, and the fastest way to answer that is
 the list of cases it was never put to.
 
-The licence the code carries out. This board declares no licence today, so
-there is nothing to inherit and the terms have to be settled before anything
-leaves. Entry one of issue #46 is where that is answered, and entry three asks
-who may place a contributor's work under another board's terms. Until both
-carry an answer, the honest state of this line is that a hand-over of somebody
-else's work cannot be completed, and writing anything else into it would be
-inventing permission nobody gave.
+The licence the code carries out. [LICENSE](../LICENSE) at the root of this
+board is the GNU Affero General Public License version 3, so that is what the
+code carries out and the receiving side inherits terms rather than finding
+none. Which licence this repository declares to the checks that read one is a
+separate thing and is open on issue #47. Entry three of issue #46 asks who may
+place a contributor's work under another board's terms and carries no answer,
+so a hand-over of somebody else's work still cannot be completed, and writing
+anything else into this line would be inventing permission nobody gave.
 
 What would have to change for this to be production code, written by whoever
 did the work. They know and nobody else does. An experiment is allowed to cut

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -166,10 +166,23 @@ untrusted. Reopen this line when #61 lands rather than before.
 
 `license file not detected`, with `Warn: project does not have a license file`
 
-Correct, and it is the most consequential zero here. Without a licence file,
-default copyright applies and nobody has permission to reuse anything in this
-repository. Which licence is an open question on issue #46, and issue #47 lands
-the file once that is answered. This score should go to 10 in the same change.
+Correct for the run above, and the tree has moved since. `LICENSE` is at the
+root of the default branch carrying the GNU Affero General Public License
+version 3, restored in `36442adad2d9dc66032cf3d29ab070697650db5c` and merged as
+`bb0de9cbcc79015054e3da10cef44a8ae3669b01`, so the reasoning that stood here,
+that default copyright applies and nobody may reuse anything, no longer follows.
+The audit has not been re-run for this document and the score above is left as
+the run reported it. What the platform holds today is a different reading and is
+one command:
+
+```
+gh api 'repos/Flowfin/lab/code-scanning/alerts?tool_name=Scorecard&per_page=100' \
+  --jq '.[] | select(.rule.id=="LicenseID") | .state'
+fixed
+```
+
+What the file being there does not settle is the licence this repository
+declares to its own checks, which is empty and open on issue #47.
 
 ### Maintained, 0
 


### PR DESCRIPTION
Refs #163

## Why this is closed

The head here carries no `Signed-off-by` trailer, and the DCO gate refused it by
name:

```
FAIL  36a05d603d6cdb6943d9801d2daedc6ad758dc85 is missing: Signed-off-by: Nils Lehnen <30603423+iderex@users.noreply.github.com>
```

The repair is the same commit cherry-picked with the trailer onto a new branch,
because the alternative is rewriting a branch that has already been pushed. That
is #167, which carries the whole body this one had, the same four-file diff and
its own run of the checks.

This branch is left where it is rather than deleted. Nothing was lost, and
nothing here is waiting on anybody.

## What it changed

`LICENSE` is on the default branch and carries AGPL-3.0. Three documents and one
triage paragraph still said, in the present tense, that this repository has no
licence file. `docs/operator-guide.md`, `docs/promotion.md` and `SECURITY.md` say
what the tree holds instead, and the triage paragraph under `License, 0` in
`docs/supply-chain.md` says the file has since landed and names the commit, with
the heading and the quoted warning left as the run that document declares
reported them.

None of the four says the licence declaration is made. `DeclaredLicence` is still
empty and the licence leg still reports that it was not asked, so each document
that mentions it points at #47.

The evidence for all of that is in #167 rather than restated here, because two
copies of one transcript drift apart and a reader cannot tell which one was run.
