### PR TITLE
Say what the tree holds about the licence in the four documents that say it holds nothing

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -122,9 +122,11 @@ downloaded and none to have been tampered with.
 A refusal you disagree with is not a vulnerability, and neither is a check that
 is too strict about a legitimate tree, nor a supply-chain score lower than you
 expected, which `docs/supply-chain.md` already triages check by check. Those
-are issues and they are welcome as issues. Nor is the missing licence file,
-which is real and is a legal problem rather than a security one, open on issue
-#46.
+are issues and they are welcome as issues. Nor is anything about the licence.
+[LICENSE](LICENSE) at the root carries the GNU Affero General Public License
+version 3, and what this repository declares to the checks that read a licence
+is still empty and open on issue #47. Both of those are legal or housekeeping
+questions rather than security ones.
 
 ## What a reporter gets
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -201,9 +201,11 @@ is already on. Only the measurement is written down. Nothing here uploads,
 phones home, or reports usage, and there is no telemetry to turn off because
 there is none to turn on.
 
-There is no licence file in this repository. The question is open, so nothing
-here grants permission to reuse what you find, and that is the state rather than
-an oversight this page can repair.
+[LICENSE](../LICENSE) at the root of the checkout is the GNU Affero General
+Public License version 3, and those are the terms this tree carries. What is
+still open is the licence this repository declares to its own checks, which is
+empty on issue #47, so a run here that says nothing about the licence is not
+saying the file is absent.
 
 ## The record format may change
 

--- a/docs/promotion.md
+++ b/docs/promotion.md
@@ -32,13 +32,14 @@ is always the half that gets left out. A reader on the other side is deciding
 whether the result holds for their case, and the fastest way to answer that is
 the list of cases it was never put to.
 
-The licence the code carries out. This board declares no licence today, so
-there is nothing to inherit and the terms have to be settled before anything
-leaves. Entry one of issue #46 is where that is answered, and entry three asks
-who may place a contributor's work under another board's terms. Until both
-carry an answer, the honest state of this line is that a hand-over of somebody
-else's work cannot be completed, and writing anything else into it would be
-inventing permission nobody gave.
+The licence the code carries out. [LICENSE](../LICENSE) at the root of this
+board is the GNU Affero General Public License version 3, so that is what the
+code carries out and the receiving side inherits terms rather than finding
+none. Which licence this repository declares to the checks that read one is a
+separate thing and is open on issue #47. Entry three of issue #46 asks who may
+place a contributor's work under another board's terms and carries no answer,
+so a hand-over of somebody else's work still cannot be completed, and writing
+anything else into this line would be inventing permission nobody gave.
 
 What would have to change for this to be production code, written by whoever
 did the work. They know and nobody else does. An experiment is allowed to cut

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -166,10 +166,23 @@ untrusted. Reopen this line when #61 lands rather than before.
 
 `license file not detected`, with `Warn: project does not have a license file`
 
-Correct, and it is the most consequential zero here. Without a licence file,
-default copyright applies and nobody has permission to reuse anything in this
-repository. Which licence is an open question on issue #46, and issue #47 lands
-the file once that is answered. This score should go to 10 in the same change.
+Correct for the run above, and the tree has moved since. `LICENSE` is at the
+root of the default branch carrying the GNU Affero General Public License
+version 3, restored in `36442adad2d9dc66032cf3d29ab070697650db5c` and merged as
+`bb0de9cbcc79015054e3da10cef44a8ae3669b01`, so the reasoning that stood here,
+that default copyright applies and nobody may reuse anything, no longer follows.
+The audit has not been re-run for this document and the score above is left as
+the run reported it. What the platform holds today is a different reading and is
+one command:
+
+```
+gh api 'repos/Flowfin/lab/code-scanning/alerts?tool_name=Scorecard&per_page=100' \
+  --jq '.[] | select(.rule.id=="LicenseID") | .state'
+fixed
+```
+
+What the file being there does not settle is the licence this repository
+declares to its own checks, which is empty and open on issue #47.
 
 ### Maintained, 0
 


### PR DESCRIPTION
Closes #163

## What this changes

`LICENSE` is on the default branch and carries AGPL-3.0. Three documents and one
triage paragraph still said, in the present tense, that this repository has no
licence file. Each of them now says what the tree holds, in the place its current
sentence sits and keeping what that sentence was doing for its reader.

`docs/operator-guide.md` is the page somebody who downloads the runner opens, so
it names the file, the licence and the link, and says the declaration is what is
still open rather than the file.

`docs/promotion.md` is the checklist filled in at the moment work leaves this
board, so its line says what the code carries out. The blocked half stays
blocked: entry three of #46 asks who may place a contributor's work under
another board's terms and carries no answer, so a hand-over of somebody else's
work still cannot be completed and that sentence is unchanged in substance.

