### PR TITLE
Record four answers from the plan decision issue

### DIFF
--- a/docs/decisions/0018-the-licence-of-this-board.md
+++ b/docs/decisions/0018-the-licence-of-this-board.md
@@ -1,0 +1,145 @@
+# 0018. The licence of this board
+
+## What was decided
+
+GPL-3.0, and one licence for both the runner and the experiment content.
+
+The reason is the direction the work actually moves. What a result on this
+board is for is being taken somewhere it keeps running, and the place that
+usually is sits in this organisation already: the plugin boards, every one of
+which carries GPL-3.0 today. The platform fills that field in from the licence
+file it finds at a root, and it is read one repository at a time:
+
+    gh api repos/Flowfin/jellyfin-plugin-sso --jq '.license.spdx_id'
+    GPL-3.0
+
+Read that way when this record was written, the twelve plugin boards carry
+GPL-3.0 and three other boards of this organisation carry AGPL-3.0. So this is
+a choice about which of two neighbourhoods this board hands work to rather than
+a house style everything here already follows. That population moves, and what
+derives it rather than trusting the sentence above is:
+
+    for r in $(gh repo list Flowfin --limit 100 --json name --jq '.[].name'); do
+      spdx=$(gh api "repos/Flowfin/$r" --jq '.license.spdx_id // "none"')
+      printf '%s %s\n' "$r" "$spdx"
+    done
+
+The same licence on both sides is what makes the hand-over cheap. Record `0005`
+fixes promotion as a hand-over that names the terms the code leaves under, and
+naming terms the receiving board already carries is a line somebody writes,
+while naming different terms is a relicensing question somebody has to answer
+before any code moves.
+
+One licence rather than two, and the question is real rather than rhetorical.
+The runner is downloaded and run, the experiment content is read and copied
+from, and those are different audiences. What a second licence would buy is a
+better fit for one of them. What it costs is that every reader of this tree has
+to work out which of two sets of terms the thing in front of them is under
+before they can use it, on a board whose whole purpose is lowering the cost of
+trying something. One file governing everything is the answer, and record `0019`
+is the one exception to it: code under another licence lives in a quarantined
+directory inside the experiment that borrowed it, under the terms its own
+licence file names.
+
+**What this costs, in the direction it costs it.** A result that would have been
+useful to a permissively licensed project cannot go there. An experiment that
+wants to borrow permissively licensed code and give something back is
+constrained, because what it gives back leaves under these terms. Neither is
+hypothetical. They are the ordinary price of choosing the copyleft side, and
+they are written here so that somebody meeting them later meets a decision
+rather than a surprise.
+
+**The file on the default branch says something else today, and this record
+does not change it.** The platform reads the bytes at the root and reports what
+it finds:
+
+    gh api repos/Flowfin/lab --jq '.license.spdx_id'
+    AGPL-3.0
+
+So the answer above and the file disagree until issue #47 lands the file this
+answer names, sets the licence this repository declares to the checks that read
+one, and takes `README.md` with it. What this repository declares is a separate
+thing from what the platform detects, and it is empty:
+
+    git grep -n 'const DeclaredLicence' origin/main \
+      -- internal/invariants/invariants.go
+    origin/main:internal/invariants/invariants.go:81:const DeclaredLicence = ""
+
+A reader arriving between this record and that change should trust neither the
+sidebar nor this record alone. The sidebar says which file is there, this record
+says what was decided, and the two agree only once #47 has landed.
+
+**Adding a licence does not place the commits that came before it under those
+terms.** Everything committed until that file lands arrived with no inbound
+terms at all, which is a fact about copyright rather than about this tree, and
+no file added at the root settles it afterwards. Repairing it is a question for
+whoever holds the copyright in those commits. It is written here because the
+alternative is a reader assuming the whole history is covered, and a reader who
+assumes that is exactly the reader who would rely on it.
+
+## What it applies to
+
+Everything this repository holds, from the commit the licence file lands on: the
+runner under `cmd/` and `internal/`, the experiment content under
+`experiments/`, and the documents and records under `docs/`.
+
+It applies to issue #47, which lands the file, the declaration and the line in
+`README.md`, and it is what that issue reads to know which licence it is
+landing.
+
+It applies to promotion. The licence a promotion section names under record
+`0005` is this one, unless what is being handed over is borrowed code under
+record `0019`, in which case it is that directory's own.
+
+It does not apply to borrowed code. Record `0019` puts code under another
+licence in a quarantined directory carrying its own licence file, and that is
+the one place in this tree where the answer above is not the answer.
+
+It does not apply to the commits made before the file lands, for the reason
+stated above. It also does not decide which licences may be borrowed from. Some
+of them are incompatible with a hand-over into a GPL board whatever directory
+the code sits in, and record `0019` says that is a separate question and does
+not answer it either.
+
+## What else was considered
+
+Apache-2.0.
+
+MIT.
+
+CC0 or a public-domain dedication.
+
+Leaving the repository unlicensed.
+
+## What each rejected option would have cost
+
+Apache-2.0 is permissive and carries an explicit patent grant, which matters
+more than it looks for work touching authentication and media handling. Under it
+a result could move into a GPL plugin board and also anywhere else. What it
+costs is that the flow only runs one way: code borrowed from one of those plugin
+boards cannot come back into an Apache-2.0 experiment without the experiment
+becoming GPL, and an experiment that starts from existing plugin code is a
+question this board expects to be asked. It buys reach in the direction this
+board rarely goes and charges for it in the direction it goes most.
+
+MIT has the same permissive shape as Apache-2.0, is shorter and is more widely
+understood, and what it costs beyond Apache-2.0 is exactly that patent grant. On
+work about authentication and media handling the grant is the part of
+Apache-2.0 worth having, so taking MIT over it pays the same one-way-flow cost
+and gets less for it.
+
+CC0 or a public-domain dedication removes the attribution obligation entirely,
+which suits a throwaway prototype and is the closest thing to no terms at all
+that still counts as terms. What it costs is that some organisations will not
+accept public-domain-dedicated code, because the dedication is not effective in
+every jurisdiction, so the option chosen to simplify the promotion path can
+block the promotion path instead. A cost that lands only sometimes, and only at
+the moment the work is wanted, is worse than one that lands predictably.
+
+Leaving the repository unlicensed costs everything the other options are being
+compared on, and it grows rather than holding steady. Default copyright applies,
+nobody has permission to reuse anything here, the sign-off gate asks
+contributors to certify their right to contribute under terms that do not exist,
+and every day it stays that way another contribution arrives with no inbound
+terms. It is also the only option on the list that is not a decision. It is what
+happens when nobody takes one.

