### PR TITLE
Refuse a borrowed quarantine where record 0019 puts none

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,17 +122,21 @@ licence it arrives under, and it sits with the rest of the header in
 [docs/experiment-template.md](docs/experiment-template.md). An experiment that
 borrows nothing writes no such line.
 
-Two of those a run refuses and the rest of them it does not, and the difference
-is worth knowing before you lean on any of it. A `borrowed/` directory with no
-`LICENSE` beside it is refused, and so is a record declaring `Borrowed:` in an
-experiment that holds no such directory. A `borrowed/` directory in an
-experiment whose record declares nothing passes, because a field added to the
-format after
+Some of that a run refuses and some of it it does not, and the difference is
+worth knowing before you lean on any of it. A `borrowed/` directory with no
+`LICENSE` beside it is refused. So is a record declaring `Borrowed:` in an
+experiment that holds no such directory. So is a directory named `borrowed`
+anywhere else inside an experiment, since `experiments/<slug>/borrowed` is the
+one place a quarantine lives and one is all record `0019` allows. A directory
+of that name inside the quarantine is not refused: what is in there is somebody
+else's code laid out somebody else's way, and this board's rules stop at that
+edge.
+
+What still passes is a `borrowed/` directory in an experiment whose record
+declares nothing, because a field added to the format after
 [docs/decisions/0013-how-the-record-format-changes.md](docs/decisions/0013-how-the-record-format-changes.md)
-is never refused for being absent. A second quarantine deeper inside an
-experiment passes as well, since the check reads `experiments/<slug>/borrowed`
-and no other name, so the one-directory limit above is yours to keep rather
-than the gate's.
+is never refused for being absent. That one is yours to keep rather than the
+gate's.
 
 Nothing opens the licence file. A green run says the layout and the declaration
 do not contradict each other, and it says nothing about which licence the code

--- a/docs/experiment-template.md
+++ b/docs/experiment-template.md
@@ -35,6 +35,11 @@ almost every experiment borrows nothing. The code itself goes in
 terms, and a record declaring the field with no such directory is refused, as is
 a borrowed directory with no licence file in it.
 
+That directory is the only place a quarantine may be, and one is all record
+`0019` allows, so a directory named `borrowed` anywhere else in the experiment
+is refused too. One inside the quarantine is not: the code in there is laid out
+by whoever wrote it and this board does not rearrange it.
+
 What that refusal does not do is worth knowing before you rely on it. Nothing
 reads the licence file, so a green run says the layout and the declaration agree
 and says nothing about which licence the code is actually under or whether the

--- a/internal/check/borrowed.go
+++ b/internal/check/borrowed.go
@@ -51,6 +51,24 @@ const (
 	// The declaration having been made is what this reads, so record 0013 is
 	// untouched by it: an absent field says nothing and is not refused here.
 	RecordBorrowedDeclarationNamesNoDirectory = "record-borrowed-declaration-names-no-directory"
+
+	// AQuarantineOutsideThePlaceQuarantinesLive refuses a directory named
+	// borrowed inside an experiment that is not the one record 0019 fixes.
+	// That record puts the quarantine at experiments/<slug>/borrowed and
+	// allows one per experiment, and both halves of that are this one
+	// property: a second quarantine is necessarily somewhere the record does
+	// not put one.
+	//
+	// What it protects is the reason the quarantine exists at all. A person
+	// promoting the work walks the tree and reads the boundary off the layout,
+	// so a boundary somewhere below the first means the first one was not the
+	// boundary, and the reader who stopped at it learned something untrue.
+	//
+	// It is refused whatever the record says, for the same reason the licence
+	// arm is. The declaration names one source and one licence, so a second
+	// quarantine is undeclared by construction however carefully the header
+	// was written.
+	AQuarantineOutsideThePlaceQuarantinesLive = "quarantine-outside-the-place-quarantines-live"
 )
 
 // refuseBorrowed holds an experiment's borrowed quarantine and its record's
@@ -109,6 +127,16 @@ func refuseBorrowed(fsys fs.FS, root, inside, record string, data []byte) ([]Ref
 		}
 	}
 
