### PR TITLE
Publish the held-back window where a reporter reads it

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -104,6 +104,28 @@ while asking a different question, which is the common case. The work stops and
 the report goes to them. What comes back here afterwards is the record, once
 the flaw is fixed and the affected project has said what it wants said.
 
+How long that record waits is 90 days from the report, and it is published at
+the end of them whether or not the fix and the statement have arrived. Waiting
+on those two indefinitely would hand the schedule to whoever is slowest to
+reply, and it would leave this board holding a record of a real finding that
+nobody outside knows exists. There is exactly one extension, granted on a
+reasoned request and written down, because a date fixed 90 days before anybody
+had looked at the flaw is sometimes the wrong date for it, and moving that date
+should be a choice somebody took rather than a slip. The reasoning, and what
+each rejected option would have cost, is in
+[decision record 0022](docs/decisions/0022-how-long-a-held-back-record-waits.md)
+and is not restated here. Where the affected project publishes its own
+disclosure policy and this board has reported into it, the earlier of the two
+dates is the one that binds here.
+
+That window is not a deadline anybody reporting to this board gets, and it is
+not the sentence under "What a reporter gets" below saying there is no response
+deadline. The two run in opposite directions and both stand. That one is about a
+report arriving here, and how long a reporter waits for an answer from me. The
+90 days are about a report leaving here, and how long this board holds back its
+own record of a flaw it found in somebody else's software. A window on what this
+board owes others is not a promise about what others may expect from it.
+
 A problem in Jellyfin itself belongs to
 [the Jellyfin project](https://github.com/jellyfin/jellyfin/security/policy). A
 report that lands here instead is pointed the right way rather than closed.


### PR DESCRIPTION
Closes #194

## What this changes

`SECURITY.md` gains two paragraphs in the section "An experiment that finds a
flaw in software somebody runs", immediately after the sentence saying what
comes back here once the flaw is fixed and the affected project has said what it
wants said.

The first states the window: 90 days from the report, published at the end of
them whether or not the fix and the statement have arrived, with exactly one
extension granted on a reasoned request and written down. It links
`docs/decisions/0022-how-long-a-held-back-record-waits.md` for the reasoning and
the rejected options rather than restating either, and it carries the one clause
of record `0022` a reporter cannot infer from the window alone: where the
affected project publishes its own disclosure policy and this board has reported
into it, the earlier of the two dates binds here.

The second separates that window from the sentence already standing further down
under "What a reporter gets", which says there is no response deadline and there
will not be one. Both sentences stand and they run in opposite directions: one
is about a report arriving here, the other about a report leaving here.

No path leaves the tree in this change. It adds 22 lines to one file and removes
nothing:

```
git diff --name-status origin/main...HEAD
M	SECURITY.md
```

The section is where these paragraphs go because record `0010` already stands
there and the window is the continuation of that rule. Putting them under "What
a reporter gets" instead would have placed a window on what this board owes
others inside the section describing what others may expect from this board,
which is the confusion the second paragraph exists to prevent.

## What failure it prevents

A reporter or an affected project being unable to read the date this board is
holding itself to. Record `0022` decides the window and names `SECURITY.md` as
where it is published; until this change it existed only in the decision record,
which is not a file either of them opens. A window nobody outside can read is
not something either side can plan against, and the silence around it is what
the record was written to end.

The second paragraph prevents a different failure, in the reader rather than in
the process. `SECURITY.md` says there is no response deadline. Adding a 90-day
window without saying which report each sentence is about leaves a file that
reads as contradicting itself, and a reader who has to guess which sentence
governs will guess the one that suits them.

## What was run

At the commit being pushed, `d6ed552204000cc7063613b9d5728425711f4df8`:

```
$ git rev-parse HEAD
d6ed552204000cc7063613b9d5728425711f4df8

$ go build ./cmd/... ./internal/... && echo 'exit 0, no output'
exit 0, no output

$ go vet ./cmd/... ./internal/... && echo 'exit 0, no output'
exit 0, no output

$ gofmt -l cmd internal
(no output is the passing result)

$ go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	0.451s
ok  	github.com/Flowfin/lab/cmd/lab	1.804s
ok  	github.com/Flowfin/lab/cmd/notices	7.949s
ok  	github.com/Flowfin/lab/cmd/pullrequest	0.494s
ok  	github.com/Flowfin/lab/internal/check	0.778s
ok  	github.com/Flowfin/lab/internal/contexts	0.485s
ok  	github.com/Flowfin/lab/internal/hardware	0.494s
ok  	github.com/Flowfin/lab/internal/invariants	0.870s
ok  	github.com/Flowfin/lab/internal/notices	0.477s
ok  	github.com/Flowfin/lab/internal/prose	0.507s
ok  	github.com/Flowfin/lab/internal/pullrequest	0.533s

$ go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
25 decision records read
the time this run read is 2026-08-26T12:35:47Z
0 refused
```

The suite above was run without `-v`, so the line that says what it did not
cover is not in that output. It was run separately over the package that prints
it:

```
$ go test -count=1 -v ./internal/hardware/... | tail -5
the integration-hardware harness was not asked for and nothing in it ran.
asking costs a machine with the hardware each test names and an explicit request:
    go test -tags integration_hardware ./internal/hardware
with LAB_INTEGRATION_HARDWARE=1 in the environment. its results are about that machine and are not this suite's results.
ok  	github.com/Flowfin/lab/internal/hardware	0.449s
```

The four clauses of the done-condition, read at the same commit:

```
$ git grep -c '90 days' HEAD -- SECURITY.md
HEAD:SECURITY.md:3

$ git grep -n 'exactly one extension' HEAD -- SECURITY.md
HEAD:SECURITY.md:111:nobody outside knows exists. There is exactly one extension, granted on a

$ git grep -n '0022-how-long-a-held-back-record-waits' HEAD -- SECURITY.md
HEAD:SECURITY.md:116:[decision record 0022](docs/decisions/0022-how-long-a-held-back-record-waits.md)

$ git grep -n 'no response' HEAD -- SECURITY.md
HEAD:SECURITY.md:122:not the sentence under "What a reporter gets" below saying there is no response
HEAD:SECURITY.md:161:There is no response deadline and there will not be one. Nothing holds me to a
```

The last one is the separation clause: line 122 is the new paragraph naming the
sentence, and line 161 is the sentence it names, still standing unedited.

There is no second reader on this board tonight, and this body carries the
evidence in place of one rather than implying a review happened.

## What this does not do

It builds no guard. Nothing in this repository refuses a `SECURITY.md` that
stops stating the window, and nothing counts a day against a held-back record.
The 90 days are held by whoever writes the record and by this file being read,
which is the same standing every other prose rule on this board has.

It does not add the `Held-back:` field. Record `0022` says a held-back record
stays in `asking` and carries that field, and that the listing prints it as its
own dated line. The field is in no source file on the default branch:

```
git grep -n 'Held-back\|HeldBack' origin/main -- internal/ cmd/
(no output, exit 1)
```

So the visibility half of record `0022` is not delivered, this change does not
deliver it, and the paragraphs above claim nothing about what `lab list` prints.
That gap is on the tracker rather than only here.

It does not touch the reporting route. The private form named at the top of this
file is still off as a repository setting, which that part of the file already
states and this change leaves exactly as it found it.
