### PR TITLE
Land the licence entry one names

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-                    GNU AFFERO GENERAL PUBLIC LICENSE
-                       Version 3, 19 November 2007
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
@@ -7,15 +7,17 @@
 
                             Preamble
 
-  The GNU Affero General Public License is a free, copyleft license for
-software and other kinds of works, specifically designed to ensure
-cooperation with the community in the case of network server software.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
 
   The licenses for most software and other practical works are designed
 to take away your freedom to share and change the works.  By contrast,
-our General Public Licenses are intended to guarantee your freedom to
+the GNU General Public License is intended to guarantee your freedom to
 share and change all versions of a program--to make sure it remains free
-software for all its users.
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
 
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
@@ -24,34 +26,44 @@ them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
 free programs, and that you know you can do these things.
 
-  Developers that use our General Public Licenses protect your rights
-with two steps: (1) assert copyright on the software, and (2) offer
-you this License which gives you legal permission to copy, distribute
-and/or modify the software.
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
 
-  A secondary benefit of defending all users' freedom is that
-improvements made in alternate versions of the program, if they
-receive widespread use, become available for other developers to
-incorporate.  Many developers of free software are heartened and
-encouraged by the resulting cooperation.  However, in the case of
-software used on network servers, this result may fail to come about.
-The GNU General Public License permits making a modified version and
-letting the public access it on a server without ever releasing its
-source code to the public.
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
 
-  The GNU Affero General Public License is designed specifically to
-ensure that, in such cases, the modified source code becomes available
-to the community.  It requires the operator of a network server to
-provide the source code of the modified version running there to the
-users of that server.  Therefore, public use of a modified version, on
-a publicly accessible server, gives the public access to the source
-code of the modified version.
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
 
-  An older license, called the Affero General Public License and
-published by Affero, was designed to accomplish similar goals.  This is
-a different license, not a version of the Affero GPL, but Affero has
-released a new version of the Affero GPL which permits relicensing under
-this license.
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
@@ -60,7 +72,7 @@ modification follow.
 
   0. Definitions.
 
-  "This License" refers to version 3 of the GNU Affero General Public License.
+  "This License" refers to version 3 of the GNU General Public License.
 
   "Copyright" also means copyright-like laws that apply to other kinds of
 works, such as semiconductor masks.
@@ -537,45 +549,35 @@ to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
 License would be to refrain entirely from conveying the Program.
 
-  13. Remote Network Interaction; Use with the GNU General Public License.
-
-  Notwithstanding any other provision of this License, if you modify the
-Program, your modified version must prominently offer all users
-interacting with it remotely through a computer network (if your version
-supports such interaction) an opportunity to receive the Corresponding
-Source of your version by providing access to the Corresponding Source
-from a network server at no charge, through some standard or customary
-means of facilitating copying of software.  This Corresponding Source
-shall include the Corresponding Source for any work covered by version 3
-of the GNU General Public License that is incorporated pursuant to the
-following paragraph.
+  13. Use with the GNU Affero General Public License.
 
   Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
-under version 3 of the GNU General Public License into a single
+under version 3 of the GNU Affero General Public License into a single
 combined work, and to convey the resulting work.  The terms of this
 License will continue to apply to the part which is the covered work,
-but the work with which it is combined will remain governed by version
-3 of the GNU General Public License.
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
 
   14. Revised Versions of this License.
 
   The Free Software Foundation may publish revised and/or new versions of
-the GNU Affero General Public License from time to time.  Such new versions
-will be similar in spirit to the present version, but may differ in detail to
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
   Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU Affero General
+Program specifies that a certain numbered version of the GNU General
 Public License "or any later version" applies to it, you have the
 option of following the terms and conditions either of that numbered
 version or of any later version published by the Free Software
 Foundation.  If the Program does not specify a version number of the
-GNU Affero General Public License, you may choose any version ever published
+GNU General Public License, you may choose any version ever published
 by the Free Software Foundation.
 
   If the Program specifies that a proxy can decide which future
-versions of the GNU Affero General Public License can be used, that proxy's
+versions of the GNU General Public License can be used, that proxy's
 public statement of acceptance of a version permanently authorizes you
 to choose that version for the Program.
 
@@ -633,29 +635,40 @@ the "copyright" line and a pointer to where the full notice is found.
     Copyright (C) 2026  Nils Lehnen
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
+    it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+    GNU General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
+    You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-  If your software can interact with users remotely through a computer
-network, you should also make sure that it provides a way for users to
-get its source.  For example, if your program is a web application, its
-interface could display a "Source" link that leads users to an archive
-of the code.  There are many ways you could offer source, and different
-solutions will be better for different programs; see section 13 for the
-specific requirements.
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
 
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU AGPL, see
+For more information on this, and how to apply and follow the GNU GPL, see
 <https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@ does not cover.
 
 ## License
 
