### PR TITLE
actions: bump astral-sh/setup-uv from 9.0.0 to 10.0.1

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -62,7 +62,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Audit workflows (SARIF for code scanning)
         # --no-build: install zizmor from its prebuilt wheel only, never executing a


### PR DESCRIPTION
One commit under #190, carrying the pin Dependabot resolved in #174, where CodeQL and the builds were already green - only the issue-reference rule refused it. Supersedes #174.