### PR TITLE
The help output names the three documents an operator is owed

### DIFF
--- a/cmd/lab/main.go
+++ b/cmd/lab/main.go
@@ -50,6 +50,31 @@ const (
 	exitCannot = 2
 )
 
+// The three documents the last paragraph of the usage text names. They are
+// named rather than restated, because a paraphrase printed by a binary somebody
+// downloaded months ago is a copy of a document that has since moved on, and the
+// reader has no way to tell which of the two they are holding.
+//
+// TWO LIMITS THAT BELONG HERE RATHER THAN ONLY IN THE ISSUE. A notice is not a
+// control. Printing it stops nothing, and it should not be counted as a thing
+// that prevents misuse when somebody later asks what does. And a notice an
+// operator has to run a verb to see is weaker than one sitting in the download
+// beside the binary, because the operator who most needs it is the one who runs
+// the thing without asking it for help first. Both routes exist for that
+// reason rather than either alone; the download half is issue #36 and has no
+// archive to be carried in yet.
+//
+// Nothing outside this package holds these strings to the tree. The paths leg
+// of the invariants scan reads this repository's own documents, which is the
+// files at the root and everything under docs/, and a path named inside the
+// runner is outside that subject by the leg's own reckoning. So the guard is
+// the test beside this declaration and there is no second one.
+var documentsAnOperatorIsOwed = []string{
+	"NOTICE.md",
+	"LICENSE",
+	"docs/privacy.md",
+}
+
 const usage = `lab reads this repository and reports what it examined.
 
     lab check [path]   walk the tree at path, default ".", and report
@@ -58,6 +83,10 @@ const usage = `lab reads this repository and reports what it examined.
     lab help           print this text
 
 lab writes nothing to the tree it reads.
+
+NOTICE.md says what this program is for, LICENSE carries the terms it is under,
+and docs/privacy.md says what stays on the host. Reading them is on you; this
+text only says where they are.
 `
 
 // THIS IS WHERE THE RUNNER READS THE TIME, and it is read once. Everything

--- a/cmd/lab/main_test.go
+++ b/cmd/lab/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -212,6 +214,36 @@ func TestTheDocumentedCodesAreTheNumbersTheRecordFixes(t *testing.T) {
 	for name := range want {
 		if _, ok := codes[name]; !ok {
 			t.Errorf("record 0011 names %s and this command has no constant for it", name)
+		}
+	}
+}
+
+// TestHelpNamesTheDocumentsAnOperatorIsOwed holds the last paragraph of the
+// usage text to the three files it points at. An operator who reads that
+// paragraph and then looks for one of the files is the reader this asserts for,
+// and both halves of the walk they make are here: that the text names the file,
+// and that the file is in the tree to be found.
+//
+// The second half is the one that earns its place. A pointer in the runner is
+// outside the subject of the invariants paths leg, which reads the files at the
+// root and everything under docs/ and holds those to the paths they name. So a
+// document deleted or moved under this paragraph reddens nothing anywhere else,
+// and a binary would go on telling operators to read a file that is not there.
+//
+// What it does not judge is whether any of the three says what it should. That
+// is a reading of prose and no test here makes it.
+func TestHelpNamesTheDocumentsAnOperatorIsOwed(t *testing.T) {
+	var out, errOut bytes.Buffer
+	if got := run([]string{"help"}, &out, &errOut, ordinary(realWalk)); got != exitClean {
+		t.Fatalf("exit code %d, want %d", got, exitClean)
+	}
+
+	for _, document := range documentsAnOperatorIsOwed {
+		if !strings.Contains(out.String(), document) {
+			t.Errorf("the help output does not name %s:\n%s", document, out.String())
+		}
+		if _, err := os.Stat(filepath.Join("..", "..", filepath.FromSlash(document))); err != nil {
+			t.Errorf("the help output names %s and it is not in this tree: %v", document, err)
 		}
 	}
 }


### PR DESCRIPTION
Superseded by #173 and closed unmerged. The change itself is unchanged and
lands there.

This branch carried no DCO sign-off, and the sign-off gate refused it by name:

```
FAIL  31a68c0b193cdb20080baa7debc0fce3d6e4c3dc is missing: Signed-off-by: Nils Lehnen <30603423+iderex@users.noreply.github.com>
```

The repair is a rebuild rather than a rewrite. I did not force-push this branch
and I have left it alone. The commit was rebuilt on a fresh branch with the
sign-off, and the two are proven to carry identical content rather than assumed
to:

```
git show 31a68c0 | git patch-id --stable
2962ce886cd65390d358ec734f0b35ea51013281 31a68c0b193cdb20080baa7debc0fce3d6e4c3dc

git show 7595a9d | git patch-id --stable
2962ce886cd65390d358ec734f0b35ea51013281 7595a9d4d0d390b5bea8a841201c004edc931c54
```

Everything this pull request said about the change, the evidence behind it and
what it does not close is carried in the body of #173.