-AGPL-3.0, copyright 2026 Nils Lehnen.
+GPL-3.0, copyright 2026 Nils Lehnen.
 
 The full text is in [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -123,9 +123,9 @@ A refusal you disagree with is not a vulnerability, and neither is a check that
 is too strict about a legitimate tree, nor a supply-chain score lower than you
 expected, which `docs/supply-chain.md` already triages check by check. Those
 are issues and they are welcome as issues. Nor is anything about the licence.
-[LICENSE](LICENSE) at the root carries the GNU Affero General Public License
-version 3, and what this repository declares to the checks that read a licence
-is still empty and open on issue #47. Both of those are legal or housekeeping
+[LICENSE](LICENSE) at the root carries the GNU General Public License version
+3, which is the answer record 0018 writes down, and it is what this repository
+declares to the checks that read a licence. Both of those are legal or housekeeping
 questions rather than security ones.
 
 ## What a reporter gets

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -201,11 +201,12 @@ is already on. Only the measurement is written down. Nothing here uploads,
 phones home, or reports usage, and there is no telemetry to turn off because
 there is none to turn on.
 
-[LICENSE](../LICENSE) at the root of the checkout is the GNU Affero General
-Public License version 3, and those are the terms this tree carries. What is
-still open is the licence this repository declares to its own checks, which is
-empty on issue #47, so a run here that says nothing about the licence is not
-saying the file is absent.
+[LICENSE](../LICENSE) at the root of the checkout is the GNU General Public
+License version 3, and those are the terms this tree carries. The licence this
+repository declares to its own checks is the same one, so a run here reports
+what it compared the file against rather than reporting that it was not asked.
+[docs/decisions/0018-the-licence-of-this-board.md](decisions/0018-the-licence-of-this-board.md)
+is where the answer and what it costs are written down.
 
 ## The record format may change
 

--- a/docs/promotion.md
+++ b/docs/promotion.md
@@ -33,10 +33,11 @@ whether the result holds for their case, and the fastest way to answer that is
 the list of cases it was never put to.
 
 The licence the code carries out. [LICENSE](../LICENSE) at the root of this
-board is the GNU Affero General Public License version 3, so that is what the
-code carries out and the receiving side inherits terms rather than finding
-none. Which licence this repository declares to the checks that read one is a
-separate thing and is open on issue #47. Entry three of issue #46 asks who may
+board is the GNU General Public License version 3, so that is what the code
+carries out and the receiving side inherits terms rather than finding none.
+This repository declares the same licence to the checks that read one, and
+[docs/decisions/0018-the-licence-of-this-board.md](docs/decisions/0018-the-licence-of-this-board.md)
+is the answer both of them come from. Entry three of issue #46 asks who may
 place a contributor's work under another board's terms and carries no answer,
 so a hand-over of somebody else's work still cannot be completed, and writing
 anything else into this line would be inventing permission nobody gave.

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -166,11 +166,15 @@ untrusted. Reopen this line when #61 lands rather than before.
 
 `license file not detected`, with `Warn: project does not have a license file`
 
-Correct for the run above, and the tree has moved since. `LICENSE` is at the
-root of the default branch carrying the GNU Affero General Public License
-version 3, restored in `36442adad2d9dc66032cf3d29ab070697650db5c` and merged as
-`bb0de9cbcc79015054e3da10cef44a8ae3669b01`, so the reasoning that stood here,
-that default copyright applies and nobody may reuse anything, no longer follows.
+Correct for the run above, and the tree has moved twice since. `LICENSE` is at
+the root of the default branch carrying the GNU General Public License version
+3, which is the answer record 0018 writes down. What stood there before it was
+the GNU Affero General Public License version 3, restored in
+`36442adad2d9dc66032cf3d29ab070697650db5c` and merged as
+`bb0de9cbcc79015054e3da10cef44a8ae3669b01` and replaced by the change that
+answered the licence question. Under either of them the reasoning that stood
+here, that default copyright applies and nobody may reuse anything, no longer
+follows.
 The audit has not been re-run for this document and the score above is left as
 the run reported it. What the platform holds today is a different reading and is
 one command:
@@ -181,8 +185,11 @@ gh api 'repos/Flowfin/lab/code-scanning/alerts?tool_name=Scorecard&per_page=100'
 fixed
 ```
 
-What the file being there does not settle is the licence this repository
-declares to its own checks, which is empty and open on issue #47.
+What the file being there does not settle is whether its bytes are the
+canonical text of the licence they claim to be. The licence this repository
+declares to its own checks is set and is compared against the file, and that
+comparison asks whether the file names the declared licence rather than whether
+the text is canonical.
 
 ### Maintained, 0
 

--- a/internal/invariants/invariants.go
+++ b/internal/invariants/invariants.go
@@ -70,15 +70,26 @@ const (
 	gitDir = ".git"
 )
 
-// DeclaredLicence is the licence this repository has decided on, and it is
-// empty because that question is open. Entry one of the maintainer question
-// issue holds it, issue #47 lands the file and the decision record once it is
-// answered, and setting this string is the last line of that change.
+// DeclaredLicence is the licence this repository has decided on. Record 0018
+// answers entry one of the maintainer question issue with GPL-3.0, one licence
+// for the runner and the experiment content alike, and issue #47 is the change
+// that lands the file and sets this string.
 //
-// While it is empty the licence leg reports that it was not asked rather than
-// passing, so a run that could not check the licence is never read as one that
-// checked and was satisfied.
-const DeclaredLicence = ""
+// IT IS SPELLED AS THE TITLE LINE RATHER THAN AS THE SPDX IDENTIFIER, and that
+// is forced by what the leg below asks. The leg asks whether the licence file
+// NAMES the declared licence, and the canonical text of this licence never
+// writes an SPDX identifier anywhere in it, so a constant reading GPL-3.0
+// would refuse the very file it is about. The identifier is what the platform
+// reports and what README.md says; this is what the bytes at the root carry.
+//
+// WHAT IT SEPARATES AND WHAT IT DOES NOT. It separates this licence from the
+// GNU Affero General Public License, which this repository carried until the
+// change that set this string and whose text never writes this title. It does
+// not separate version 3 from version 2, because both carry the same title,
+// and no reading of the file below closes that gap while the comparison is a
+// substring. What guards the version is whoever lands the file taking it from
+// its canonical source, which is issue #47's sentence rather than this one.
+const DeclaredLicence = "GNU GENERAL PUBLIC LICENSE"
 
 // The properties this package can refuse. A property is the rule, named once
 // here and nowhere else, so a case declaring what it expects and a refusal the


### PR DESCRIPTION
Closes #47

## What this changes

`LICENSE` at the root is the GNU General Public License version 3, which is the
answer record `0018` writes down for entry one of #46. The text was fetched from
the Free Software Foundation rather than retyped, and the only departure from it
is the two lines of the appendix boilerplate the licence itself asks an author
to fill in:

```
$ curl -sS -o gpl-3.0.txt https://www.gnu.org/licenses/gpl-3.0.txt
$ diff gpl-3.0.txt LICENSE
634,635c634,635
<     <one line to give the program's name and a brief idea of what it does.>
<     Copyright (C) <year>  <name of author>
---
>     lab, experiments around Flowfin that do not have to finish.
>     Copyright (C) 2026  Nils Lehnen
```

Those two lines are the same two the file this replaces carried, so the
program name and the copyright line are unchanged by this. The conditional
interactive notice further down keeps the canonical placeholders, because that
notice is for a program that does terminal interaction in an interactive mode
and this runner does not, and filling it in would be asserting something that is
not true of what is here.

`DeclaredLicence` is set, and it is spelled as the title line rather than as the
SPDX identifier. That is forced rather than chosen: the leg asks whether the
licence file NAMES the declared licence, and the canonical text never writes an
SPDX identifier anywhere in it, so a constant reading `GPL-3.0` would refuse the
very file it is about. The identifier is what the platform reports and what
`README.md` says; the constant is what the bytes at the root carry, and the
comment above it now says so along with what the spelling separates and what it
does not.

Five documents said this tree carried the Affero licence and would have been
false the moment this landed, so they move in the same change rather than after
it: `README.md`, `SECURITY.md`, `docs/operator-guide.md`, `docs/promotion.md`
and `docs/supply-chain.md`. Four of them also carried a sentence saying the
declared licence was still empty and open on this issue, and that half is
answered rather than deleted. The supply-chain paragraph keeps the commits that
restored the earlier file, because that history is true and is not what this
change corrects.

Means: the canonical licence text as bytes at the root, which is the form the
platform and every downstream reader parse, plus one Go constant in the package
that already reads that file. It adds no language, no runtime and no dependency,
and both the leg that judges the file and the fixtures that prove the leg bites
already exist.

## What failure it prevents

A public repository whose terms nobody can rely on. Until this lands the tree
carries one licence, the decision record names another, and the check that would
notice reports that it was not asked. Any of the three read alone gives a
confident and different answer, and the reader who is hurt by that is the one
deciding whether they may reuse something.

It also ends the state the licence leg was built to make visible. A run that
could not check the licence printed `NOT ASKED` and passed, which is the honest
version of a gap and is still a gap: nothing compared the file at the root
against anything at all. After this the leg examines one subject and a wrong
file is a red run.

## What was run

At `d5bc879d7808b4b72212ee31118ed08e1cf0173e`, from the root of the checkout:

```
$ go build ./cmd/... ./internal/...

$ go vet ./cmd/... ./internal/...

$ gofmt -l cmd internal

$ go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
25 decision records read
the time this run read is 2026-08-26T02:17:37Z
0 refused

$ go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	1.872s
ok  	github.com/Flowfin/lab/cmd/lab	21.712s
ok  	github.com/Flowfin/lab/cmd/notices	121.923s
ok  	github.com/Flowfin/lab/cmd/pullrequest	2.476s
ok  	github.com/Flowfin/lab/internal/check	2.720s
ok  	github.com/Flowfin/lab/internal/contexts	2.451s
ok  	github.com/Flowfin/lab/internal/hardware	2.504s
ok  	github.com/Flowfin/lab/internal/invariants	3.525s
ok  	github.com/Flowfin/lab/internal/notices	2.461s
ok  	github.com/Flowfin/lab/internal/prose	2.483s
ok  	github.com/Flowfin/lab/internal/pullrequest	2.483s
```

The leg this change exists to move, asked rather than assumed:

```
$ go test ./internal/invariants -count=1 -v -run TestTheLicenceLegSaysWhetherItWasAsked
=== RUN   TestTheLicenceLegSaysWhetherItWasAsked
--- PASS: TestTheLicenceLegSaysWhetherItWasAsked (0.14s)
ok  	github.com/Flowfin/lab/internal/invariants	3.615s
```

That test requires the opposite thing depending on whether a licence is
declared, so it passing here is not the same assertion it was passing before.
With the constant set, the run reports `the licence: 1 examined` instead of the
`NOT ASKED` line it printed on the default branch.

**The guard was proved by breaking it, on the near miss somebody would actually
make.** With the new declaration in place and the previous `LICENSE` blob put
back in the working tree:

```
$ git show origin/main:LICENSE > LICENSE
$ go test ./internal/invariants -count=1 -run TestThisRepositorySatisfiesTheInvariants
--- FAIL: TestThisRepositorySatisfiesTheInvariants (0.15s)
          the licence: 1 examined
          ..\..\LICENSE: this repository declares GNU GENERAL PUBLIC LICENSE and the file never names it (licence-file-does-not-match-the-declared-licence)
FAIL	github.com/Flowfin/lab/internal/invariants	3.001s
```

The file this change lands makes the same run green. That is the one-character
version of this mistake: declaring the answer and forgetting the file, or
landing the file and leaving the old one in place.

This change removes no tracked path.

## What this does not do

**The repository metadata still reports the old licence at the moment this is
written, and that is not something this branch can move.** The platform derives
that field from the bytes it finds at the root of the DEFAULT branch, so it
reads the file this pull request replaces until the merge:

```
$ gh api repos/Flowfin/lab --jq '.license.spdx_id'
AGPL-3.0
```

The done-condition on #47 asks that the metadata report the chosen licence. It
is a detection rather than a declaration anybody sets, so it is read after the
merge rather than claimed here, and if it does not move the issue is not
finished by this change.

The declaration does not separate version 3 of this licence from version 2. Both
carry the same title, the comparison is a substring, and no reading of the file
closes that while it stays one. What guards the version is that the text was
taken from its canonical source, which is a sentence in the issue rather than a
check, and the comment at the constant says so rather than leaving a reader to
assume the leg is stronger than it is.

It does not place the commits made before it under these terms. Everything
committed until now arrived with no inbound terms at all. Record `0018` says so
and this file does not change it.

It does not touch `docs/decisions/0018-the-licence-of-this-board.md`, whose
paragraph on the disagreement between the answer and the file is written as the
state before this change and names this issue as what ends it. It also leaves
the sentence in `docs/promotion.md` that says entry three of #46 carries no
answer, which record `0020` has since answered. That sentence is stale for a
different reason than this change, it is a different topic, and it is not folded
in here.

This board has no second reader tonight. What stands in place of one is the diff
against the canonical text quoted above, the deliberate breaking of the guard,
and the full suite at the pushed commit.
