### PR TITLE
actions: bump github/codeql-action to 4.37.7

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -84,7 +84,7 @@ jobs:
           cache: false
 
       - name: Initialise CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: go
           # Manual rather than autobuild, because autobuild builds the module
@@ -102,6 +102,6 @@ jobs:
         run: go build ./cmd/... ./internal/...
 
       - name: Analyse
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: "/language:go"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -90,7 +90,7 @@ jobs:
 
       # Surface the findings in the code-scanning tab, alongside CodeQL and zizmor.
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif
           category: scorecard

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -82,7 +82,7 @@ jobs:
         # skip the "Fail on actionable findings" step below.
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
One commit under #190: init, analyze and upload-sarif move to 4.37.7 together, with exactly the pins Dependabot resolved in #175, #176 and #177 - separately those three red each other because the CodeQL workflow needs the steps in one version. Supersedes #175, #176, #177.