### PR TITLE
Read a root file a document under docs/ links, which neither reading reached

### DIFF
--- a/internal/check/paths.go
+++ b/internal/check/paths.go
@@ -63,3 +63,54 @@ func LinkTargetsWithoutADirectory(text string) []string {
 	}
 	return named
 }
+
+// LinkTargetsAboveTheirDocument returns the markdown link targets a text
+// carries that step out of the document's own directory, in the order it names
+// them, each once. A caller joins each one to the directory its document sits
+// in and gets a repository-relative path.
+//
+// This is a third reading rather than either of the two above growing, and the
+// reason is that both of them are already exact about a different population.
+// PathsNamedInProse requires a leading segment naming a directory of this tree,
+// and `..` is not one; widening it would make it read a pair of full stops in a
+// sentence. LinkTargetsWithoutADirectory skips a target carrying a slash, which
+// is what its name says it returns and what its own comment hands to the prose
+// pattern. A target spelled `../NAME` falls between the two: it is inside
+// parentheses, so the intent is there, and it carries a slash, so the reading
+// that resolves intent will not touch it.
+//
+// The shape it is for is a document under docs/ naming a file at the root,
+// which is the only way one can write that link. `docs/operator-guide.md`
+// pointing at `../LICENSE` is a reader being told a file is there, and until
+// this existed nothing in this tree read that link at all.
+//
+// WHAT THE CALLER STILL OWES. The target is relative to the document and this
+// returns it as written, so a caller that resolves it against the root instead
+// resolves the wrong thing. It also has to decide what to do with a target that
+// climbs past the root of the tree, because this returns that one too: `../..`
+// from a document one directory down names something outside the checkout, and
+// whether such a file exists is not a question any reading of this tree
+// answers.
+func LinkTargetsAboveTheirDocument(text string) []string {
+	var named []string
+	seen := make(map[string]bool)
+
+	for _, match := range linkTarget.FindAllStringSubmatch(text, -1) {
+		target := match[1]
+		if cut := strings.IndexAny(target, "#?"); cut >= 0 {
+			target = target[:cut]
+		}
+		if !strings.HasPrefix(target, "../") {
+			continue
+		}
+		// A scheme or a backslash is left alone for the same reasons the
+		// reading above leaves them alone: one is somebody else's server
+		// and the other is not how a path is written here.
+		if strings.ContainsAny(target, ":\\") || seen[target] {
+			continue
+		}
+		seen[target] = true
+		named = append(named, target)
+	}
+	return named
+}

--- a/internal/check/paths_test.go
+++ b/internal/check/paths_test.go
@@ -87,3 +87,83 @@ func TestWhatCountsAsALinkToAFileBesideTheDocument(t *testing.T) {
 		})
 	}
 }
