### PR TITLE
Carry the borrowed-code rule into the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,45 @@ and the states are fixed in
 [docs/decisions/0003-the-experiment-lifecycle.md](docs/decisions/0003-the-experiment-lifecycle.md).
 There are three states and no others: `asking`, `answered`, `abandoned`.
 
+## Starting from somebody else's code
+
+An experiment may start from code somebody else wrote, and there is exactly one
+place that code may live. The argument is in
+[docs/decisions/0019-code-under-another-licence.md](docs/decisions/0019-code-under-another-licence.md);
+what follows is what the rule asks of you.
+
+The code goes in `experiments/<slug>/borrowed/`, and that directory carries its
+own `LICENSE` naming the terms the code arrives under. One such directory per
+experiment. Everything under it is under the licence that file names and
+everything outside it is under this board's, so the boundary is something a
+person walking the tree can see rather than something they have to be told.
+That is the whole point of it: a directory named `borrowed` with a licence file
+in it is visible to a walk, and a line in a header is visible only to somebody
+who opened the header.
+
+The record declares it too. `Borrowed:` in the header of
+`experiments/<slug>/EXPERIMENT.md` names where the code came from and the
+licence it arrives under, and it sits with the rest of the header in
+[docs/experiment-template.md](docs/experiment-template.md). An experiment that
+borrows nothing writes no such line.
+
+Two of those a run refuses and the rest of them it does not, and the difference
+is worth knowing before you lean on any of it. A `borrowed/` directory with no
+`LICENSE` beside it is refused, and so is a record declaring `Borrowed:` in an
+experiment that holds no such directory. A `borrowed/` directory in an
+experiment whose record declares nothing passes, because a field added to the
+format after
+[docs/decisions/0013-how-the-record-format-changes.md](docs/decisions/0013-how-the-record-format-changes.md)
+is never refused for being absent. A second quarantine deeper inside an
+experiment passes as well, since the check reads `experiments/<slug>/borrowed`
+and no other name, so the one-directory limit above is yours to keep rather
+than the gate's.
+
+Nothing opens the licence file. A green run says the layout and the declaration
+do not contradict each other, and it says nothing about which licence the code
+is actually under, or about whether the result may be promoted into a board
+under other terms, which record `0019` leaves undecided on purpose.
+
 ## Stopping one
 
 Two honest ways to stop, and both of them are finished work.


### PR DESCRIPTION
Closes #204.

Record `0019` says twice that its rule belongs in the contributing guide, and the
guide carried no mention of it. This adds one section under `## Starting an
experiment`, which is where somebody meets the question the rule answers.

## The means

Markdown prose in a file the guide already is, adding no language, no runtime and
no dependency. The obligation record `0019` states is that a person starting an
experiment meets the rule, and the artefact that reaches that person is the guide
itself, so the means is fixed by the audience rather than chosen. The guards it
is judged by already exist: the paths leg of the invariants scan and the prose
format check both read this file today.

## What the section says a run does not do

The point of the section is not to restate `0019`, which it links instead. It is
to say which parts of the rule a run holds and which it does not, because a rule
written without that teaches a reader the gate is holding all of it.

Two refusals exist:

```
git grep -n 'BorrowedDirectoryCarriesNoLicence = \|RecordBorrowedDeclarationNamesNoDirectory = ' origin/main -- internal/check/borrowed.go
origin/main:internal/check/borrowed.go:43:	BorrowedDirectoryCarriesNoLicence = "borrowed-directory-carries-no-licence"
origin/main:internal/check/borrowed.go:53:	RecordBorrowedDeclarationNamesNoDirectory = "record-borrowed-declaration-names-no-directory"
```

Two things the section states as passing were run rather than reasoned about,
each against a tree built for it.

A `borrowed/` directory in an experiment whose record declares no `Borrowed:`,
carrying its licence file:

```
go run ./cmd/lab check <a tree holding experiments/one/borrowed/LICENSE and a record declaring nothing>
1 experiment directory walked, 1 record read
0 refused
```

The same tree with that licence file removed, which is the neighbour that shows
the first refusal is reached at all rather than the walk missing the directory:

```
1 refused
  ...\experiments\one\borrowed: it holds no LICENSE, so it reads as code under somebody else's terms and names none of them. record 0019 puts that file at experiments/one/borrowed/LICENSE (borrowed-directory-carries-no-licence)
```

A second quarantine deeper inside an experiment, holding no licence file, while
the top-level one is correct:

```
find . -type f | sort
./experiments/one/borrowed/LICENSE
./experiments/one/deeper/borrowed/note.txt
./experiments/one/EXPERIMENT.md

go run ./cmd/lab check <that tree>
1 experiment directory walked, 1 record read
0 refused
```

So the one-directory-per-experiment limit `0019` states is refused by nothing,
and the section says so in those words instead of implying the gate keeps it.

## That the guards reach the new text

The paths leg passing is not evidence that it read this section, so one link in
the new text was pointed at a file that is not in the tree:

```
go test -count=1 -v -run TestThisRepositorySatisfiesTheInvariants ./internal/invariants
        paths this repository's own documents name: 42 examined
        1 refused
          ..\..\CONTRIBUTING.md: it names docs/decisions/0019-code-under-another-licence-typo.md, which is not in this tree (document-names-a-path-that-does-not-resolve)
--- FAIL: TestThisRepositorySatisfiesTheInvariants (0.16s)
```

Restored, and the literal is gone:

```
git grep -c 'licence-typo' CONTRIBUTING.md ; echo "exit=$?"
exit=1
```

## The gate, at this commit

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	0.560s
ok  	github.com/Flowfin/lab/cmd/lab	3.970s
ok  	github.com/Flowfin/lab/cmd/notices	18.251s
ok  	github.com/Flowfin/lab/cmd/pullrequest	0.760s
ok  	github.com/Flowfin/lab/internal/check	1.022s
ok  	github.com/Flowfin/lab/internal/contexts	0.526s
ok  	github.com/Flowfin/lab/internal/hardware	0.760s
ok  	github.com/Flowfin/lab/internal/invariants	1.110s
ok  	github.com/Flowfin/lab/internal/notices	0.525s
ok  	github.com/Flowfin/lab/internal/prose	0.546s
ok  	github.com/Flowfin/lab/internal/pullrequest	0.764s

go run ./cmd/lab check .
1 experiment directory walked, 1 record read
26 decision records read
0 refused
```

`gofmt -l` printed nothing, which is its passing result.

## No second reader

Nothing here has been read by anybody but me. There is no second reader on this
board tonight, so the evidence above stands in place of one rather than beside
one, and this sentence is not a formality: a change nobody else has read is what
this is, and the reader who merges it should read the diff rather than the list
of green ticks.

## What this does not do

It does not build the third refusal. A `borrowed/` directory in an experiment
declaring nothing stays unrefused, that is what record `0013` requires today, and
whether it should change is #188, which is open and waiting on a decision about
`0013`. This change documents that state and does not settle it.
