### PR TITLE
Refuse a borrowed quarantine that does not declare itself

### DIFF
--- a/docs/experiment-template.md
+++ b/docs/experiment-template.md
@@ -26,9 +26,25 @@ under `internal/hardware`, in a file whose name ends
 `_integration_hardware_test.go`, and a record that says one thing while the
 directory says the other is refused.
 
+Add `Borrowed` where the experiment starts from code somebody else wrote, naming
+where that code came from and the licence it arrives under. It is not in the
+header above for the reason `Measurement-Commit` is not: a template that ships a
+field filled in teaches every new record to declare a value it does not have, and
+almost every experiment borrows nothing. The code itself goes in
+`experiments/<slug>/borrowed/`, which carries its own `LICENSE` naming those
+terms, and a record declaring the field with no such directory is refused, as is
+a borrowed directory with no licence file in it.
+
+What that refusal does not do is worth knowing before you rely on it. Nothing
+reads the licence file, so a green run says the layout and the declaration agree
+and says nothing about which licence the code is actually under or whether the
+result may be promoted anywhere. A borrowed directory in an experiment whose
+record declares nothing passes, because an absent field is never refused.
+
 The format is `docs/decisions/0008-the-experiment-record.md`, as added to by
-`docs/decisions/0015-an-experiment-declares-the-harness-it-needs.md` and by
-`docs/decisions/0016-an-answer-names-the-commit-it-measured.md`. This file is a
+`docs/decisions/0015-an-experiment-declares-the-harness-it-needs.md`, by
+`docs/decisions/0016-an-answer-names-the-commit-it-measured.md` and by
+`docs/decisions/0019-code-under-another-licence.md`. This file is a
 convenience and those records are the authority.
 
 ## Question