--- a/docs/decisions/0020-consent-to-promote-under-other-terms.md
+++ b/docs/decisions/0020-consent-to-promote-under-other-terms.md
@@ -1,0 +1,129 @@
+# 0020. Consent to promote a result under another board's terms
+
+## What was decided
+
+A result may be promoted into a board under different terms from this one only
+with the contributor's explicit consent, given at promotion time.
+
+No contributor agreement in advance, and no restriction to work somebody
+authored themselves. Both of those are on the list below with what they would
+have cost.
+
+**This record names record `0005` and says what moved.** That record fixes
+promotion as a hand-over recorded on both sides, and it says the promotion
+section names four things and that nothing about it is optional. It also says
+that who is entitled to place a contributor's work under another board's terms
+is not decided there. This is that question answered, and the answer reaches the
+section: it names a fifth thing.
+
+It does not supersede record `0005`. Everything else that record fixes stands
+unchanged, and marking it superseded would tell a reader that the whole of it
+had been replaced when one paragraph of it has been added to. What that costs is
+real and is not softened here: read on its own, `0005`'s sentence that the
+section names four things is now wrong, and nothing in `0005` says so. What
+carries the correction is this record and a reader who finds it.
+
+**The consent is a line in the record rather than a conversation somebody
+remembers.** `Consent:` in the promotion section, naming who consented and the
+terms consented to. A hand-over that happened in a conversation is a
+hand-over nobody can check afterwards, and the question it gets asked in is the
+one nobody wants to be answering: whether a contributor agreed to their work
+going somewhere, months after the person who asked them has stopped thinking
+about it.
+
+**What reads it, stated as it stands rather than as it is meant to end up.**
+`promotion-section-is-missing-something` is the property that reads the
+promotion section and refuses one that does not name what record `0005` fixes:
+
+    git grep -n -o 'promotion-section-is-missing-something' origin/main \
+      -- internal/check/promotion.go
+    origin/main:internal/check/promotion.go:16:promotion-section-is-missing-something
+
+It names four things today and the consent line is not one of them, so **nothing
+in this repository refuses a promotion section that names no consent on the day
+this record lands.** What stands behind the rule until that changes is this
+record and whoever reads the change. Adding the line to the set that property
+reads is what turns the rule into a refusal, and it is a change to the record
+format, which goes through
+[0013-how-the-record-format-changes.md](0013-how-the-record-format-changes.md).
+
+That route decides the shape of the refusal, and it is worth reading before
+somebody writes one. Record `0013` makes an added field optional and
+refuses only what is present, so a refusal on an absent `Consent:` line is a
+refusal on an absence, which that record forbids. What is available instead is
+the shape the four fields already have: the promotion section is the optional
+thing, an experiment that was never handed over carries none and is not refused,
+and a section that is present is held to everything it has to name. No record on
+this board carries one today, so nothing turns red when the fifth name is added:
+
+    git grep -c '^## Promotion' origin/main -- 'experiments/*/EXPERIMENT.md'
+    exit=1
+
+That count is what makes the change free at the moment it lands, and it is a
+fact about today rather than a property of the design. A promotion section that
+lands before the refusal does and carries no consent line is what record `0013`
+says must not be reddened afterwards, and the repair then is a reader's rather
+than a check's.
+
+**The sign-off gate does not cover this, and nobody should read it as though it
+did.** Every non-merge commit here carries a `Signed-off-by` trailer matching
+its author, checked by the DCO workflow. What a contributor certifies there is
+their right to contribute the work under this project's licence. It says
+nothing about a different licence on a different board, it was not written to,
+and a hand-over that leaned on it would be resting a licensing question on a
+certificate about another one.
+
+**What the answer costs.** A step at promotion time is a step that will
+sometimes be skipped under time pressure, and promotion time is exactly when
+somebody is trying to get a result into the place that wants it. That is the
+known cost, it is the reason the consent is a written line rather than an
+understanding, and the line is not a control until something reads it. Both
+halves belong together: a residual stated with what holds it is honest, and a
+residual stated alone reads as an excuse.
+
+## What it applies to
+
+Every promotion out of this board into a repository whose terms differ from the
+licence record `0018` names, from the commit this record lands on.
+
+It applies to the promotion section record `0005` fixes, which gains the
+`Consent:` line, and to the record format, which gains it under record `0013`.
+
+It applies to whoever does the promoting rather than to the receiving board. A
+board takes work by its own rules, and nothing here obliges it to check what
+this record asks for.
+
+It does not apply to a promotion into a board under the same terms. There is
+nothing for a contributor to consent to when the code leaves under the licence
+it was written under, and asking anyway turns a real question into a formality
+that gets ticked.
+
+It does not apply to somebody copying an idea out of a record with no code
+moving, which record `0005` already says needs no section at all.
+
+## What else was considered
+
+A contributor agreement, signed in advance, covering promotion under other
+terms for everything that contributor ever writes here.
+
+Taking only work the promoter authored themselves, so consent is never needed
+from anybody else.
+
+## What each rejected option would have cost
+
+A contributor agreement puts a legal document in front of somebody who wanted to
+try an idea. That is a real deterrent, and it is heaviest on a board whose whole
+purpose is lowering the cost of trying: the person it turns away is the one who
+had a question and half an hour, which is the contributor this board is for. It
+also buys certainty at the wrong moment. The agreement is signed before anybody
+knows which board the work might go to or what terms it would go under, so what
+it collects is a permission granted in the abstract, and the cost of getting it
+is paid by every contributor including the ones whose work never leaves.
+
+Taking only self-authored work costs the board the thing the hand-over path
+exists for. The results worth promoting are not reliably the ones the promoter
+wrote, and under this option an experiment somebody else ran well enough to be
+wanted elsewhere is stuck here. It also has a failure mode worse than the
+restriction: the cheapest way around it is for the promoter to rewrite the work
+and hand over their own version, which produces a worse result, loses the
+original author's contribution, and does it quietly.

