### PR TITLE
The licence notice names this program and its author

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -629,8 +629,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    hoersaal, a self-hosted conferencing service that scales itself.
-    Copyright (C) 2026  iderex
+    lab, experiments around Flowfin that do not have to finish.
+    Copyright (C) 2026  Nils Lehnen
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published by


### PR DESCRIPTION
The licence notice names this program and its author

The appendix of the licence file, the section headed "How to Apply These Terms
to Your New Programs", carried a worked example naming `hoersaal` and not this
repository. The file had been copied and the two lines that identify the program
were never adapted; thirty-one public boards carry the same pair.

The copyright line now names the author. Across the fleet that line stood in two
forms, `iderex` on thirty-seven boards and `Nils Lehnen` on nine, and the second
is the one that stays: under the law that applies here the author of a work is
the natural person who made it, and an organisation holds rights rather than
authorship.

Nothing operative changes. Both lines sit after `END OF TERMS AND CONDITIONS`,
inside instructional text addressed to an author. The grant is the AGPL-3.0 as
published, unmodified, and it was unmodified before this change too.


Closes #171

Signed-off-by: Nils Lehnen <30603423+iderex@users.noreply.github.com>
