### PR TITLE
Record where code under another licence may live

### DIFF
--- a/docs/decisions/0019-code-under-another-licence.md
+++ b/docs/decisions/0019-code-under-another-licence.md
@@ -1,0 +1,100 @@
+# 0019. Code under another licence
+
+## What was decided
+
+An experiment may bring in code under a licence that is not this board's, and
+only inside a quarantined directory that carries its own licence file.
+
+The directory is `experiments/<slug>/borrowed/`, and the licence the borrowed
+code arrives under is `experiments/<slug>/borrowed/LICENSE`. One such directory
+per experiment. It sits inside the experiment rather than at the root of the
+tree, which is not a stylistic choice: record `0002` refuses a root directory it
+does not name, so a quarantine at the root would be a change to that record,
+while the layout inside an experiment is loose by that record's own words and
+`experiments/<slug>/` already holds one experiment and everything it needs.
+
+Everything under that directory is under the licence its own file names.
+Everything outside it is under this board's own licence, which is decided as
+entry one of the plan and recorded under its own issue rather than here.
+
+The experiment record declares it. `Borrowed:` in the header names the source and
+the licence, and its absence means the experiment borrowed nothing. That is a
+field the record format does not carry today, so adding it is a change to the
+format and goes through
+[0013-how-the-record-format-changes.md](0013-how-the-record-format-changes.md)
+rather than being written into a header and discovered by a reader.
+
+Why this rather than the two ends. Allowing borrowed code anywhere with nothing
+but a line in the record puts a directory that is not under this board's licence
+somewhere in a tree that reads as uniform, and somebody promoting the work later
+has to notice it at the exact moment they are least careful. That is a footgun
+placed where attention is lowest. Forbidding it outright makes a real class of
+question unaskable here, and the questions that begin with existing code are a
+class this board wants, because most interesting questions about software are
+questions about software that already exists.
+
+What the quarantine buys is that the boundary is in the layout rather than in
+somebody's attention. A person promoting a result walks a directory tree, and a
+directory named `borrowed` with a licence file in it is visible to a walk. A
+declaration in a header is visible only to a reader who opened the header.
+
+What it costs, stated rather than left to be discovered. It is a layout rule that
+has to be taught, so it belongs in the contributing guide and not only here. It
+needs a check, which is ordinary gate work in this tree rather than a new
+apparatus: the runner already walks `experiments/` and already reads the header.
+
+**Nothing in this repository refuses a violation of this rule today.** No check
+reads `borrowed/`, no check reads a `Borrowed:` field, and the field is not part
+of the format yet. What stands behind the rule is this record, the guide, and
+whoever reads the change. That is the state on the day this lands, and it is
+written here so the rule is not mistaken for a gate.
+
+## What it applies to
+
+Every experiment on this board that starts from code somebody else wrote, from
+the commit this record lands on.
+
+It applies to the contributing guide, which has to carry the rule where a person
+starting an experiment meets it, and to the record format, which has to gain the
+field before the declaration means anything.
+
+It does not apply to the runner. `cmd/lab/` and `internal/` borrow nothing under
+this rule; a dependency of the runner is a module requirement and is covered by
+the notices and the bill of materials the release carries.
+
+It does not decide whether a particular licence may be borrowed from at all.
+Some licences are incompatible with promotion into a GPL plugin board whatever
+directory the code sits in, and this record fixes where borrowed code lives
+rather than which licences are acceptable.
+
+## What else was considered
+
+Allowing borrowed code anywhere in an experiment, with a declaration in the
+experiment record naming the source and its licence.
+
+Forbidding borrowed code entirely, so every experiment starts from nothing.
+
+Putting the quarantine at the root of the tree, in one directory shared by every
+experiment.
+
+## What each rejected option would have cost
+
+Allowing it anywhere costs the promotion path its safety. The tree then reads as
+uniform and is not, and the only thing separating a file under this board's
+licence from a file under somebody else's is a line in a header that the person
+copying the directory did not open. The failure lands on whoever promotes the
+result, which is later, elsewhere, and after the person who knew has stopped
+thinking about it.
+
+Forbidding it entirely costs a class of question this board exists to take. An
+experiment asking whether an existing implementation behaves a particular way
+cannot be run without that implementation, and the answer would be to run it
+somewhere unrecorded, which is worse than running it here: the board loses the
+record and gains nothing.
+
+A shared quarantine at the root costs a change to record `0002`, which refuses a
+root directory it does not name, and it costs the property that makes the
+quarantine work. Borrowed code would sit away from the experiment that borrowed
+it, so deleting an abandoned experiment leaves its borrowed code behind, and two
+experiments borrowing different versions of one thing collide in a directory
+neither of them owns.