--- a/docs/decisions/0022-how-long-a-held-back-record-waits.md
+++ b/docs/decisions/0022-how-long-a-held-back-record-waits.md
@@ -1,0 +1,138 @@
+# 0022. How long a held-back record waits
+
+## What was decided
+
+A held-back record waits 90 days from the report. The window is published in the
+security policy. There is exactly one written extension, granted on a reasoned
+request.
+
+**This record names record `0010` and says what moved.** That record decides
+that an experiment whose question is whether shipped software can be made to
+misbehave does not start here in public, and that the record is written once the
+flaw is fixed and the affected project has said what it wants said. It says in
+its own words that how long such a record waits when neither of those arrives is
+not decided there, and that what the listing shows meanwhile is part of the same
+question and is also not decided there. Both halves are decided here. Nothing
+else in `0010` moves: which experiments do not start in public, where the
+question goes instead, and what has to be true before the record is written are
+unchanged, and this record does not supersede it.
+
+**Why a window rather than waiting.** Waiting indefinitely is safest for the
+people running the affected software, and it hands the schedule to whoever is
+slowest to reply. What it costs is a board carrying an unwritten record that
+nobody outside knows exists, which is the invisible half-finished state this
+board was opened to make impossible. A date is what turns a silence into
+something both sides can plan against.
+
+**Why one written extension rather than a bare window.** A date chosen in
+advance is sometimes wrong for the flaw in front of it, and publishing on
+schedule against a flaw still live in software this organisation ships is a
+thing to choose deliberately rather than to arrive at by default. The extension
+is written and reasoned so that the choice is visible afterwards, and it is one
+rather than any number, because a window that can be extended repeatedly is
+waiting indefinitely with extra paperwork.
+
+**What the extension costs, stated rather than presented as free.** It needs
+somebody here to answer the request inside the window. That is the same failure
+the window exists to handle, arriving one level up: a request that goes
+unanswered leaves the record at its original date, which is the better of the
+two outcomes and is not a decision anybody took in that moment.
+
+**What the listing shows while a record waits.** A field beside the state rather
+than a fourth state. The record stays in `asking`, and it carries `Held-back:`
+with the date of the report, which is what the 90 days are counted from. The
+listing prints that as its own dated line, saying that an experiment is held
+back and when the clock started, and saying nothing about what it is about. A
+date and the fact of a hold disclose that something exists. They disclose
+nothing a reader could act on, which is the whole point of holding it back.
+
+**What that costs record `0003` and the state refusal, which is where this
+answer is not free.** Record `0003` fixes three states and no others, and
+`record-state-is-not-one-of-the-three` refuses a fourth:
+
+    git grep -n -o 'record-state-is-not-one-of-the-three' origin/main \
+      -- internal/check/check.go
+    origin/main:internal/check/check.go:176:record-state-is-not-one-of-the-three
+
+Both stay exactly as they are, and that is the cost rather than the saving. The
+refusal guarantees that the state a record carries is one of three. It has never
+guaranteed what the listing prints, and after this record the listing prints a
+line that no refusal governs. A reader who took a green run for a guarantee that
+the listing shows one of three things was already wrong, and this is the change
+that makes them visibly wrong.
+
+The second half of the cost is the field itself. It is a field added to the
+record format after record `0013` landed, so it is optional and a check over it
+refuses only what is present. A record that is being held back and does not
+carry the field is not refused: it sits in `asking` with a question that says
+nothing, which is exactly the misreport this half of the answer exists to
+prevent. **Nothing in this repository refuses that today, and nothing can under
+record `0013`.** What stands behind it is the template, the review, and whoever
+writes the record.
+
+**The 90 days has to reach `SECURITY.md`, and it is not there today.** That file
+is where the window is published, and this record is not that publication. It
+also carries a sentence that a reader will meet first and could take for a
+contradiction:
+
+    git show origin/main:SECURITY.md | grep -n 'no response deadline'
+    139:There is no response deadline and there will not be one. Nothing holds me to a
+
+The two run in opposite directions and both stand. That sentence is about a
+report arriving here and how long a reporter waits for an answer from this
+board. This record is about a report leaving here and how long this board waits
+before publishing what it found in somebody else's software. A window on what
+this board owes others is not a promise about what others may expect from it.
+
+## What it applies to
+
+Every experiment record held back under record `0010`, from the commit this
+record lands on: the 90 days, the single extension, and the `Held-back:` line
+that makes the hold visible in the listing.
+
+It applies to `SECURITY.md`, which is where the window is published and where a
+reporter and an affected project read it.
+
+It applies to the record format, which gains the field under record `0013`, and
+to whatever check reads that field, in the direction of what is present only.
+
+It does not apply to record `0003`. The three states stay three, and a held-back
+experiment is in `asking` like any other experiment whose work has not finished.
+
+It does not apply to the questions record `0010` answers. Which experiments do
+not start here in public, where the question goes instead, and what has to be
+true before a record is written are that record's and are unchanged by this one.
+
+It does not apply where an affected project publishes its own disclosure policy
+and this board has reported into it. The two windows are separate promises, and
+the earlier date is the one that binds this board.
+
+## What else was considered
+
+Waiting indefinitely, so the record is written when the fix and the statement
+arrive and never before.
+
+A fixed window with no extension, counted from the report and published in the
+security policy.
+
+## What each rejected option would have cost
+
+Waiting indefinitely costs this board the thing it was opened for. An experiment
+that found something real would sit in a state nobody outside can see, for as
+long as whoever is slowest to reply takes, and the schedule would belong to them
+rather than to anybody who took a decision. It is also the option that decays
+quietly: nothing marks the day it became unreasonable, so the record is not
+published late, it is simply never published, and the board reads as though the
+experiment never happened. That is the invisible half-finished state every other
+rule here exists to prevent, arriving through the one door left open for a good
+reason.
+
+A fixed window with no extension costs the case the window is worst at. A date
+chosen 90 days in advance is a guess about a flaw nobody had looked at yet, and
+the case where it is wrong is the case where publishing on schedule puts a live
+flaw in software this organisation ships in front of everybody who might use it.
+Under that option the only ways out are publishing anyway or breaking the rule,
+and a rule broken once for a good reason is a rule everybody afterwards knows
+can be broken. The extension costs an answer inside the window, which is a real
+cost and is written above. What it buys is that the exception is taken in
+writing rather than taken silently.