+
+// TestWhatCountsAsALinkToAFileAboveTheDocument exercises the third reader
+// directly, for the same reason the one above is exercised directly. A fixture
+// is a tree and a verdict, so it proves that a document under docs/ linking a
+// root file that is not there is refused and one linking a file that is there
+// is not, and it says nothing about a target carrying a scheme or a fragment,
+// about a target repeated, or about the order two of them come back in. Those
+// arms all fail as silence, which is what a passing suite looks like.
+func TestWhatCountsAsALinkToAFileAboveTheDocument(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{
+			name: "a root file linked from one directory down",
+			text: "The terms are in [LICENSE](../LICENSE) at the root.",
+			want: []string{"../LICENSE"},
+		},
+		{
+			name: "a fragment on the end",
+			text: "See [the notice](../NOTICE.md#scope).",
+			want: []string{"../NOTICE.md"},
+		},
+		{
+			name: "the same target twice",
+			text: "[one](../LICENSE) and [again](../LICENSE)",
+			want: []string{"../LICENSE"},
+		},
+		{
+			name: "two targets keep the order they were written in",
+			text: "[first](../NOTICE.md) then [second](../LICENSE)",
+			want: []string{"../NOTICE.md", "../LICENSE"},
+		},
+		{
+			name: "a climb of more than one directory is returned for the caller to place",
+			text: "See [it](../../NOTICE.md).",
+			want: []string{"../../NOTICE.md"},
+		},
+		{
+			name: "a directory on the way back down",
+			text: "See [the record](../docs/decisions/0002-repository-layout.md).",
+			want: []string{"../docs/decisions/0002-repository-layout.md"},
+		},
+
+		{
+			name: "a target beside the document is the second reader's",
+			text: "See [the notice](NOTICE.md) beside this page.",
+		},
+		{
+			name: "a target under a directory is the prose pattern's",
+			text: "See [the record](docs/decisions/0002-repository-layout.md).",
+		},
+		{
+			name: "two full stops in a sentence rather than in a link",
+			text: "The file is one directory up, at ../LICENSE, and this names it.",
+		},
+		{
+			name: "a target on somebody else's server that climbs",
+			text: "See [the page](https://example.invalid/../NOTICE.md).",
+		},
+		{
+			name: "a windows separator after the climb",
+			text: `See [the record](..\notes.md).`,
+		},
+		{
+			name: "a place inside the same page",
+			text: "See [further down](#what-was-run).",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := LinkTargetsAboveTheirDocument(tc.text)
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Errorf("read %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/invariants/invariants.go
+++ b/internal/invariants/invariants.go
@@ -497,7 +497,7 @@ func pathsLeg(root string, texts []textFile) (Leg, []Refusal) {
 }
 
 // pathsNamedIn returns every repository-relative path one document names, by
-// both readings, each once. The two readings are joined here rather than
+// all three readings, each once. The readings are joined here rather than
 // refused separately so that one property is produced at one site: a document
 // that writes a path in a sentence and links it as well is one dead pointer and
 // is worth one refusal.
@@ -506,6 +506,13 @@ func pathsLeg(root string, texts []textFile) (Leg, []Refusal) {
 // join uses the document's own directory and not the root. docs/privacy.md
 // links supply-chain.md and means docs/supply-chain.md; resolving that against
 // the root would refuse the file that is there and pass the one that is not.
+//
+// The third reading is the one that reaches a document under docs/ naming a
+// file at the root, which is written ../NAME and is the only way it can be
+// written. That target carries a slash, so the reading above hands it on, and
+// it opens with two full stops, so the prose pattern never had it. It was the
+// shape both of them sat either side of, and until it was read a link nobody
+// could follow was the one that passed.
 func pathsNamedIn(document textFile) []string {
 	named := check.PathsNamedInProse(document.text)
 
@@ -526,7 +533,32 @@ func pathsNamedIn(document textFile) []string {
 		seen[beside] = true
 		named = append(named, beside)
 	}
+
+	for _, target := range check.LinkTargetsAboveTheirDocument(document.text) {
+		above := path.Join(directory, target)
+		if outsideTheTree(above) {
+			// The target climbs past the root of the checkout. Whether a
+			// file out there exists is not a question this tree answers,
+			// and joining it to the root anyway would ask the filesystem
+			// about a path this repository does not hold. It is left alone
+			// for the same reason a target with a scheme in it is.
+			continue
+		}
+		if seen[above] {
+			continue
+		}
+		seen[above] = true
+		named = append(named, above)
+	}
 	return named
+}
+
+// outsideTheTree says whether a path that has already been cleaned still points
+// above the root it was resolved from. path.Join collapses what it can, so what
+// is left leading with a pair of full stops is what could not be collapsed, and
+// a target that resolves to the root itself names no file either.
+func outsideTheTree(cleaned string) bool {
+	return cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../")
 }
 
 // isOwnDocument says whether a path is one of this repository's own documents.

--- a/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-not-there/expected
+++ b/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-not-there/expected
@@ -1,0 +1,1 @@
+text-files 3

--- a/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-not-there/expected-refusals
+++ b/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-not-there/expected-refusals
@@ -1,0 +1,1 @@
+document-names-a-path-that-does-not-resolve

--- a/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-not-there/near-neighbour
+++ b/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-not-there/near-neighbour
@@ -1,0 +1,1 @@
+a-document-under-docs-linking-a-root-file-that-is-there

--- a/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-not-there/tree/NOTICE.md
+++ b/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-not-there/tree/NOTICE.md
@@ -1,0 +1,5 @@
+# Notice
+
+This software is developed for lawful use. Operators and users are responsible
+for making sure that their deployment and use comply with the laws that apply
+to them.

--- a/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-not-there/tree/README.md
+++ b/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-not-there/tree/README.md
@@ -1,0 +1,4 @@
+# a tree
+
+See [NOTICE.md](NOTICE.md) for the intended-use notice. The guide is in
+[docs/guide.md](docs/guide.md).

--- a/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-not-there/tree/docs/guide.md
+++ b/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-not-there/tree/docs/guide.md
@@ -1,0 +1,4 @@
+# The guide
+
+The terms this tree is published under are in [LICENSE](../LICENSE) at the root
+of the checkout, one directory above this page.

--- a/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-there/expected
+++ b/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-there/expected
@@ -1,0 +1,1 @@
+text-files 4

--- a/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-there/tree/LICENSE
+++ b/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-there/tree/LICENSE
@@ -1,0 +1,1 @@
+The terms this tree is published under.

--- a/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-there/tree/NOTICE.md
+++ b/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-there/tree/NOTICE.md
@@ -1,0 +1,5 @@
+# Notice
+
+This software is developed for lawful use. Operators and users are responsible
+for making sure that their deployment and use comply with the laws that apply
+to them.

--- a/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-there/tree/README.md
+++ b/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-there/tree/README.md
@@ -1,0 +1,4 @@
+# a tree
+
+See [NOTICE.md](NOTICE.md) for the intended-use notice. The guide is in
+[docs/guide.md](docs/guide.md).

--- a/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-there/tree/docs/guide.md
+++ b/testdata/invariants/a-document-under-docs-linking-a-root-file-that-is-there/tree/docs/guide.md
@@ -1,0 +1,4 @@
+# The guide
+
+The terms this tree is published under are in [LICENSE](../LICENSE) at the root
+of the checkout, one directory above this page.


### PR DESCRIPTION
Closes #168

## What this changes

A document under `docs/` writes a link to a file at the repository root as
`../NAME`, and that target was read by neither of the two readings the paths leg
joins. `PathsNamedInProse` requires a leading segment naming a directory of this
tree and `..` is not one; `LinkTargetsWithoutADirectory` skips any target
carrying a slash. The two sat either side of the shape.

Neither of them grows. Both are exact about a population and argue for that
exactness in their own comments, so this adds a third reading,
`LinkTargetsAboveTheirDocument`, which returns a link target stepping out of the
document's own directory and leaves the caller to place it.

`pathsNamedIn` joins it to the document's own directory rather than to the root,
which is what the issue requires of whichever reading was chosen, and it drops a
target that climbs past the root of the checkout.

Two fixtures hold both directions, in the register the two neighbouring cases
already use: a document under `docs/` linking a root file that is not there, and
its near neighbour linking one that is.

## What failure it prevents

The passing run. Three links on the default branch are in this shape and all
three resolve, so nothing is broken today. The day one of them is not has
already happened once: `LICENSE` left the default branch for a day under #155
and `docs/operator-guide.md` would have pointed at nothing while the leg stayed
green.

## What was run

At `2eb07c1`, on `windows/amd64`.

The near-miss the issue names, in both spellings. Before this change the `../`
spelling passed and only the bare spelling reddened. Both redden now:

```
printf '\n[a file that is not there](../NO-SUCH-FILE.md)\n' >> docs/privacy.md
go test ./internal/invariants -run TestThisRepositorySatisfiesTheInvariants -count=1 -v
          paths this repository's own documents name: 34 examined
          ..\..\docs\privacy.md: it names NO-SUCH-FILE.md, which is not in this tree (document-names-a-path-that-does-not-resolve)
--- FAIL: TestThisRepositorySatisfiesTheInvariants (0.15s)
```

```
printf '\n[a file that is not there](NO-SUCH-FILE.md)\n' >> docs/privacy.md
go test ./internal/invariants -run TestThisRepositorySatisfiesTheInvariants -count=1 -v
          paths this repository's own documents name: 34 examined
          ..\..\docs\privacy.md: it names docs/NO-SUCH-FILE.md, which is not in this tree (document-names-a-path-that-does-not-resolve)
--- FAIL: TestThisRepositorySatisfiesTheInvariants (0.15s)
```

The guard deleted, which is what says it bites for the reason it names. With the
third reading's loop taken out of `pathsNamedIn` and nothing else changed, one
case reddens and no other:

```
go test ./internal/invariants -run TestCases -count=1
--- FAIL: TestCases (0.02s)
    --- FAIL: TestCases/a-document-under-docs-linking-a-root-file-that-is-not-there (0.00s)
        invariants_test.go:159: expected refusal not produced: document-names-a-path-that-does-not-resolve
FAIL
```

The three links the issue lists are subjects the leg examines rather than text it
walks past. Moving `LICENSE` out of the tree and running the leg reaches both of
the `docs/` ones, alongside the two root documents the second reading already
had:

```
mv LICENSE LICENCE-MOVED-FOR-A-MEASUREMENT
go test ./internal/invariants -run TestThisRepositorySatisfiesTheInvariants -count=1 -v
          ..\..\README.md: it names LICENSE, which is not in this tree (document-names-a-path-that-does-not-resolve)
          ..\..\SECURITY.md: it names LICENSE, which is not in this tree (document-names-a-path-that-does-not-resolve)
          ..\..\docs\operator-guide.md: it names LICENSE, which is not in this tree (document-names-a-path-that-does-not-resolve)
          ..\..\docs\promotion.md: it names LICENSE, which is not in this tree (document-names-a-path-that-does-not-resolve)
```

and the third one the same way:

```
mv NOTICE.md NOTICE-MOVED-FOR-A-MEASUREMENT.md
go test ./internal/invariants -run TestThisRepositorySatisfiesTheInvariants -count=1 -v
          ..\..\docs\operator-guide.md: it names NOTICE.md, which is not in this tree (document-names-a-path-that-does-not-resolve)
          ..\..\README.md: it names NOTICE.md, which is not in this tree (document-names-a-path-that-does-not-resolve)
```

Both files were put back before the commit, which `git status` reported clean
afterwards.

The gate `CONTRIBUTING.md` names, in the order it names it:

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
go test -count=1 -v ./cmd/... ./internal/...
```

`gofmt -l` printed nothing, which is its passing result. The suite:

```
ok  	github.com/Flowfin/lab/cmd/contexts	1.354s
ok  	github.com/Flowfin/lab/cmd/lab	2.885s
ok  	github.com/Flowfin/lab/cmd/notices	10.550s
ok  	github.com/Flowfin/lab/cmd/pullrequest	0.845s
ok  	github.com/Flowfin/lab/internal/check	3.081s
ok  	github.com/Flowfin/lab/internal/contexts	1.142s
ok  	github.com/Flowfin/lab/internal/hardware	0.831s
ok  	github.com/Flowfin/lab/internal/invariants	1.590s
ok  	github.com/Flowfin/lab/internal/notices	1.132s
ok  	github.com/Flowfin/lab/internal/prose	1.044s
ok  	github.com/Flowfin/lab/internal/pullrequest	1.032s
```

and the runner over this tree:

```
go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
18 decision records read
the time this run read is 2026-08-22T07:45:01Z
0 refused
```

That run is on one platform. What the other two suite platforms do with this
change is not measured here and is the workflow's answer rather than mine.

## What this does not do

Nobody but me has read this change. The evidence above is in place of a second
reader rather than alongside one, and it is a weaker thing.

It does not widen `PathsNamedInProse` to read `..` in a sentence. That pattern is
narrow on purpose and the reason is written where it is narrow, so `../LICENSE`
typed into a sentence is still a word here and only a link is resolved.

It says nothing about a target that climbs past the root of the checkout. Such a
target is returned by the reading and dropped by the caller, deliberately and
with the reason at the drop: whether a file outside the checkout exists is not a
question any reading of this tree answers, which is the same reason a target
carrying a scheme is left alone. So a document linking `../../somewhere` is
neither resolved nor refused, and a run that is green says nothing about it.

The fixture proves the property and never which line inside the leg produced it,
which is the bound the harness states about itself. The arms a tree cannot reach
are covered by the direct table in `internal/check/paths_test.go` instead: a
fragment on the end, a repeated target, ordering, a scheme, a backslash, and the
two shapes that belong to the other two readings.