`SECURITY.md` keeps the licence out of the set of things that are
vulnerabilities, which is what its sentence was for. It does that by naming the
file and the open declaration instead of by naming an absence.

`docs/supply-chain.md` is a different case. That document declares at the top
that every score in it comes from one named run, so the `License, 0` heading and
the quoted warning are a faithful reading of that run and are untouched. Only the
triage prose under them changes: it says the file has since landed, names the
commit, and states plainly that the audit has not been re-run for this document.
The one command it adds is a reading of what the platform holds today and is not
a re-run of the triage.

None of the four says the declaration is made. Each one that mentions it points
at #47.

## What failure it prevents

A reader who believes any of the three concludes they may not reuse anything
here, which is the opposite of the terms the tree carries. That is worse than a
broken link, because each of the three resolves fine and reads as current.

The triage paragraph failed in the other direction. It argued in the present
tense from an absence that has ended and pointed at an issue as the thing that
would end it, so a reader of the score page was told the repair was ahead of them
when it is behind.

## What was run

At `8f3819af46d0959e5da2720f445633eca35b0270`.

The four readings the issue's done-when asks for, each returning nothing:

```
git grep -n -F 'no licence file' HEAD -- SECURITY.md docs/
exit=1
git grep -n -F 'missing licence file' HEAD -- SECURITY.md
exit=1
git grep -n -F 'declares no licence today' HEAD -- docs/
exit=1
git grep -n -F 'Without a licence file' HEAD -- docs/supply-chain.md
exit=1
```

Four greps that return nothing are four greps that could each have missed
something, so here is the whole set of licence mentions left in tracked Markdown
outside the decision records and the fixtures, with the dependency-notices sense
of the word filtered out:

```
git grep -niE 'licen[cs]e' HEAD -- '*.md' \
  | grep -v ':docs/decisions/' | grep -v ':testdata/' \
  | grep -viE 'third-party|notices|dependenc'
HEAD:CONTRIBUTING.md:132:- No file whose licence forbids it being here.
HEAD:NOTICE.md:7:in it is designed to enable such use. The license contains the full
HEAD:README.md:59:## License
HEAD:README.md:63:The full text is in [LICENSE](LICENSE).
HEAD:SECURITY.md:61:somebody's licence is in scope.
HEAD:SECURITY.md:125:are issues and they are welcome as issues. Nor is anything about the licence.
HEAD:SECURITY.md:126:[LICENSE](LICENSE) at the root carries the GNU Affero General Public License
HEAD:SECURITY.md:127:version 3, and what this repository declares to the checks that read a licence
HEAD:docs/operator-guide.md:189:## The notice, the privacy document and the licence
HEAD:docs/operator-guide.md:204:[LICENSE](../LICENSE) at the root of the checkout is the GNU Affero General
HEAD:docs/operator-guide.md:205:Public License version 3, and those are the terms this tree carries. What is
HEAD:docs/operator-guide.md:206:still open is the licence this repository declares to its own checks, which is
HEAD:docs/operator-guide.md:207:empty on issue #47, so a run here that says nothing about the licence is not
HEAD:docs/promotion.md:35:The licence the code carries out. [LICENSE](../LICENSE) at the root of this
HEAD:docs/promotion.md:36:board is the GNU Affero General Public License version 3, so that is what the
HEAD:docs/promotion.md:38:none. Which licence this repository declares to the checks that read one is a
HEAD:docs/promotion.md:73:whether the untested half is honestly listed, and whether the licence line was
HEAD:docs/supply-chain.md:165:### License, 0
HEAD:docs/supply-chain.md:167:`license file not detected`, with `Warn: project does not have a license file`
HEAD:docs/supply-chain.md:169:Correct for the run above, and the tree has moved since. `LICENSE` is at the
HEAD:docs/supply-chain.md:170:root of the default branch carrying the GNU Affero General Public License
HEAD:docs/supply-chain.md:180:  --jq '.[] | select(.rule.id=="LicenseID") | .state'
HEAD:docs/supply-chain.md:184:What the file being there does not settle is the licence this repository
```

`CONTRIBUTING.md:132` and `SECURITY.md:61` are about somebody else's licence
reaching this tree, `NOTICE.md:7` is the notice pointing at the licence, and
`docs/promotion.md:73` is about whether the line was agreed rather than about what
it says. None of the four is a claim that the file is absent.

What the documents now assert, read at the source rather than from recollection:

```
git ls-tree --name-only origin/main LICENSE
LICENSE
head -2 LICENSE
                    GNU AFFERO GENERAL PUBLIC LICENSE
                       Version 3, 19 November 2007
git log --diff-filter=A --format='%H %s' origin/main -- LICENSE
36442adad2d9dc66032cf3d29ab070697650db5c Restore the licence file and the readme lines that name it (#155)
5615b762b087b15ce541bca4bde3fbf1f5818afc Carry the licence this repository is published under (#149)
git log -1 --format='%H %s' bb0de9cbcc79015054e3da10cef44a8ae3669b01
bb0de9cbcc79015054e3da10cef44a8ae3669b01 Merge pull request #161 from Flowfin/licence/the-file-and-the-readme-section-that-left-the-default-branch
```