+	// Asked whether or not the experiment holds a quarantine of its own, and
+	// asked before the declaration is read, because the two arms below return
+	// early on an unparseable record and a directory in the wrong place is not
+	// a thing a header could excuse.
+	elsewhere, err := refuseQuarantineElsewhere(fsys, root, inside, quarantine)
+	if err != nil {
+		return nil, err
+	}
+	refusals = append(refusals, elsewhere...)
+
 	parsed, err := ParseRecord(data)
 	if err != nil {
 		return refusals, nil
@@ -123,6 +151,70 @@ func refuseBorrowed(fsys fs.FS, root, inside, record string, data []byte) ([]Ref
 		Detail: fmt.Sprintf("it declares %s and there is no %s directory in %s, so the record says the experiment borrows and the tree says it does not",
 			FieldBorrowed, BorrowedDir, inside),
 	}), nil
+}
+
+// refuseQuarantineElsewhere walks an experiment for a directory named borrowed
+// that is not the one record 0019 fixes. It takes the allowed one as a path
+// rather than deriving it a second time, so the place this walks past and the
+// place refuseBorrowed judges cannot drift apart.
+//
+// IT STOPS AT THE QUARANTINE RATHER THAN JUDGING PAST IT. What is inside the
+// allowed directory is somebody else's code laid out somebody else's way, and a
+// directory named borrowed in there is that code's own business. Descending
+// would refuse honest work for the shape of a name this board does not own, and
+// the whole point of the quarantine is that this repository's rules stop at its
+// edge.
+//
+// WHERE IT DOES NOT REACH, in three places.
+//
+// Below WalkDepthBound nothing is examined, which is the bound the stray-record
+// walk already carries. A tree deep enough to hide a quarantine there is refused
+// by that walk for its depth, so the repair is the same one either way, and a
+// second bound here would give one tree two answers about how far a walk goes.
+//
+// A symbolic link named borrowed is not a directory to fs.WalkDir, so it is
+// neither followed nor refused here. That is the same position isDirectory
+// takes at its own declaration for the same reason: a link under experiments/
+// is already refused where the stray-record walk meets it, by reading the entry
+// rather than the target.
+//
+// Nothing here opens a licence file or reads a word of one, so a quarantine in
+// the right place with the wrong terms inside it is not this arm's subject and
+// is not any other arm's either.
+func refuseQuarantineElsewhere(fsys fs.FS, root, inside, quarantine string) ([]Refusal, error) {
+	var refusals []Refusal
+
+	err := fs.WalkDir(fsys, inside, func(name string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() {
+			return nil
+		}
+		if name == quarantine {
+			return fs.SkipDir
+		}
+		if depthOf(name) > WalkDepthBound {
+			return fs.SkipDir
+		}
+		if entry.Name() != BorrowedDir {
+			return nil
+		}
+		// Refused and not descended into. What is under it is code this board
+		// has already said it will not judge, and the repair is to move the
+		// directory rather than anything inside it.
+		refusals = append(refusals, Refusal{
+			Property: AQuarantineOutsideThePlaceQuarantinesLive,
+			Subject:  at(root, name),
+			Detail: fmt.Sprintf("a quarantine lives at %s and this one is at %s, so %s holds a second boundary below the first and record 0019 allows one",
+				quarantine, name, inside),
+		})
+		return fs.SkipDir
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot walk %s: %w", at(root, inside), err)
+	}
+	return refusals, nil
 }
 
 // isDirectory says whether a name in the walked filesystem is a directory. A

--- a/testdata/cases/a-borrowed-directory-inside-the-quarantine/expected
+++ b/testdata/cases/a-borrowed-directory-inside-the-quarantine/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/a-borrowed-directory-inside-the-quarantine/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/a-borrowed-directory-inside-the-quarantine/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,15 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+Needs-Hardware: none
+Borrowed: the reference implementation from example.invalid, under the MIT licence
+
+## Question
+
+Does the reference implementation lose a frame when the stream stalls?
+
+## Method
+
+The implementation was read and run from the copy this experiment carries.
+
+## Answer

--- a/testdata/cases/a-borrowed-directory-inside-the-quarantine/tree/experiments/one/borrowed/LICENSE
+++ b/testdata/cases/a-borrowed-directory-inside-the-quarantine/tree/experiments/one/borrowed/LICENSE
@@ -1,0 +1,1 @@
+The MIT licence, as the reference implementation carries it.

--- a/testdata/cases/a-borrowed-directory-inside-the-quarantine/tree/experiments/one/borrowed/source.txt
+++ b/testdata/cases/a-borrowed-directory-inside-the-quarantine/tree/experiments/one/borrowed/source.txt
@@ -1,0 +1,1 @@
+the reference implementation, as it was copied

--- a/testdata/cases/a-borrowed-directory-inside-the-quarantine/tree/experiments/one/borrowed/vendor/borrowed/source.txt
+++ b/testdata/cases/a-borrowed-directory-inside-the-quarantine/tree/experiments/one/borrowed/vendor/borrowed/source.txt
@@ -1,0 +1,1 @@
+a directory the borrowed code names itself, which this board does not own

--- a/testdata/cases/a-quarantine-outside-the-place-quarantines-live/expected
+++ b/testdata/cases/a-quarantine-outside-the-place-quarantines-live/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/a-quarantine-outside-the-place-quarantines-live/expected-refusals
+++ b/testdata/cases/a-quarantine-outside-the-place-quarantines-live/expected-refusals
@@ -1,0 +1,1 @@
+quarantine-outside-the-place-quarantines-live

--- a/testdata/cases/a-quarantine-outside-the-place-quarantines-live/near-neighbour
+++ b/testdata/cases/a-quarantine-outside-the-place-quarantines-live/near-neighbour
@@ -1,0 +1,1 @@
+an-experiment-that-borrows-and-declares-it

--- a/testdata/cases/a-quarantine-outside-the-place-quarantines-live/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/a-quarantine-outside-the-place-quarantines-live/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,15 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+Needs-Hardware: none
+Borrowed: the reference implementation from example.invalid, under the MIT licence
+
+## Question
+
+Does the reference implementation lose a frame when the stream stalls?
+
+## Method
+
+The implementation was read and run from the copy this experiment carries.
+
+## Answer

--- a/testdata/cases/a-quarantine-outside-the-place-quarantines-live/tree/experiments/one/borrowed/LICENSE
+++ b/testdata/cases/a-quarantine-outside-the-place-quarantines-live/tree/experiments/one/borrowed/LICENSE
@@ -1,0 +1,1 @@
+The MIT licence, as the reference implementation carries it.

--- a/testdata/cases/a-quarantine-outside-the-place-quarantines-live/tree/experiments/one/borrowed/source.txt
+++ b/testdata/cases/a-quarantine-outside-the-place-quarantines-live/tree/experiments/one/borrowed/source.txt
@@ -1,0 +1,1 @@
+the reference implementation, as it was copied

--- a/testdata/cases/a-quarantine-outside-the-place-quarantines-live/tree/experiments/one/prototype/borrowed/source.txt
+++ b/testdata/cases/a-quarantine-outside-the-place-quarantines-live/tree/experiments/one/prototype/borrowed/source.txt
@@ -1,0 +1,1 @@
+a second copy of somebody else's code, outside the quarantine


### PR DESCRIPTION
Closes #206.

Record `0019` puts the quarantine at `experiments/<slug>/borrowed` and allows one
per experiment. Nothing refused a directory of that name anywhere else inside an
experiment. This adds that refusal, and corrects the two documents whose
sentences it falsifies.

## The means

Go, in the package that already walks `experiments/` and already refuses this
family, adding no language, no runtime and no dependency. The alternative
considered was a document saying the limit is the reader's to keep, which is what
the tree carried until this branch and is what `0019` calls a rule with no gate.
The proof apparatus this needs already exists here: the case harness derives its
property list from the source, so the fixture obligation arrived with the
constant rather than being remembered.

## What is refused, and what is deliberately not

Refused: a directory named `borrowed` inside an experiment that is not
`experiments/<slug>/borrowed`.

Not refused: a directory of that name **inside** the quarantine. What is in
there is somebody else's code laid out somebody else's way, and
`experiments/<slug>/borrowed/vendor/borrowed/` is that code's own business.
Refusing it would refuse honest work for the shape of a name this board does not
own, and the point of the quarantine is that this repository's rules stop at its
edge.

The walk takes the allowed path from the caller rather than deriving it a second
time, so the place it walks past and the place the licence arm judges cannot
drift apart.

## The proofs

Three, each run at the head of this branch with the change reverted afterwards.

Deleting the skip at the quarantine reddens three cases, including the correct
experiment itself, because that same test is what excludes the allowed directory:

```
--- FAIL: TestCases (0.06s)
    --- FAIL: TestCases/a-borrowed-directory-inside-the-quarantine (0.00s)
    --- FAIL: TestCases/an-experiment-that-borrows-and-declares-it (0.00s)
    --- FAIL: TestCases/a-borrowed-directory-with-no-licence-file (0.00s)
```

That one proves the exclusion and the descent-stop together, so the second proof
separates them. Turning the skip into a descent that still allows the quarantine
(`return fs.SkipDir` to `return nil`) reddens only the case built for the
boundary:

```
--- FAIL: TestCases (0.07s)
    --- FAIL: TestCases/a-borrowed-directory-inside-the-quarantine (0.00s)
```

Removing the refusal site while leaving the walk running reddens only the case
that declares the property:

```
--- FAIL: TestCases (0.06s)
    --- FAIL: TestCases/a-quarantine-outside-the-place-quarantines-live (0.00s)
```

The refusing case declares exactly this property and no other and names
`an-experiment-that-borrows-and-declares-it` as its near neighbour, which differs
by that one directory and refuses nothing.

## The bounds, written at the site rather than only here

Below `WalkDepthBound` nothing is examined. That is the bound the stray-record
walk already carries and already refuses a tree for reaching, so a tree deep
enough to hide a quarantine there is refused either way, and a second bound here
would give one tree two answers about how far a walk goes.

A symbolic link named `borrowed` is not a directory to `fs.WalkDir`, so it is
neither followed nor refused here. That is the position `isDirectory` already
takes at its own declaration, for the reason it gives there.

Nothing opens a licence file. A quarantine in the right place with the wrong
terms inside it is not this arm's subject and is not any other arm's either.

## The documents

The second commit is a correction rather than an addition. #204 landed a
paragraph in `CONTRIBUTING.md` two hours ago saying a second quarantine passes
and that the one-directory limit was the reader's to keep rather than the gate's.
That was true when it was written and this branch makes it false, so it is
rewritten in the same change that falsifies it. The template gains the same two
sentences, because it already says what is refused and would otherwise be the
accurate half of a document that reads as complete.

## The gate, at this commit

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
go run ./cmd/lab check .
1 experiment directory walked, 1 record read
26 decision records read
0 refused

go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/contexts	0.741s
ok  	github.com/Flowfin/lab/cmd/lab	3.195s
ok  	github.com/Flowfin/lab/cmd/notices	15.012s
ok  	github.com/Flowfin/lab/cmd/pullrequest	0.756s
ok  	github.com/Flowfin/lab/internal/check	1.023s
ok  	github.com/Flowfin/lab/internal/contexts	0.704s
ok  	github.com/Flowfin/lab/internal/hardware	0.704s
ok  	github.com/Flowfin/lab/internal/invariants	1.051s
ok  	github.com/Flowfin/lab/internal/notices	0.715s
ok  	github.com/Flowfin/lab/internal/prose	0.734s
ok  	github.com/Flowfin/lab/internal/pullrequest	0.703s
```

`gofmt -l` printed nothing, which is its passing result.

## No second reader

Nothing here has been read by anybody but me. There is no second reader on this
board tonight, so the proofs above stand in place of one rather than beside one.
This is a new refusal on a walk that reaches every experiment, so the reader who
merges it should read `refuseQuarantineElsewhere` and decide for themselves that
the skip is in the right place.

## What this does not do

It does not touch the clause #188 is waiting on. A `borrowed/` directory in an
experiment whose record declares no `Borrowed:` still passes, record `0013`
requires that, and whether it changes is a decision about that record rather than
anything here.