--- a/docs/decisions/0024-who-may-run-an-experiment-here.md
+++ b/docs/decisions/0024-who-may-run-an-experiment-here.md
@@ -1,0 +1,135 @@
+# 0024. Who may run an experiment here
+
+## What was decided
+
+This board takes experiments from anybody.
+
+That is what a public board usually means, and it is the only way this one
+becomes useful to anybody who is not already here. The whole apparatus was built
+for it before it was decided: a sign-off gate that asks somebody to certify
+their right to contribute, an issue template that invites a proposal, and a
+contributing guide written for a person arriving with an idea. None of those
+settled the question, and each of them reads as a promise until it is settled.
+
+**The residual is the part of this answer that has to survive into the record.**
+The cost is not review effort. Review effort is ordinary, it scales with what
+arrives, and nobody was ever going to decide this question on it. The cost is
+that three rules on this board depend on a person having read them before they
+start, and somebody arriving for the first time is exactly the person least
+likely to have read any of them.
+
+**The three rules, named rather than gestured at.**
+
+What may never be committed. The list is in
+[0006-everything-here-is-public.md](0006-everything-here-is-public.md) and again
+under `## What may never be committed` in `CONTRIBUTING.md`: no credential, no
+personal data, no copy of a real library or real logs, no file whose licence
+forbids it being here. Git history does not forget, so a mistake here is handled
+as an exposure rather than as a revert.
+
+What happens when an experiment finds a flaw in shipped software. That is
+[0010-a-flaw-in-shipped-software.md](0010-a-flaw-in-shipped-software.md), and
+what it asks of somebody is that they recognise the moment before they write
+anything down in public. It is the rule most likely to be met by accident, by
+somebody asking a different question who finds something.
+
+What an experiment may do with real data. `docs/privacy.md` carries what is
+settled and says plainly that whether an experiment here may touch real personal
+data at all is not settled there. So the third rule a newcomer must have read is
+one this board has not finished writing, which is a worse position than the
+other two rather than a lesser one: a person cannot follow a rule that does not
+exist, and the part of it that does exist is the part in the list above.
+
+**Nothing here refuses a violation of any of the three, and this record does not
+soften that.** The guide says so at the list itself:
+
+    git show origin/main:CONTRIBUTING.md | grep -n 'refuses a violation'
+    141:Nothing in this repository refuses a violation of that list today. What stands
+
+The nearest thing to a mechanism is the credential-shape scan over tracked text,
+and its own source says what it is worth before anybody quotes it as cover:
+
+    git grep -n -o 'FLOOR AND NOT A GUARANTEE' origin/main \
+      -- internal/invariants/vocabulary.go
+    origin/main:internal/invariants/vocabulary.go:22:FLOOR AND NOT A GUARANTEE
+
+It matches formats that have actually leaked. It does not read entropy, it does
+not see anything base64-wrapped or split across lines, and a password and a name
+have no shape at all. Personal data, a copy of a real library and a licence that
+forbids a file being here are outside it entirely, and the first two are what
+this rule is mostly about. For the other two rules there is nothing at all:
+whether a question is about a flaw in shipped software, and what an experiment
+did on a host that is not this tree, are not properties of a checkout, and no
+reading of one decides them.
+
+So the residual sits on whoever reads the change, and the first two rules are
+the ones where a mistake is public and permanent. That is what taking
+experiments from anybody costs, and it is written here rather than left in the
+issue that is closed when this record lands.
+
+**The answer belongs in the first paragraph of `CONTRIBUTING.md`, with the three
+rules linked from it.** The first paragraph, because the alternative is somebody
+finding out after doing the work, and linked from that paragraph, because the
+person least likely to have read the three rules should meet them where they
+arrive rather than a hundred lines further down. That guide is on the default
+branch already and carries none of this today, so what this record fixes is
+where the sentence goes and the edit that puts it there is owed:
+
+    git show origin/main:CONTRIBUTING.md | sed -n '3,8p' | head -1
+    This board is for questions that will probably fail. Everything here is public
+
+## What it applies to
+
+Who may open an issue, propose an experiment and send a change here, from the
+commit this record lands on. The answer is anybody.
+
+It applies to `CONTRIBUTING.md`, whose first paragraph carries the answer and
+links the three rules.
+
+It applies to the templates under `.github/ISSUE_TEMPLATE/`, which invite a
+proposal and are written for the audience this answer says exists.
+
+It applies to the sign-off gate, which asks a contributor to certify their right
+to contribute under this project's licence, and which now has contributors to
+ask.
+
+It applies to record `0020`. Consent to promote a result under another board's
+terms only becomes a question once somebody other than the promoter has written
+something here, and this is the answer that makes it one.
+
+It does not decide what this board does with what arrives. A proposal can be
+declined, an experiment can be asked to state its question better, and a change
+can be rejected. Taking experiments from anybody is about who may offer, and
+nothing here obliges this board to take any particular thing.
+
+It does not settle the third rule. What an experiment may do with real data is
+open, `docs/privacy.md` says where the answer comes from, and this record does
+not answer it by needing it.
+
+## What else was considered
+
+Taking no outside experiments, and saying so.
+
+Taking proposals as issues rather than as changes, so a question is discussed
+before anybody writes code against it.
+
+## What each rejected option would have cost
+
+Taking none costs the board its reach, which is most of what a public board is
+for, and it buys a much smaller surface: the three rules above would then be
+read only by people who already know them. The cost that decides it is what
+happens to everything already built. The contributing guide, the issue templates
+and the sign-off gate are all written for a person arriving from outside, and
+under this option every one of them is furniture for an audience that does not
+exist. A repository that reads as open while accepting nothing wastes the time
+of whoever believes it, and it wastes it after they have done the work.
+
+Taking proposals as issues rather than as changes looks like the careful middle
+and costs the cheapest thing this board offers. Trying something is the whole
+proposition here, and under this option trying something first becomes a request
+that somebody has to answer. The person with a question and an afternoon is the
+contributor this board is for, and a queue between them and the work is a queue
+they will not join. It also moves the residual rather than reducing it: the
+three rules still have to be read before anybody runs anything, and a discussion
+in an issue is not a mechanism that refuses a violation any more than the guide
+is.