### PR DESCRIPTION
Closes #180.

## What this does

Entry two of #46 was answered on 2026-08-24: an experiment may bring in code
under a licence that is not this board's, only inside a quarantined directory
carrying its own licence file. Record `0000` says a decision that exists only in
an issue is not yet recorded, so this writes it down.

The answer fixed the shape and not the layout, so the record fixes the layout and
argues the placement rather than asserting it. The directory is
`experiments/<slug>/borrowed/`, its licence is
`experiments/<slug>/borrowed/LICENSE`, one per experiment, and it sits inside the
experiment rather than at the root.

**Why inside the experiment.** Record `0002` refuses a root directory it does not
name, and says so in its own words:

```
git grep -n 'does not name is refused' origin/main -- docs/decisions/0002-repository-layout.md
```

so a shared quarantine at the root is a change to that record rather than a
placement choice. The same record makes the layout inside a named directory
loose, and `experiments/<slug>/` already holds one experiment and everything it
needs. A root quarantine would also separate borrowed code from the experiment
that borrowed it: deleting an abandoned experiment leaves its borrowed code
behind, and two experiments borrowing different versions of one thing collide in
a directory neither owns. Both are in section four.

**What the quarantine buys.** The boundary is in the layout rather than in
somebody's attention. A person promoting a result walks a directory tree, and a
directory named `borrowed` with a licence file in it is visible to a walk; a
declaration in a header is visible only to somebody who opened the header. The
failure the rule is written against lands on whoever promotes the result, which
is later, elsewhere, and after the person who knew has stopped thinking about it.

**The declaration.** `Borrowed:` in the experiment record header names the source
and the licence, and its absence means the experiment borrowed nothing. The
record says plainly that the format does not carry that field today, so adding it
is a change to the format that goes through
`docs/decisions/0013-how-the-record-format-changes.md` rather than a header
somebody writes and a reader discovers.

## What this record does not claim

**Nothing in this repository refuses a violation of this rule today**, and the
record says so at the rule rather than in a footnote. No check reads `borrowed/`,
no check reads the field, and the field is not part of the format yet. What
stands behind the rule is this record, the contributing guide and whoever reads
the change. That sentence is what stops the rule being read as a gate, and it is
the state on the day this lands rather than a permanent one - entry two's answer
says the check is ordinary gate work, and the runner already walks `experiments/`
and already reads the header.

It also does not decide which licences may be borrowed from. Some are
incompatible with promotion into a GPL plugin board whatever directory the code
sits in, and this record fixes where borrowed code lives rather than which
licences are acceptable.

## The gate

Run at this head, in the order `CONTRIBUTING.md` names:

```
go build ./cmd/... ./internal/...        (no output)
go vet ./cmd/... ./internal/...          (no output)
gofmt -l cmd internal                    (no output)
go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	0.686s
ok  	github.com/Flowfin/lab/cmd/lab	13.004s
ok  	github.com/Flowfin/lab/cmd/notices	52.408s
ok  	github.com/Flowfin/lab/cmd/pullrequest	0.661s
ok  	github.com/Flowfin/lab/internal/check	0.877s
ok  	github.com/Flowfin/lab/internal/contexts	0.627s
ok  	github.com/Flowfin/lab/internal/hardware	0.652s
ok  	github.com/Flowfin/lab/internal/invariants	0.949s
ok  	github.com/Flowfin/lab/internal/notices	0.639s
ok  	github.com/Flowfin/lab/internal/prose	0.666s
ok  	github.com/Flowfin/lab/internal/pullrequest	0.682s

go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
21 decision records read
the time this run read is 2026-08-24T19:34:32Z
0 refused
```

This adds no code, so it adds no refusal site and owes no fixture. What holds it
is the record checks already running over this tree: the section rule that
refuses a record missing any of the four headings, and the numbering rule that
refuses two records under one number. The run above is those checks reading
twenty-one records where they read twenty before.

The integration-hardware harness was not asked for and produced nothing here.

## The means

Markdown under `docs/decisions/`, because record `0000` fixes that decisions live
there one per file in that shape, and the checks that read a decision record
already read that directory. No language, runtime or dependency is added.

No second person has read this change. The gate output above stands in place of
one.