The one command the supply-chain triage now pastes, re-run against the live
platform at this commit:

```
gh api 'repos/Flowfin/lab/code-scanning/alerts?tool_name=Scorecard&per_page=100' \
  --jq '.[] | select(.rule.id=="LicenseID") | .state'
fixed
```

The declaration leg, unmoved, quoted because three of the four documents now say
it is the thing that is open:

```
git grep -n 'const DeclaredLicence' -- internal/invariants/invariants.go
internal/invariants/invariants.go:80:const DeclaredLicence = ""
go test ./internal/invariants -run TestThisRepositorySatisfiesTheInvariants -count=1 -v
      the licence: NOT ASKED, no licence is declared, so there is nothing to compare LICENSE against. asking costs answering entry one of the open questions issue and landing the file, the repository metadata and the decision record that names it, which is issue #47
--- PASS: TestThisRepositorySatisfiesTheInvariants (0.12s)
```

The four commands `CONTRIBUTING.md` names, in its order. The first three printed
nothing, which is what they say when they pass:

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	0.725s
ok  	github.com/Flowfin/lab/cmd/lab	2.102s
ok  	github.com/Flowfin/lab/cmd/notices	9.921s
ok  	github.com/Flowfin/lab/cmd/pullrequest	0.523s
ok  	github.com/Flowfin/lab/internal/check	0.783s
ok  	github.com/Flowfin/lab/internal/contexts	0.521s
ok  	github.com/Flowfin/lab/internal/hardware	0.418s
ok  	github.com/Flowfin/lab/internal/invariants	0.753s
ok  	github.com/Flowfin/lab/internal/notices	0.413s
ok  	github.com/Flowfin/lab/internal/prose	0.453s
ok  	github.com/Flowfin/lab/internal/pullrequest	0.414s
```

The hardware suite behind the build constraint was not run. It is asked for
explicitly and nothing here asked for it, so what it would have said about a
change to four Markdown files is unmeasured rather than green.

The checker against this checkout:

```
go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
18 decision records read
the time this run read is 2026-08-22T05:58:50Z
0 refused
```

The paths this change touches are the four the issue names and nothing else:

```
git diff --name-only origin/main...HEAD
SECURITY.md
docs/operator-guide.md
docs/promotion.md
docs/supply-chain.md
```

## What this does not do

It does not answer the declaration question. `DeclaredLicence` is empty, the
licence leg still reports that it was not asked, and none of the four documents
is edited to say otherwise. That is #47.

It does not re-run the supply-chain audit. The `License, 0` heading, the quoted
warning and the aggregate above them are the run that document declares at its
top, left exactly as that run reported them. The alert state pasted in the triage
is what the platform holds today, which is a different reading from a re-run and
is written as one.

It adds no guard, so there is no proof by deletion to show. The three links it
adds are read by no check here, and that is measured rather than assumed.
`[LICENSE](LICENSE)` in `SECURITY.md` sits beside the same link in `README.md`,
which is already the subject, so the count of paths the invariants examine is the
same with this change and without it:

```
go test ./internal/invariants -run TestThisRepositorySatisfiesTheInvariants -count=1 -v
      paths this repository's own documents name: 34 examined
git stash
go test ./internal/invariants -run TestThisRepositorySatisfiesTheInvariants -count=1 -v
      paths this repository's own documents name: 34 examined
```

The two `[LICENSE](../LICENSE)` links from `docs/` are not read at all, and that
is a gap in the paths leg rather than a property of this change.
`PathsNamedInProse` requires a leading segment naming a directory of this tree
and `..` is not one, and `LinkTargetsWithoutADirectory` skips any target
containing a slash, so a link from a document in `docs/` to a file at the root
falls between the two readings. `[NOTICE.md](../NOTICE.md)` in the same document
has been in that state since before this change. It is written up as its own
issue rather than repaired here, because widening either reading is a change to a
guard and belongs with the guard.

No second reader was available for this change. It carries the commands above in
place of one, and the run that was not made is written as not made rather than
left out.

## Why this is the second pull request for this issue

The first was #166, whose head carried no `Signed-off-by` trailer, and the DCO
gate refused it by name:

```
FAIL  36a05d603d6cdb6943d9801d2daedc6ad758dc85 is missing: Signed-off-by: Nils Lehnen <30603423+iderex@users.noreply.github.com>
```

The commit here is that one cherry-picked with the trailer, so the content is the
same and the history is not rewritten. #166 is closed with this reason in its
body and its branch is left where it is. The other checks on that head had passed
or were still running when it was refused, and this head is judged on its own
run rather than on that one.