### PR DESCRIPTION
Closes #179
Closes #181
Closes #183
Closes #185

Four answers from #46 written down where a decision lives. Four records
under `docs/decisions/` and nothing else, which is why they share one
branch: each separate landing moves the mainline under the others, and
these four touch no file any of them shares.

## What this changes

`0018-the-licence-of-this-board.md`, for #179. GPL-3.0, and one licence for
both the runner and the experiment content. The reason is the direction a
result actually moves: the twelve plugin boards of this organisation all
carry GPL-3.0, so a hand-over under record `0005` names terms the receiving
board already has, and three other boards carry AGPL-3.0, which is why the
record calls this a choice between two neighbourhoods rather than a house
style. It carries the cost in the permissive direction, lists the four
options entry one names with what each would have cost, and says three
things a reader would otherwise assume: that the file at the root is
AGPL-3.0 today so the answer and the file disagree until #47 lands, that
what this repository declares to the checks is empty and is a different
thing from what the platform detects, and that adding a licence does not
place the commits made before it under those terms.

`0020-consent-to-promote-under-other-terms.md`, for #181. A result may be
promoted into a board under different terms only with the contributor's
explicit consent, given at promotion time, written as a `Consent:` line in
the promotion section. The record names record `0005` and says what moved,
and it does not supersede it, because everything else `0005` fixes stands
and a supersession line would tell a reader the whole of it had been
replaced. What that costs is written rather than left to be found: `0005`'s
sentence that the section names four things is wrong read on its own, and
nothing in `0005` says so. It states that the sign-off gate does not cover
this, and that a step at promotion time is a step that will sometimes be
skipped.