--- a/internal/check/borrowed.go
+++ b/internal/check/borrowed.go
@@ -1,0 +1,163 @@
+package check
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path"
+)
+
+// FieldBorrowed names where borrowed code came from and the licence it arrives
+// under. Record 0019 adds it and record 0013 makes it optional, as it makes
+// every field added after it, so an experiment that borrows nothing writes
+// nothing and that is never a refusal.
+//
+// It is declared here rather than beside the four record 0008 fixes, which is
+// the shape FieldMeasurementCommit already argues for at its own declaration: a
+// field a later record adds arrives with the check that reads it, so a checker
+// built before the field is unaware of it and a field with no check has nowhere
+// to hide.
+const FieldBorrowed = "Borrowed"
+
+// BorrowedDir is the one directory inside an experiment that may hold code
+// under a licence that is not this board's, and BorrowedLicenceName is the file
+// that says which licence that is. Record 0019 fixes both names and puts the
+// directory inside the experiment rather than at the root, because record 0002
+// refuses a root directory it does not name.
+const (
+	BorrowedDir         = "borrowed"
+	BorrowedLicenceName = "LICENSE"
+)
+
+// The properties a borrowed quarantine can be refused for.
+const (
+	// BorrowedDirectoryCarriesNoLicence refuses a borrowed directory with no
+	// licence file in it. That is the quarantine without the thing that makes
+	// it one: a directory a reader walking the tree takes for code under
+	// somebody else's terms, declaring none of them, so the person promoting
+	// the work later reads the boundary and learns nothing from it.
+	//
+	// It is refused whatever the record says, because the layout is what
+	// record 0019 buys and a header field is visible only to somebody who
+	// opened the header.
+	BorrowedDirectoryCarriesNoLicence = "borrowed-directory-carries-no-licence"
+
+	// RecordBorrowedDeclarationNamesNoDirectory refuses a record that declares
+	// Borrowed while the experiment holds no borrowed directory. The record
+	// then says code under other terms is in the experiment and the tree says
+	// it is not, and which of the two is wrong decides the repair, so the
+	// message names both sides rather than restating the rule.
+	//
+	// The declaration having been made is what this reads, so record 0013 is
+	// untouched by it: an absent field says nothing and is not refused here.
+	RecordBorrowedDeclarationNamesNoDirectory = "record-borrowed-declaration-names-no-directory"
+)
+
+// refuseBorrowed holds an experiment's borrowed quarantine and its record's
+// Borrowed declaration to each other and to record 0019's layout.
+//
+// WHAT A GREEN RUN DOES NOT SAY, and it is most of what somebody wants when
+// they read the word licence. Whether the licence file names the licence the
+// code is actually under is a judgement about the world rather than about the
+// tree, and nothing here opens that file or reads a word of it. So is whether
+// the borrowed code may be promoted into a board under other terms, which
+// record 0019 explicitly leaves undecided. What passes here is a layout and a
+// declaration that do not contradict each other, and nothing further.
+//
+// WHERE IT DOES NOT REACH, in three places rather than one.
+//
+// A borrowed directory in an experiment whose record declares no Borrowed field
+// passes. That is the second direction of the disagreement above and it is a
+// refusal on an absent field, which record 0013 forbids in the words
+// refuseHardware already declines the same shape in. Closing it is a change to
+// that record rather than a wider check here.
+//
+// A Borrowed declaration written with nothing after the colon is a declaration,
+// so the directory half above is read against it, and nothing here asks whether
+// it names a source or a licence. Record 0019 says the field names both;
+// whether it does is prose a reader judges.
+//
+// An experiment whose record the walk did not reach - absent, unreadable, above
+// the size bound - is not judged here at all, because this is called with the
+// record's bytes in hand and those runs never get that far.
+//
+// A record whose bytes do not parse as a record is judged for its directory and
+// not for its declaration, for the reason refuseState and refuseHardware both
+// give: nothing can read a field out of a file that has no header.
+func refuseBorrowed(fsys fs.FS, root, inside, record string, data []byte) ([]Refusal, error) {
+	quarantine := path.Join(inside, BorrowedDir)
+
+	held, err := isDirectory(fsys, quarantine)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read %s: %w", at(root, quarantine), err)
+	}
+
+	var refusals []Refusal
+
+	if held {
+		carried, err := isRegularFile(fsys, path.Join(quarantine, BorrowedLicenceName))
+		if err != nil {
+			return nil, fmt.Errorf("cannot read %s: %w", at(root, path.Join(quarantine, BorrowedLicenceName)), err)
+		}
+		if !carried {
+			refusals = append(refusals, Refusal{
+				Property: BorrowedDirectoryCarriesNoLicence,
+				Subject:  at(root, quarantine),
+				Detail: fmt.Sprintf("it holds no %s, so it reads as code under somebody else's terms and names none of them. record 0019 puts that file at %s",
+					BorrowedLicenceName, path.Join(quarantine, BorrowedLicenceName)),
+			})
+		}
+	}
+
+	parsed, err := ParseRecord(data)
+	if err != nil {
+		return refusals, nil
+	}
+	if _, declared := parsed.Field(FieldBorrowed); !declared || held {
+		return refusals, nil
+	}
+
+	return append(refusals, Refusal{
+		Property: RecordBorrowedDeclarationNamesNoDirectory,
+		Subject:  record,
+		Detail: fmt.Sprintf("it declares %s and there is no %s directory in %s, so the record says the experiment borrows and the tree says it does not",
+			FieldBorrowed, BorrowedDir, inside),
+	}), nil
+}
+
+// isDirectory says whether a name in the walked filesystem is a directory. A
+// name that is not there is not one, and that is the ordinary answer rather
+// than an error: almost every experiment borrows nothing.
+//
+// THIS FOLLOWS A SYMBOLIC LINK AND DOES NOT REFUSE ONE. fs.Stat resolves a
+// link, so a link named borrowed that points at a directory reads as a
+// quarantine here and its target is stated to be inside the experiment by
+// nothing. That is deliberately not repaired at this site: a link anywhere
+// under experiments/ is already refused by the stray-record walk, which reads
+// the entry rather than the target, and a second rule deciding what a link
+// points at is the resolution that walk exists to avoid.
+func isDirectory(fsys fs.FS, name string) (bool, error) {
+	info, err := fs.Stat(fsys, name)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return info.IsDir(), nil
+}
+
+// isRegularFile says whether a name in the walked filesystem is a file a reader
+// can open. A licence that is a directory, or a link, is not one, and it is the
+// same answer as a licence that is not there: in both cases nothing at that
+// path states terms.
+func isRegularFile(fsys fs.FS, name string) (bool, error) {
+	info, err := fs.Stat(fsys, name)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return info.Mode().IsRegular(), nil
+}

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -524,14 +524,19 @@ func walkExperiments(fsys fs.FS, root string, res *Result) error {
 		res.Refusals = append(res.Refusals, refuseMeasurementCommit(record, data)...)
 		res.Refusals = append(res.Refusals, refuseDates(record, data, res.Now)...)
 		res.Refusals = append(res.Refusals, refusePromotion(record, data)...)
-		// The only rule here that reads the directory as well as the record,
-		// which is why it takes both and why it can fail: the others judge
-		// bytes already in hand and this one walks.
+		// The two rules here that read the directory as well as the record,
+		// which is why they take both and why they can fail: the others judge
+		// bytes already in hand and these two walk.
 		hardwareRefusals, err := refuseHardware(fsys, experimentPath, experiment, record, data)
 		if err != nil {
 			return err
 		}
 		res.Refusals = append(res.Refusals, hardwareRefusals...)
+		borrowedRefusals, err := refuseBorrowed(fsys, root, experimentPath, record, data)
+		if err != nil {
+			return err
+		}
+		res.Refusals = append(res.Refusals, borrowedRefusals...)
 		if parsed, err := ParseRecord(data); err == nil {
 			seen.slug, seen.declaresSlug = parsed.Field(FieldSlug)
 		}

--- a/testdata/cases/a-borrowed-directory-with-no-licence-file/expected
+++ b/testdata/cases/a-borrowed-directory-with-no-licence-file/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/a-borrowed-directory-with-no-licence-file/expected-refusals
+++ b/testdata/cases/a-borrowed-directory-with-no-licence-file/expected-refusals
@@ -1,0 +1,1 @@
+borrowed-directory-carries-no-licence

--- a/testdata/cases/a-borrowed-directory-with-no-licence-file/near-neighbour
+++ b/testdata/cases/a-borrowed-directory-with-no-licence-file/near-neighbour
@@ -1,0 +1,1 @@
+an-experiment-that-borrows-and-declares-it

--- a/testdata/cases/a-borrowed-directory-with-no-licence-file/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/a-borrowed-directory-with-no-licence-file/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,15 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+Needs-Hardware: none
+Borrowed: the reference implementation from example.invalid, under the MIT licence
+
+## Question
+
+Does the reference implementation lose a frame when the stream stalls?
+
+## Method
+
+The implementation was read and run from the copy this experiment carries.
+
+## Answer

--- a/testdata/cases/a-borrowed-directory-with-no-licence-file/tree/experiments/one/borrowed/source.txt
+++ b/testdata/cases/a-borrowed-directory-with-no-licence-file/tree/experiments/one/borrowed/source.txt
@@ -1,0 +1,1 @@
+The borrowed implementation would sit here.

--- a/testdata/cases/a-record-declaring-borrowed-with-no-borrowed-directory/expected
+++ b/testdata/cases/a-record-declaring-borrowed-with-no-borrowed-directory/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/a-record-declaring-borrowed-with-no-borrowed-directory/expected-refusals
+++ b/testdata/cases/a-record-declaring-borrowed-with-no-borrowed-directory/expected-refusals
@@ -1,0 +1,1 @@
+record-borrowed-declaration-names-no-directory

--- a/testdata/cases/a-record-declaring-borrowed-with-no-borrowed-directory/near-neighbour
+++ b/testdata/cases/a-record-declaring-borrowed-with-no-borrowed-directory/near-neighbour
@@ -1,0 +1,1 @@
+a-record-that-declares-no-borrowing

--- a/testdata/cases/a-record-declaring-borrowed-with-no-borrowed-directory/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/a-record-declaring-borrowed-with-no-borrowed-directory/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,15 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+Needs-Hardware: none
+Borrowed: the reference implementation from example.invalid, under the MIT licence
+
+## Question
+
+Does the reference implementation lose a frame when the stream stalls?
+
+## Method
+
+The implementation was read and run from the copy this experiment carries.
+
+## Answer

--- a/testdata/cases/a-record-that-declares-no-borrowing/expected
+++ b/testdata/cases/a-record-that-declares-no-borrowing/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/a-record-that-declares-no-borrowing/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/a-record-that-declares-no-borrowing/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,14 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+Needs-Hardware: none
+
+## Question
+
+Does the reference implementation lose a frame when the stream stalls?
+
+## Method
+
+The implementation was read and run from the copy this experiment carries.
+
+## Answer

--- a/testdata/cases/an-experiment-that-borrows-and-declares-it/expected
+++ b/testdata/cases/an-experiment-that-borrows-and-declares-it/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/an-experiment-that-borrows-and-declares-it/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/an-experiment-that-borrows-and-declares-it/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,15 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+Needs-Hardware: none
+Borrowed: the reference implementation from example.invalid, under the MIT licence
+
+## Question
+
+Does the reference implementation lose a frame when the stream stalls?
+
+## Method
+
+The implementation was read and run from the copy this experiment carries.
+
+## Answer

--- a/testdata/cases/an-experiment-that-borrows-and-declares-it/tree/experiments/one/borrowed/LICENSE
+++ b/testdata/cases/an-experiment-that-borrows-and-declares-it/tree/experiments/one/borrowed/LICENSE
@@ -1,0 +1,7 @@
+MIT License
+
+Copyright (c) 2026 the author of the borrowed implementation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files, to deal in the software
+without restriction.

--- a/testdata/cases/an-experiment-that-borrows-and-declares-it/tree/experiments/one/borrowed/source.txt
+++ b/testdata/cases/an-experiment-that-borrows-and-declares-it/tree/experiments/one/borrowed/source.txt
@@ -1,0 +1,1 @@
+The borrowed implementation would sit here.


### PR DESCRIPTION
Refs #188

## What this changes

Record `0019` puts code under another licence in `experiments/<slug>/borrowed/`,
carrying its own `LICENSE`, declared by a `Borrowed:` field in the experiment
record. It says at the rule that nothing in this repository refuses a violation
of any of that. Two of the three violations #188 names are refused now.

`borrowed-directory-carries-no-licence` refuses a borrowed directory with no
licence file in it, whatever the record says, because the layout is what record
`0019` buys and a header field is visible only to somebody who opened the header.

`record-borrowed-declaration-names-no-directory` refuses a record declaring
`Borrowed:` while the experiment holds no such directory. The message names both
sides, because which of the two is wrong decides the repair.

The field arrives in the file that reads it, which is the shape
`FieldMeasurementCommit` already argues for at its own declaration. #188 says
the format change is a prerequisite rather than part of this work, and evidences
that with a grep of `internal/check/record.go` alone. That file is not where the
last field the format gained was declared:

```
git grep -n 'Field[A-Za-z]* = "' origin/main -- internal/check/
origin/main:internal/check/measurement.go:14:const FieldMeasurementCommit = "Measurement-Commit"
origin/main:internal/check/record.go:16:	FieldSlug = "Slug"
origin/main:internal/check/record.go:19:	FieldState = "State"
origin/main:internal/check/record.go:24:	FieldQuestionWritten = "Question-Written"
origin/main:internal/check/record.go:28:	FieldAnswerWritten = "Answer-Written"
origin/main:internal/check/record.go:34:	FieldNeedsHardware = "Needs-Hardware"
```

Record `0016`'s field, its check and the record itself landed in one change:

```
git log --format='%h %ad %s' --date=short origin/main -- internal/check/measurement.go
19ac2bf 2026-08-12 Say which commit a measurement in an answer was produced at (#123)
```

So what the prerequisite is, is record `0013`'s rule rather than a separate
landing, and that rule is met here: the field is optional and an absent one is
never refused. The template names the field in its prose rather than carrying it
in its header, for the reason `Measurement-Commit` is named the same way, and it
carries what a green run does not prove.

The one record on the board is left exactly as it was, which is what record
`0013` requires of a record already on the default branch.

The means is Go, in the package that already walks `experiments/` and already
reads the header, proved by the fixture harness that already exists. It adds no
language, no runtime and no dependency, and record `0019` says this check is
ordinary gate work in this tree rather than a new apparatus.

## What failure it prevents

A directory a reader walking the tree takes for quarantined, declaring none of
the terms it is under. That is the footgun record `0019` describes: the person
who meets it is whoever promotes the result later, at the moment they are least
careful, and the boundary they are relying on tells them nothing.

And a record that says an experiment borrows while the tree says it does not,
which is the same claim going quietly out of date from the other side.

## What was run

At `eafb8ddb9600ce694cea86c7e32e1c201f251eac`, the four commands `CONTRIBUTING.md`
names, in that order:

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
(no output)
go test -count=1 -v ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	1.740s
ok  	github.com/Flowfin/lab/cmd/lab	10.551s
ok  	github.com/Flowfin/lab/cmd/notices	65.274s
ok  	github.com/Flowfin/lab/cmd/pullrequest	0.755s
ok  	github.com/Flowfin/lab/internal/check	0.997s
ok  	github.com/Flowfin/lab/internal/contexts	0.750s
ok  	github.com/Flowfin/lab/internal/hardware	0.754s
ok  	github.com/Flowfin/lab/internal/invariants	1.075s
ok  	github.com/Flowfin/lab/internal/notices	0.738s
ok  	github.com/Flowfin/lab/internal/prose	0.775s
ok  	github.com/Flowfin/lab/internal/pullrequest	0.761s
```

What the `-v` run says it did not cover:

```
go test -count=1 -v ./internal/hardware
the integration-hardware harness was not asked for and nothing in it ran.
asking costs a machine with the hardware each test names and an explicit request:
    go test -tags integration_hardware ./internal/hardware
with LAB_INTEGRATION_HARDWARE=1 in the environment. its results are about that machine and are not this suite's results.
```

The harness was not asked for on this branch and nothing in it ran. The change
registers no test with it.

The run over this tree:

```
go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
21 decision records read
the time this run read is 2026-08-25T05:17:26Z
0 refused
```

What each refusal says, run against its own fixture tree:

```
go run ./cmd/lab check testdata/cases/a-borrowed-directory-with-no-licence-file/tree
1 refused
  testdata\cases\a-borrowed-directory-with-no-licence-file\tree\experiments\one\borrowed: it holds no LICENSE, so it reads as code under somebody else's terms and names none of them. record 0019 puts that file at experiments/one/borrowed/LICENSE (borrowed-directory-carries-no-licence)
exit status 1

go run ./cmd/lab check testdata/cases/a-record-declaring-borrowed-with-no-borrowed-directory/tree
1 refused
  testdata\cases\a-record-declaring-borrowed-with-no-borrowed-directory\tree\experiments\one\EXPERIMENT.md: it declares Borrowed and there is no borrowed directory in experiments/one, so the record says the experiment borrows and the tree says it does not (record-borrowed-declaration-names-no-directory)
exit status 1

go run ./cmd/lab check testdata/cases/an-experiment-that-borrows-and-declares-it/tree
0 refused
```

Both guards were proved by deleting them and watching the suite go red.

Deleting the licence refusal site:

```
go test -count=1 ./internal/check
--- FAIL: TestCases (0.05s)
    --- FAIL: TestCases/a-borrowed-directory-with-no-licence-file (0.00s)
        check_test.go:46: expected refusal not produced: borrowed-directory-carries-no-licence
FAIL
```

Deleting the declaration refusal site:

```
go test -count=1 ./internal/check
--- FAIL: TestCases (0.05s)
    --- FAIL: TestCases/a-record-declaring-borrowed-with-no-borrowed-directory (0.00s)
        check_test.go:46: expected refusal not produced: record-borrowed-declaration-names-no-directory
FAIL
```

Deleting the dispatch in `walkExperiments`:

```
go test -count=1 ./internal/check
--- FAIL: TestCases (0.04s)
    --- FAIL: TestCases/a-borrowed-directory-with-no-licence-file (0.00s)
        check_test.go:46: expected refusal not produced: borrowed-directory-carries-no-licence
    --- FAIL: TestCases/a-record-declaring-borrowed-with-no-borrowed-directory (0.00s)
        check_test.go:46: expected refusal not produced: record-borrowed-declaration-names-no-directory
FAIL
```

Each site was restored and the suite re-run green before the commit was made.
Each refusing case declares a near neighbour that refuses nothing and differs by
the smallest legal change: the licence file arriving, and the declaration line
going away.

## What this does not do

**#188 stays open, and this pull request does not finish it.** That sentence is
phrased around the platform's closing keywords rather than with them, and the
reason is a trap this change walked into. The heading originally read as a denial
built on one of those keywords followed by the issue number; the platform read
the keyword and never the denial, and merging this closed that issue while two
thirds of its done-condition were unmet. It was reopened and the wording repaired. The
literal is not reproduced here, deliberately: a body quoting it carries the same
live keyword, which is how this paragraph would become the second instance of
what it is written against.

The third refusal that issue asks for is a borrowed
directory in an experiment whose record declares no `Borrowed:`. That is a
refusal on an absent field, and record `0013` says an absent field is never a
refusal, in the same words `refuseHardware` already declines the identical shape
in, at its own declaration. Building it here would be taking a decision about
record `0013` inside a check, so it is not built and the issue keeps that clause.
It is written into #188 with what it waits on.

**Nothing reads the licence file.** A green run says the layout and the
declaration do not contradict each other. It says nothing about which licence
the code is actually under, and nothing about whether the borrowed code may be
promoted into a board under other terms, which record `0019` explicitly leaves
undecided.

**A `Borrowed:` declaration written with nothing after the colon is a
declaration.** The directory half is read against it and nothing asks whether it
names a source or a licence. Record `0019` says the field names both; whether it
does is prose a reader judges.

**An experiment whose record the walk did not reach is not judged here at all**,
whether the record is absent, unreadable, or above the size bound. The check is
called with the record's bytes in hand and those runs never get that far.

**A symbolic link named `borrowed` pointing at a directory reads as a quarantine
here**, because `fs.Stat` resolves it. That is not repaired at this site: a link
anywhere under `experiments/` is already refused by the stray-record walk, which
reads the entry rather than the target, and a second rule deciding what a link
points at is the resolution that walk exists to avoid.

**Record `0019` also owes the contributing guide.** It says the rule belongs
where a person starting an experiment meets it, and this change carries it into
`docs/experiment-template.md` and not into `CONTRIBUTING.md`. That is outside
what #188 asks for and no issue holds it.

**There is no second reader on this board tonight.** What stands in place of one
is the evidence above: the commands, their output, and each guard shown red with
its site removed.