`0022-how-long-a-held-back-record-waits.md`, for #183. Ninety days from the
report, published in the security policy, with exactly one written
extension on a reasoned request. It names record `0010` and says what
moved. The design question it had to settle is settled as a field beside
the state rather than as a fourth state: the record stays in `asking` and
carries a `Held-back:` date, and the listing prints that as its own dated
line.

`0024-who-may-run-an-experiment-here.md`, for #185. This board takes
experiments from anybody. It names the three rules a newcomer must have
read, says the answer belongs in the first paragraph of `CONTRIBUTING.md`
with those three linked from it, and lists both rejected options with what
each would have cost.

Means: Markdown under `docs/decisions/`, which is the form record `0000`
fixes for a decision record and the one three checks already read. It adds
no language, no runtime and no dependency, and `decision-record-is-missing-a-section`,
`two-decision-records-share-a-number` and
`supersession-names-a-record-that-is-not-there` judge these four exactly as
they judge the twenty-one already there.

## What failure it prevents

A decision that exists only in an issue. Record `0000` says it plainly: the
record is what survives the argument, and a decision that lives in a
tracker thread has no current state, reads as three decisions where it was
revised twice, and loses its source the day the tracker moves. Four answers
were taken on 2026-08-24 and four issues were opened to write them down;
until they are written down the plan depends on four sentences in a closed
issue.

The second failure is narrower and is the reason each record is longer than
its answer. Every one of these four answers has a cost that lands on
somebody who did not take it, and a record that carries the answer without
the cost reads as though the answer were free. The permissive direction
closing, a consent step that will be skipped under pressure, an extension
request nobody answers, and three unenforced rules a newcomer has to have
read are each written at the answer they belong to.

## What was run

At `29bd767ca5881079b0c81c8af9d5f190b01dd1f0`, the commands `CONTRIBUTING.md`
names, from the root of the checkout:

```
$ go build ./cmd/... ./internal/...

$ go vet ./cmd/... ./internal/...

$ gofmt -l cmd internal

$ go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
25 decision records read
the time this run read is 2026-08-26T01:17:01Z
0 refused

$ go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	6.284s
ok  	github.com/Flowfin/lab/cmd/lab	13.657s
ok  	github.com/Flowfin/lab/cmd/notices	65.059s
ok  	github.com/Flowfin/lab/cmd/pullrequest	5.547s
ok  	github.com/Flowfin/lab/internal/check	5.803s
ok  	github.com/Flowfin/lab/internal/contexts	5.522s
ok  	github.com/Flowfin/lab/internal/hardware	5.539s
ok  	github.com/Flowfin/lab/internal/invariants	5.869s
ok  	github.com/Flowfin/lab/internal/notices	4.810s
ok  	github.com/Flowfin/lab/internal/prose	4.852s
ok  	github.com/Flowfin/lab/internal/pullrequest	4.870s
```

The prose format is the check most likely to be moved by four new
documents, so it was read rather than assumed:

```
$ go test ./internal/prose -run TestThisRepositorySatisfiesTheProseFormat -count=1 -v
        39 prose files read, and testdata is not read
--- PASS: TestThisRepositorySatisfiesTheProseFormat (0.00s)
```

Every command each record pastes was run before the sentence resting on it
was written, and two pastes were corrected against what the command
returned rather than against what was expected. The licence readings were
taken one repository at a time through `gh api repos/Flowfin/<name> --jq
'.license.spdx_id'`, which is the reading behind the twelve and the three;
the loop the record hands a reader derives the same population and was not
the command that produced those numbers.

This change removes no tracked path.

## What this does not do

None of the four records is a mechanism, and each says so where it matters.
`0020` says nothing refuses a promotion section that names no consent
today, and that the route that would change it is record `0013`, which also
forbids the shape a reader would reach for first. `0022` says the field it
introduces is optional under `0013`, so a held-back record that omits it is
not refused and sits in `asking` saying nothing, and that record `0003` and
`record-state-is-not-one-of-the-three` stay exactly as they are, so the
listing prints a line no refusal governs. `0024` says nothing refuses a
violation of any of the three rules it names, and lists what the
credential-shape scan cannot see rather than leaving the scan to be read as
cover.

Two edits these records say are owed are not in this change, and neither is
in the done-condition of the issue that asks for the record. The ninety days
has to reach `SECURITY.md`, and it is not there. The answer to entry eight
has to reach the first paragraph of `CONTRIBUTING.md` with the three rules
linked from it, and that paragraph carries none of it. Both are named in the
records as owed and each needs its own issue.

`0018` does not change the licence file. The root of this branch still
carries AGPL-3.0 and the platform still reports it; #47 is what lands the
file, the declaration and the line in `README.md`, and until it does the
record and the file disagree.

This board has no second reader tonight. What stands in place of one is the
evidence above: every record is judged by the three decision-record
refusals in the run quoted, the prose format was read at the pushed commit,
and every command pasted inside the records reproduces at `origin/main`.
