### PR TITLE
Render a bill of materials from the module set a binary carries

### DIFF
--- a/cmd/bom/main.go
+++ b/cmd/bom/main.go
@@ -1,0 +1,113 @@
+// Command bom renders the bill of materials for a binary this repository built,
+// from the module table that binary carries.
+//
+// WHY THIS IS NOT A VERB OF THE RUNNER, and why it is a second command beside
+// notices. lab reads a checkout. This reads a compiled artefact, which is not a
+// checkout, and the release build is the only place it is ever run, so putting
+// it inside lab would widen what an operator has to believe about a binary they
+// downloaded in exchange for a verb that is useless outside a release. That is
+// the judgement cmd/notices, cmd/contexts and cmd/pullrequest already made.
+//
+// It is separate from cmd/notices because the two produce different documents
+// for different readers, which internal/bom argues at length, and because a
+// single command writing two files would have to choose where each one lands.
+// Where the files land is the release build's business.
+//
+// IT READS ONE PATH AND NOTHING ELSE. The binary to describe, given as the one
+// argument. Unlike the notices it needs no module cache, because a bill of
+// materials names components and reproduces no licence text, so nothing outside
+// the binary is read at all. It asks no environment variable and runs no other
+// program, so what it produced can be reproduced by hand from the path in the
+// command line.
+//
+// IT OPENS NO CONNECTION. Everything it writes comes out of the binary it was
+// given, so the document can be produced from an archive of a build with the
+// network unplugged. That is the same claim the runner makes and it is made
+// here for the same reason: a document that can only be produced online is a
+// document that stops being producible.
+package main
+
+import (
+	"debug/buildinfo"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/Flowfin/lab/internal/bom"
+	"github.com/Flowfin/lab/internal/notices"
+)
+
+// The exit codes. Decision record 0011 is the contract, and this command
+// returns the same three the runner does, for the same reasons, which is why
+// they are written here with the record named rather than invented. The
+// exit-code leg in internal/invariants reads every exit-code constant in the
+// tree and refuses a code declared with two numbers, or a number declared under
+// two codes, so keep the convention these three follow.
+const (
+	// exitClean means the run completed and refused nothing. It does not mean
+	// the document is complete in the eyes of anybody consuming it, only that
+	// every module the binary carries reached it with a version, and that the
+	// build named a release of its own.
+	exitClean = 0
+
+	// exitRefused means the run completed and refused something. The document
+	// is still written, because a document that is incomplete by named
+	// entries is more useful than none, and the entries are named on standard
+	// error rather than inside it: a field this repository invented would be
+	// dropped in silence by anything reading the document as CycloneDX.
+	exitRefused = 1
+
+	// exitCannot means the command could not do its job: no argument, or a
+	// binary it cannot read a module table out of. It is deliberately not the
+	// code a refusal returns, because a gate that treats a broken invocation
+	// like a violation reports one as the other and nobody investigates
+	// either.
+	exitCannot = 2
+)
+
+const usage = "usage: bom <binary>"
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run is main with its edges passed in.
+//
+// The document goes to standard output rather than to a path this command
+// chooses, which is the shape cmd/notices already has. Where the file lands is
+// the release build's business, and a command that writes where it likes is one
+// more thing to read before you can tell what a release contains.
+func run(args []string, out, errOut io.Writer) int {
+	if len(args) != 1 {
+		fmt.Fprintf(errOut, "bom: %s\n", usage)
+		return exitCannot
+	}
+	binaryPath := args[0]
+
+	info, err := buildinfo.ReadFile(binaryPath)
+	if err != nil {
+		fmt.Fprintf(errOut, "bom: cannot read the module table of %s: %v\n", binaryPath, err)
+		return exitCannot
+	}
+
+	document := bom.Render(notices.BuildOf(info))
+	text, err := document.JSON()
+	if err != nil {
+		// Rendering is a pure function over values the toolchain wrote, so
+		// this is not a case anybody expects to meet. It is reported as the
+		// command being unable to do its job rather than as a refusal,
+		// because a document that was never written is not a document with a
+		// named gap in it.
+		fmt.Fprintf(errOut, "bom: %v\n", err)
+		return exitCannot
+	}
+	fmt.Fprint(out, text)
+
+	if len(document.Refusals) > 0 {
+		for _, refusal := range document.Refusals {
+			fmt.Fprintf(errOut, "bom: %s\n", refusal)
+		}
+		return exitRefused
+	}
+	return exitClean
+}

--- a/cmd/bom/main_test.go
+++ b/cmd/bom/main_test.go
@@ -1,0 +1,192 @@
+// What this command's own suite is for, and it is not a second copy of
+// internal/bom's cases.
+//
+// The render is proved there, against module sets a case wrote out in full.
+// What nothing there can prove is that the module table inside a real binary
+// reaches that render at all: a build read wrongly, a field taken from the
+// wrong place or a replacement flattened would leave every case green and
+// produce a document describing nothing. So this builds a binary from this
+// repository and reads that.
+//
+// WHERE THE COLLECTOR IS PROVED, because it is not proved here and a reader
+// should not have to find that out by looking. The one place a dependency can
+// be dropped between a binary and either document is notices.BuildOf, which is
+// the single reader of the module table both commands call, and
+// cmd/notices/tree_test.go builds a tree with a dependency in it and holds the
+// document to naming it. That proof covers this command because it covers that
+// function, and it stopped being two proofs when the second reader was removed.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/Flowfin/lab/internal/bom"
+)
+
+// TestTheModuleTableOfARealBinaryReachesTheDocument builds the runner and
+// describes it.
+//
+// THE MAIN MODULE IS WHAT IT ASSERTS ON, not the dependency list. This module
+// has no third-party dependencies, so a list read out of the binary and a list
+// that was never read look identical in that half. The main module path does
+// not: it is in the binary and nowhere else this command looks, so a document
+// naming it is a document that read the table. The revision is the second such
+// field, and it comes from a build setting rather than from the module record,
+// so the two together cover both halves of what BuildOf reads.
+//
+// IT DOES NOT REQUIRE ONE EXIT CODE. Whether this build carries a release
+// version is a property of the checkout the suite is running in: a run at a tag
+// carries one and a run on a branch carries a version derived from the commit.
+// Both are legitimate here, so the test requires the code and the standard
+// error to agree with each other rather than requiring a number the checkout
+// decides.
+func TestTheModuleTableOfARealBinaryReachesTheDocument(t *testing.T) {
+	binary := buildTheRunner(t)
+
+	var out, errOut bytes.Buffer
+	code := run([]string{binary}, &out, &errOut)
+
+	document := decode(t, out.Bytes())
+	if document.Metadata.Component.Name != "github.com/Flowfin/lab" {
+		t.Errorf("the document names %q as the module the binary was built from", document.Metadata.Component.Name)
+	}
+	if len(document.Components) != 0 {
+		t.Errorf("this module has no third-party dependency and the document lists %d component(s)", len(document.Components))
+	}
+	if !strings.Contains(out.String(), `"components": []`) {
+		t.Errorf("the empty component list is not written as an empty list, so a reader cannot tell it from a field nobody wrote:\n%s", out.String())
+	}
+
+	revision := ""
+	for _, property := range document.Metadata.Properties {
+		if property.Name == "lab:vcs.revision" {
+			revision = property.Value
+		}
+	}
+	if revision == "" {
+		t.Errorf("the document carries no revision property at all, so it says neither what the build was made at nor that it was made without one")
+	}
+
+	switch code {
+	case exitClean:
+		if errOut.Len() != 0 {
+			t.Errorf("returned %d and said %q, so a clean run wrote a complaint", exitClean, errOut.String())
+		}
+	case exitRefused:
+		// This module has no third-party dependency, so the only two things
+		// a build of it can be refused for are facts about the checkout the
+		// suite is running in: a working tree carrying changes, and a commit
+		// that is not a tag. Both are ordinary here and neither is a defect
+		// in the command, so what is required is that the run named one of
+		// them rather than returning a number with nothing behind it.
+		named := strings.Contains(errOut.String(), bom.MainComponentHasNoReleaseVersion) ||
+			strings.Contains(errOut.String(), bom.BuildIsFromAModifiedTree)
+		if !named {
+			t.Errorf("returned %d and named no property this build can be refused for: %q", exitRefused, errOut.String())
+		}
+	default:
+		t.Fatalf("returned %d, and stderr said %q", code, errOut.String())
+	}
+	t.Logf("described %s at version %q and revision %q, returning %d",
+		filepath.Base(binary), document.Metadata.Component.Version, revision, code)
+}
+
+// TestTheDocumentIsTheOnlyThingOnStandardOutput holds the command to writing a
+// document a program can read.
+//
+// A refusal is written to standard error and never into the document, and this
+// is where that is held rather than only stated. A run that mixed a complaint
+// into the output would produce a file that is no longer JSON, and the reader
+// that discovers it is somebody's scanner rather than this suite.
+func TestTheDocumentIsTheOnlyThingOnStandardOutput(t *testing.T) {
+	binary := buildTheRunner(t)
+
+	var out, errOut bytes.Buffer
+	run([]string{binary}, &out, &errOut)
+
+	decode(t, out.Bytes())
+	if !strings.HasSuffix(out.String(), "}\n") {
+		t.Errorf("the output does not end with the document, so something else was written after it")
+	}
+}
+
+// TestABrokenInvocationIsNotARefusal holds the two codes apart.
+//
+// A gate that returns the same number for "this build names no release" and
+// "you pointed me at a directory" reports one as the other, and record 0011 is
+// the contract that says it may not.
+func TestABrokenInvocationIsNotARefusal(t *testing.T) {
+	notABinary := filepath.Join(t.TempDir(), "not-a-binary")
+	if err := os.WriteFile(notABinary, []byte("this is text\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	binary := buildTheRunner(t)
+
+	for _, c := range []struct {
+		name string
+		args []string
+	}{
+		{"no arguments at all", nil},
+		{"two arguments", []string{binary, t.TempDir()}},
+		{"a file with no module table", []string{notABinary}},
+		{"a binary that is not there", []string{filepath.Join(t.TempDir(), "absent")}},
+		{"a directory rather than a binary", []string{t.TempDir()}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			var out, errOut bytes.Buffer
+			if code := run(c.args, &out, &errOut); code != exitCannot {
+				t.Errorf("returned %d rather than %d", code, exitCannot)
+			}
+			if errOut.Len() == 0 {
+				t.Errorf("returned %d and said nothing about why", exitCannot)
+			}
+			if out.Len() != 0 {
+				t.Errorf("could not do its job and wrote %d byte(s) of document anyway", out.Len())
+			}
+		})
+	}
+}
+
+// decode reads the document back, and fails rather than skipping when it
+// cannot. A document this suite could not parse is not a document that passed.
+func decode(t *testing.T, data []byte) bom.Document {
+	t.Helper()
+
+	var document bom.Document
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatalf("the output is not a document anything can read: %v\n%s", err, data)
+	}
+	if document.BOMFormat != "CycloneDX" || document.SpecVersion != bom.SpecVersion {
+		t.Errorf("the document declares %q %q rather than CycloneDX %s", document.BOMFormat, document.SpecVersion, bom.SpecVersion)
+	}
+	return document
+}
+
+// buildTheRunner compiles this repository's runner into a temporary directory
+// and returns the path.
+//
+// It builds rather than reading the test binary this suite is running inside.
+// The test binary carries the testing packages and is not what a release ships,
+// and the whole point of this file is to read the thing that is shipped.
+func buildTheRunner(t *testing.T) string {
+	t.Helper()
+
+	name := "lab"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	binary := filepath.Join(t.TempDir(), name)
+
+	build := exec.Command("go", "build", "-o", binary, "../lab")
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("cannot build the runner: %v\n%s", err, output)
+	}
+	return binary
+}

--- a/cmd/notices/main.go
+++ b/cmd/notices/main.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime/debug"
 
 	"github.com/Flowfin/lab/internal/notices"
 )
@@ -92,7 +91,7 @@ func run(args []string, out, errOut io.Writer) int {
 		return exitCannot
 	}
 
-	document := notices.Render(buildOf(info), notices.Cache{Root: cacheRoot})
+	document := notices.Render(notices.BuildOf(info), notices.Cache{Root: cacheRoot})
 	fmt.Fprint(out, document.Text())
 
 	if len(document.Refusals) > 0 {
@@ -102,39 +101,4 @@ func run(args []string, out, errOut io.Writer) int {
 		return exitRefused
 	}
 	return exitClean
-}
-
-// buildOf turns what the toolchain recorded into what the render reads.
-//
-// THE REPLACEMENT IS CARRIED RATHER THAN FLATTENED. A replaced module is
-// recorded twice by the toolchain: the module the build asked for, carrying the
-// replacement, and the replacement itself. What is in the binary is the
-// replacement's code, so that is what the licence has to come from, and a reader
-// comparing this document against go.mod is looking for the module that was
-// asked for. Both are written down.
-func buildOf(info *debug.BuildInfo) notices.Build {
-	build := notices.Build{
-		Main: notices.Module{Path: info.Main.Path, Version: info.Main.Version},
-	}
-	for _, setting := range info.Settings {
-		if setting.Key == "vcs.revision" {
-			build.Revision = setting.Value
-		}
-	}
-	for _, dep := range info.Deps {
-		if dep == nil {
-			continue
-		}
-		module := notices.Module{Path: dep.Path, Version: dep.Version}
-		if dep.Replace != nil {
-			module = notices.Module{
-				Path:            dep.Replace.Path,
-				Version:         dep.Replace.Version,
-				ReplacedPath:    dep.Path,
-				ReplacedVersion: dep.Version,
-			}
-		}
-		build.Deps = append(build.Deps, module)
-	}
-	return build
 }

--- a/internal/bom/bom.go
+++ b/internal/bom/bom.go
@@ -1,0 +1,388 @@
+// Package bom renders the bill of materials a release owes whoever downloads
+// it, from the module set the binary itself carries.
+//
+// WHY IT IS A SECOND DOCUMENT AND NOT A SECTION OF THE NOTICES. The two answer
+// different questions for different readers. The notices discharge a legal
+// obligation and are read by a person, so they reproduce licence text in full.
+// A bill of materials answers what an operator is running and is read by a
+// program, so it names every component in a form something else can match
+// against an advisory feed. A single document doing both would be worse at each
+// of them, and the reader who needs one of the two would have to carry the
+// other.
+//
+// WHY IT READS A BUILD RATHER THAN A FILE. The same reason internal/notices
+// does, and from the same input: the toolchain records every module that went
+// into a binary, inside the binary, so there is no second list for anything to
+// drift against. The build type is that package's rather than a copy declared
+// here. Two declarations of one input is exactly the drift that would show up
+// as a notices file and a bill of materials disagreeing about what is inside
+// the same binary, which is the failure both documents exist to prevent.
+//
+// WHAT IT WILL NOT DO IS CARRY A CLOCK OR A RANDOM IDENTIFIER. CycloneDX allows
+// both a timestamp and a serial number and both are optional, so neither is
+// written. Two runs from one tag have to produce one file: a release that
+// publishes a checksum over this document is claiming the document is a
+// function of the build, and a field that moves between two runs of the same
+// build destroys that claim while looking like metadata.
+//
+// WHAT IT CANNOT DO. It declares a specVersion and nothing in this repository
+// validates the document against the published CycloneDX schema, so what the
+// suite holds is the fields this renderer writes and not conformance to that
+// specification. It also does not identify a licence, for the reason
+// internal/notices gives at greater length: the licence a module is under is a
+// judgement no reading of its text makes reliably, and a bill of materials
+// carrying a guessed identifier is worse than one carrying none, because the
+// guess is machine-readable and will be believed.
+package bom
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/Flowfin/lab/internal/notices"
+)
+
+// SpecVersion is the CycloneDX version the document declares. It is a constant
+// here rather than a literal in the render so that the string a case asserts
+// and the string the document carries cannot become two strings.
+const SpecVersion = "1.6"
+
+// The properties this package can refuse. A property is the rule, named once
+// here and nowhere else, so a case declaring what it expects and a refusal the
+// render produced are the same string or they are not equal. It is the shape
+// internal/notices, internal/contexts and internal/check already use rather
+// than a fourth one.
+const (
+	// MainComponentHasNoReleaseVersion refuses a build whose own module
+	// version is not one a reader can resolve back to a release.
+	//
+	// This is the refusal that earns the package. The toolchain stamps the
+	// main module's version from version control, so a build made at a tag
+	// carries the tag and a build made anywhere else carries a pseudo-version
+	// or nothing at all. A bill of materials is published beside an artefact
+	// and read later by somebody asking which version they are running, and a
+	// document answering that question with a commit timestamp names no
+	// release. Refusing it at the moment the release is built is the only
+	// moment the answer can still be corrected.
+	MainComponentHasNoReleaseVersion = "main-component-has-no-release-version"
+
+	// DependencyHasNoVersion refuses a module the binary contains that is
+	// recorded with no version.
+	//
+	// A component with no version cannot be matched against an advisory, and
+	// matching against advisories is the whole operational reason this
+	// document exists. Listing it anyway would put a row in front of a
+	// scanner that the scanner has to either ignore or guess at, and both of
+	// those are worse than a document that says which entry it could not
+	// complete.
+	DependencyHasNoVersion = "dependency-has-no-version"
+
+	// BuildIsFromAModifiedTree refuses a build made from a working tree
+	// carrying changes version control does not hold.
+	//
+	// It is a second property rather than a second reason under the one
+	// above, because the repair is a different repair: a build that names no
+	// release is repaired by tagging, and this one is repaired by committing
+	// or discarding what is in the tree. A document that collapsed them would
+	// send a reader to the wrong one.
+	//
+	// IT IS READ FROM THE BUILD SETTING AND NOT FROM THE VERSION STRING, and
+	// that is the whole reason this property exists rather than being folded
+	// into the version rule. The toolchain says a tree was modified twice: as
+	// a setting, and by appending a suffix to the version. The suffix comes
+	// after the commit, so a rule matching a version derived from a commit
+	// and anchored at its end accepts a dirty one, which is what this
+	// repository's own build did until a case read the answer out of a real
+	// binary and printed it.
+	BuildIsFromAModifiedTree = "build-is-from-a-modified-tree"
+)
+
+// pseudoVersion matches the version-control-derived version the toolchain
+// writes for a build that is not at a tag: a base version, the commit time and
+// the short commit.
+//
+// It is written out rather than inferred from the presence of a hyphen, because
+// an ordinary pre-release version carries one too. Refusing v1.0.0-rc.1 as
+// unresolvable would refuse a real release for looking like a build that is not
+// one.
+//
+// THE TRAILING BUILD METADATA IS PART OF THE PATTERN AND WAS ADDED AFTER IT WAS
+// MEASURED. A build from a modified tree carries a suffix after the commit, so
+// a pattern anchored at the commit does not match it, and this repository built
+// itself and returned a clean run over exactly that string. The modified tree
+// is refused under its own property; this half is the pattern being right about
+// what a version derived from a commit looks like.
+var pseudoVersion = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?-[0-9]{14}-[0-9a-f]{12}(\+[0-9A-Za-z.-]+)?$`)
+
+// A Refusal is one rule refusing one subject. It carries the subject separately
+// from the detail so that a message can never be written without it.
+type Refusal struct {
+	Property string
+	Subject  string
+	Detail   string
+}
+
+// String leads with the subject, because somebody reading a red run is looking
+// for the thing to open first.
+func (r Refusal) String() string {
+	return fmt.Sprintf("%s: %s (%s)", r.Subject, r.Detail, r.Property)
+}
+
+// A Component is one entry in the document, in the shape CycloneDX names them.
+//
+// The field names carry their JSON spelling rather than being renamed, so a
+// reader comparing this struct against the specification is comparing the same
+// words. A hyphen is not legal in a Go identifier, which is why the tag on the
+// reference field is there at all and not only for case.
+type Component struct {
+	Type    string `json:"type"`
+	BOMRef  string `json:"bom-ref"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	PURL    string `json:"purl"`
+
+	// Description is written only for a component standing in for another
+	// module, and says which one. A replacement is what is in the binary and
+	// the module the build asked for is what a reader holding go.mod is
+	// looking for, so a document showing only one of them makes one of those
+	// two readers wrong.
+	Description string `json:"description,omitempty"`
+}
+
+// A Property is one name and value in the metadata block. The document uses it
+// for the facts about the build that CycloneDX has no field of its own for.
+type Property struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// A Metadata block says what the document is about.
+type Metadata struct {
+	Component  Component  `json:"component"`
+	Properties []Property `json:"properties,omitempty"`
+}
+
+// A Document is the rendered bill of materials and what producing it refused.
+//
+// The JSON tags are the document's wire shape and the field order below is the
+// order they are written in, because encoding/json writes a struct in
+// declaration order and a document whose field order moved between two runs
+// would break the checksum this file is published under.
+type Document struct {
+	BOMFormat   string      `json:"bomFormat"`
+	SpecVersion string      `json:"specVersion"`
+	Version     int         `json:"version"`
+	Metadata    Metadata    `json:"metadata"`
+	Components  []Component `json:"components"`
+
+	// Refusals is every entry the render could not complete. It is not part
+	// of the document's wire shape: a bill of materials is read by a program
+	// that knows the specification, and a field this repository invented
+	// would be dropped by it in silence. The refusals reach a person through
+	// the command's standard error and its exit code instead.
+	Refusals []Refusal `json:"-"`
+}
+
+// Properties returns the set of properties this document refused, which is what
+// a case declares and what the harness compares. A property refused twice is
+// one entry: a verdict is a set.
+func (d Document) Properties() []string {
+	seen := make(map[string]bool, len(d.Refusals))
+	var props []string
+	for _, refusal := range d.Refusals {
+		if !seen[refusal.Property] {
+			seen[refusal.Property] = true
+			props = append(props, refusal.Property)
+		}
+	}
+	sort.Strings(props)
+	return props
+}
+
+// Render builds the document from the module set a binary carries.
+//
+// IT SORTS BY MODULE PATH AND CARRIES NO CLOCK, for the reason the package
+// comment gives: the bytes this produces are a function of the build and of
+// nothing else, so two runs from one tag produce one file.
+func Render(build notices.Build) Document {
+	document := Document{
+		BOMFormat:   "CycloneDX",
+		SpecVersion: SpecVersion,
+		// The document's own revision, which is 1 for a document that has
+		// never been superseded. It is not the version of the thing being
+		// described, and the two are next to each other in the output, so the
+		// distinction is written here where somebody changing one of them
+		// will read it.
+		Version: 1,
+		// Never nil. A document with no dependencies has to serialise as an
+		// empty list rather than as null, because a reader distinguishing
+		// nothing in it from the field was not written gets a different answer
+		// from each, and a Go nil slice writes the second one.
+		Components: []Component{},
+	}
+
+	document.Metadata = Metadata{
+		Component:  componentOf(build.Main, "application"),
+		Properties: metadataProperties(build),
+	}
+	if !isReleaseVersion(build.Main.Version) {
+		document.Refusals = append(document.Refusals, Refusal{
+			Property: MainComponentHasNoReleaseVersion,
+			Subject:  build.Main.Describe(),
+			Detail: fmt.Sprintf("the toolchain stamped %q as this build's own version, which names no release, so a reader holding the artefact cannot resolve this document back to one",
+				build.Main.Version),
+		})
+	}
+
+	if build.Modified {
+		document.Refusals = append(document.Refusals, Refusal{
+			Property: BuildIsFromAModifiedTree,
+			Subject:  build.Main.Describe(),
+			Detail:   "the toolchain recorded that the tree this was built from carried changes version control does not hold, so the revision beside it names a commit that is not what was compiled",
+		})
+	}
+
+	deps := append([]notices.Module(nil), build.Deps...)
+	sort.Slice(deps, func(i, j int) bool {
+		if deps[i].Path != deps[j].Path {
+			return deps[i].Path < deps[j].Path
+		}
+		return deps[i].Version < deps[j].Version
+	})
+
+	for _, module := range deps {
+		if strings.TrimSpace(module.Version) == "" {
+			document.Refusals = append(document.Refusals, Refusal{
+				Property: DependencyHasNoVersion,
+				Subject:  module.Describe(),
+				Detail:   "the binary contains it and the module table records no version for it, so nothing reading this document can match it against an advisory",
+			})
+			continue
+		}
+		document.Components = append(document.Components, componentOf(module, "library"))
+	}
+	return document
+}
+
+// metadataProperties carries the facts about the build that CycloneDX has no
+// field of its own for. The names are namespaced to this repository, because an
+// unprefixed property name is a claim on a word the specification may give to
+// something else later.
+func metadataProperties(build notices.Build) []Property {
+	if build.Revision == "" {
+		// Said rather than left out. A document with no revision property and
+		// one whose revision was dropped look identical, and the first of
+		// those is an ordinary build from an archive while the second is a
+		// defect.
+		return []Property{{
+			Name:  "lab:vcs.revision",
+			Value: "the build carried no revision",
+		}}
+	}
+	return []Property{{Name: "lab:vcs.revision", Value: build.Revision}}
+}
+
+// componentOf turns one module into one component.
+func componentOf(module notices.Module, kind string) Component {
+	component := Component{
+		Type:    kind,
+		BOMRef:  PURL(module),
+		Name:    module.Path,
+		Version: module.Version,
+		PURL:    PURL(module),
+	}
+	if module.ReplacedPath != "" {
+		component.Description = fmt.Sprintf("stands in for %s@%s, which is what the build asked for", module.ReplacedPath, module.ReplacedVersion)
+	}
+	return component
+}
+
+// PURL is the package URL for one module.
+//
+// WHAT IT IS AND WHAT IT IS NOT. It is built from the module path and the
+// version the toolchain recorded, with the characters that are not safe in a
+// URL path percent-encoded. Nothing here validates it against the package-url
+// specification, and a reader who needs that guarantee has to check it rather
+// than take this function's word.
+//
+// THE CASE OF THE MODULE PATH IS NOT FOLDED. Two module paths differing only in
+// case are different modules, which is why the module cache escapes upper case
+// rather than lower-casing it, and a bill of materials that folded them would
+// name a module that was never in the binary. That is a deliberate departure
+// from any rule asking for a lower-cased name, and it is written here rather
+// than discovered by somebody comparing this output against another tool's.
+func PURL(module notices.Module) string {
+	return "pkg:golang/" + encodePath(module.Path) + "@" + encodeSegment(module.Version)
+}
+
+// encodePath percent-encodes a module path, leaving the separators alone so the
+// result still reads as a path.
+func encodePath(modulePath string) string {
+	segments := strings.Split(modulePath, "/")
+	for i, segment := range segments {
+		segments[i] = encodeSegment(segment)
+	}
+	return strings.Join(segments, "/")
+}
+
+// encodeSegment percent-encodes everything outside the unreserved set. It is
+// written here rather than taken from net/url, because url.PathEscape leaves
+// several sub-delimiters in place and this is one place where being stricter
+// than necessary costs nothing and being looser costs a document a reader has
+// to guess at.
+func encodeSegment(segment string) string {
+	var out strings.Builder
+	for _, b := range []byte(segment) {
+		if unreserved(b) {
+			out.WriteByte(b)
+			continue
+		}
+		fmt.Fprintf(&out, "%%%02X", b)
+	}
+	return out.String()
+}
+
+// unreserved is the set of bytes that need no encoding. It is the unreserved
+// set of the URI syntax plus the plus sign, which a module version carries for
+// an incompatible major version and which reads wrong when encoded.
+func unreserved(b byte) bool {
+	switch {
+	case b >= 'A' && b <= 'Z', b >= 'a' && b <= 'z', b >= '0' && b <= '9':
+		return true
+	case b == '-', b == '.', b == '_', b == '~', b == '+':
+		return true
+	}
+	return false
+}
+
+// isReleaseVersion says whether the toolchain stamped a version a reader can
+// resolve back to a release.
+//
+// Three things are not one: an empty version, the placeholder the toolchain
+// writes when it knows nothing, and a version derived from a commit. All three
+// leave the reader unable to say which release they are holding, which is why
+// one property covers them, and the refusal quotes the string so the reader can
+// tell which of the three they met.
+func isReleaseVersion(version string) bool {
+	version = strings.TrimSpace(version)
+	if version == "" || version == "(devel)" {
+		return false
+	}
+	return !pseudoVersion.MatchString(version)
+}
+
+// JSON renders the document.
+//
+// Two spaces of indentation and a trailing newline, so the published file is
+// one a person can open as well as one a program can read, and so that a diff
+// between two releases is a diff of the entries rather than of one long line.
+func (d Document) JSON() (string, error) {
+	encoded, err := json.MarshalIndent(d, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("cannot render the bill of materials: %w", err)
+	}
+	return string(encoded) + "\n", nil
+}

--- a/internal/bom/bom_test.go
+++ b/internal/bom/bom_test.go
@@ -1,0 +1,378 @@
+// The harness these rules are proved with.
+//
+// A case is a directory under testdata/bom/. It holds the module set a binary
+// recorded, as a file rather than as a struct assembled at run time, the whole
+// document the render should have produced, and the whole set of properties it
+// should have refused.
+//
+// The layout of a case:
+//
+//	testdata/bom/<name>/build              the module set, one line per fact
+//	testdata/bom/<name>/expected           the document, byte for byte
+//	testdata/bom/<name>/expected-refusals  one property per line, may be absent
+//	testdata/bom/<name>/near-neighbour     the case that differs by the
+//	                                       smallest legal change, required of a
+//	                                       case that refuses
+//
+// It is the shape internal/notices, internal/contexts and the record checks are
+// proved with rather than a fourth one, because a reader who has understood one
+// harness here should not have to learn another. The case file has one fact
+// this repository's other harnesses have no spelling for: a dependency recorded
+// with no version at all, written as a dep line carrying only a path.
+package bom
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/Flowfin/lab/internal/notices"
+)
+
+// casesDir is where the cases live. Record 0002 puts the runner's own fixtures
+// at the root of the tree rather than beside the package, so the path climbs
+// out of internal/bom.
+const casesDir = "../../testdata/bom"
+
+// A caseInput is one case as its files declare it.
+type caseInput struct {
+	name      string
+	build     notices.Build
+	expected  string
+	refusals  []string
+	neighbour string
+}
+
+// TestEveryCaseIsRenderedAsItsFilesDeclare holds the render to both halves of
+// every case: the properties it refused and the bytes it produced.
+//
+// The document is compared in full rather than by a substring. A test asserting
+// that the document contains a module path passes on one that lost the version
+// beside it or wrote the wrong reference, and a bill of materials is read by a
+// program, which will not notice either.
+func TestEveryCaseIsRenderedAsItsFilesDeclare(t *testing.T) {
+	cases := readCases(t)
+	if len(cases) == 0 {
+		t.Fatalf("no cases under %s, so this suite proved nothing", casesDir)
+	}
+
+	for _, input := range cases {
+		t.Run(input.name, func(t *testing.T) {
+			document := Render(input.build)
+
+			got := document.Properties()
+			want := append([]string(nil), input.refusals...)
+			sort.Strings(want)
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("refused %v, and the case declares %v", got, want)
+				for _, refusal := range document.Refusals {
+					t.Logf("  %s", refusal)
+				}
+			}
+
+			text, err := document.JSON()
+			if err != nil {
+				t.Fatalf("the document could not be rendered: %v", err)
+			}
+			if text != input.expected {
+				t.Errorf("the document does not match the case, byte for byte")
+				t.Logf("produced:\n%s", text)
+				t.Logf("declared:\n%s", input.expected)
+			}
+		})
+	}
+	t.Logf("%d case(s) read from %s", len(cases), casesDir)
+}
+
+// TestACaseThatRefusesNamesANeighbourThatDoesNot is the near-miss discipline.
+//
+// A case that refuses proves only that something in it was refused. What proves
+// the rule bites for the reason it names is the neighbour: the same case with
+// the one thing repaired, refusing nothing. Without it a rule that refused
+// every build it read would pass every case here.
+func TestACaseThatRefusesNamesANeighbourThatDoesNot(t *testing.T) {
+	cases := readCases(t)
+	byName := make(map[string]caseInput, len(cases))
+	for _, input := range cases {
+		byName[input.name] = input
+	}
+
+	checked := 0
+	for _, input := range cases {
+		if len(input.refusals) == 0 {
+			continue
+		}
+		if input.neighbour == "" {
+			t.Errorf("%s refuses %v and names no near neighbour", input.name, input.refusals)
+			continue
+		}
+		neighbour, ok := byName[input.neighbour]
+		if !ok {
+			t.Errorf("%s names the near neighbour %s, which is not a case", input.name, input.neighbour)
+			continue
+		}
+		if properties := Render(neighbour.build).Properties(); len(properties) != 0 {
+			t.Errorf("%s is the near neighbour of %s and refuses %v, so it proves nothing about why %s was refused",
+				neighbour.name, input.name, properties, input.name)
+			continue
+		}
+		checked++
+	}
+	t.Logf("%d refusing case(s) proved against a neighbour that passes", checked)
+}
+
+// TestAPreReleaseVersionIsAReleaseVersion is the near-miss the version rule
+// will actually meet.
+//
+// The refusal is written against a version derived from a commit, and the
+// obvious way to write that rule is to refuse a version carrying a hyphen. An
+// ordinary release candidate carries one too, so that rule would refuse the
+// first tag anybody cuts under it, at the moment the release is being made and
+// with the message saying the build names no release. The case list carries
+// a release candidate for this reason and this test says so out loud.
+func TestAPreReleaseVersionIsAReleaseVersion(t *testing.T) {
+	for _, version := range []string{"v1.0.0", "v1.0.0-rc.1", "v0.1.0-alpha", "v2.3.4+incompatible"} {
+		if !isReleaseVersion(version) {
+			t.Errorf("%q is a version somebody tags a release with and this refuses it", version)
+		}
+	}
+	for _, version := range []string{
+		"",
+		"(devel)",
+		"v0.0.0-20260827021325-db0a15471e88",
+		"v1.2.3-rc.1-20260827021325-db0a15471e88",
+		// The one this repository actually produced. It is written out
+		// rather than described, because the entry that was missing is the
+		// suffix and a reader has to be able to see it.
+		"v0.0.0-20260827021325-db0a15471e88+dirty",
+	} {
+		if isReleaseVersion(version) {
+			t.Errorf("%q names no release a reader can resolve and this accepts it", version)
+		}
+	}
+}
+
+// TestTheDocumentIsAFunctionOfTheBuildAlone holds the render to producing one
+// file from one build.
+//
+// The release milestone asks for two runs from one tag to produce identical
+// checksums, and this document is published beside the artefact those checksums
+// cover. CycloneDX offers both a timestamp and a serial number, both optional,
+// and either of them would break that while looking like metadata: a document
+// with yesterday's date in it looks correct.
+func TestTheDocumentIsAFunctionOfTheBuildAlone(t *testing.T) {
+	for _, input := range readCases(t) {
+		first, err := Render(input.build).JSON()
+		if err != nil {
+			t.Fatalf("%s: %v", input.name, err)
+		}
+		second, err := Render(input.build).JSON()
+		if err != nil {
+			t.Fatalf("%s: %v", input.name, err)
+		}
+		if first != second {
+			t.Errorf("%s renders two different documents from one build", input.name)
+		}
+	}
+}
+
+// TestADependencyAddedToTheBuildIsListed holds the render to the difference
+// rather than to a document that happened to name a module.
+//
+// THE BOUND, and it is why the command's own suite exists as well. The build
+// here is a module set constructed in this test, not one read out of a compiled
+// binary, so what this proves is the render. That the module table inside a
+// real binary reaches this render is what cmd/bom proves, against a binary it
+// builds.
+func TestADependencyAddedToTheBuildIsListed(t *testing.T) {
+	cases := readCases(t)
+	byName := make(map[string]caseInput, len(cases))
+	for _, input := range cases {
+		byName[input.name] = input
+	}
+
+	without, ok := byName["a-release-with-no-dependencies"]
+	if !ok {
+		t.Fatalf("the case a-release-with-no-dependencies is not in %s", casesDir)
+	}
+	with, ok := byName["a-release-with-one-dependency"]
+	if !ok {
+		t.Fatalf("the case a-release-with-one-dependency is not in %s", casesDir)
+	}
+	if len(with.build.Deps) != 1 {
+		t.Fatalf("a-release-with-one-dependency carries %d dependencies", len(with.build.Deps))
+	}
+	added := with.build.Deps[0]
+
+	before := Render(without.build)
+	if len(before.Components) != 0 {
+		t.Fatalf("the build with no dependencies already lists %d component(s), so the comparison below proves nothing", len(before.Components))
+	}
+
+	build := without.build
+	build.Deps = []notices.Module{added}
+	after := Render(build)
+
+	if properties := after.Properties(); len(properties) != 0 {
+		t.Fatalf("adding %s refused %v", added.Describe(), properties)
+	}
+	if len(after.Components) != 1 {
+		t.Fatalf("adding one dependency produced %d component(s)", len(after.Components))
+	}
+	component := after.Components[0]
+	if component.Name != added.Path || component.Version != added.Version {
+		t.Errorf("the component is %s@%s and the module added was %s", component.Name, component.Version, added.Describe())
+	}
+	if component.PURL != PURL(added) {
+		t.Errorf("the component reference is %q and the module resolves to %q", component.PURL, PURL(added))
+	}
+	t.Logf("adding %s moved the document from %d to %d component(s)", added.Describe(), len(before.Components), len(after.Components))
+}
+
+// TestThePackageURLSurvivesTheCharactersAModulePathCanHold is a unit rather
+// than a case, because the property is about a string and a case proving it
+// would put the answer in a file a reader has to compare by eye.
+//
+// The capital is the entry that matters here. The module path of this very
+// repository carries one, so the spelling is not an edge somebody invented for
+// a test, and the temptation to lower-case it is real: two module paths
+// differing only in case are different modules, and a reference that folded
+// them would name a module that was never in the binary.
+func TestThePackageURLSurvivesTheCharactersAModulePathCanHold(t *testing.T) {
+	for _, pair := range []struct {
+		module notices.Module
+		want   string
+	}{
+		{notices.Module{Path: "github.com/Flowfin/lab", Version: "v1.0.0"}, "pkg:golang/github.com/Flowfin/lab@v1.0.0"},
+		{notices.Module{Path: "example.com/widget", Version: "v1.2.3"}, "pkg:golang/example.com/widget@v1.2.3"},
+		{notices.Module{Path: "example.com/wid get", Version: "v1.0.0"}, "pkg:golang/example.com/wid%20get@v1.0.0"},
+		{notices.Module{Path: "example.com/widget/v2", Version: "v2.0.0+incompatible"}, "pkg:golang/example.com/widget/v2@v2.0.0+incompatible"},
+		{notices.Module{Path: "example.com/wid?get", Version: "v1.0.0"}, "pkg:golang/example.com/wid%3Fget@v1.0.0"},
+	} {
+		if got := PURL(pair.module); got != pair.want {
+			t.Errorf("PURL(%s) is %q, and the reference is %q", pair.module.Describe(), got, pair.want)
+		}
+	}
+}
+
+// readCases reads every case directory, and fails rather than skipping when one
+// is malformed. A case the harness could not read is not a case that passed.
+func readCases(t *testing.T) []caseInput {
+	t.Helper()
+
+	entries, err := os.ReadDir(casesDir)
+	if err != nil {
+		t.Fatalf("cannot read %s: %v", casesDir, err)
+	}
+
+	var cases []caseInput
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dir := filepath.Join(casesDir, entry.Name())
+
+		build, err := readBuild(filepath.Join(dir, "build"))
+		if err != nil {
+			t.Fatalf("%s: %v", entry.Name(), err)
+		}
+		expected, err := os.ReadFile(filepath.Join(dir, "expected"))
+		if err != nil {
+			t.Fatalf("%s: %v", entry.Name(), err)
+		}
+		cases = append(cases, caseInput{
+			name:      entry.Name(),
+			build:     build,
+			expected:  string(expected),
+			refusals:  readLines(t, filepath.Join(dir, "expected-refusals")),
+			neighbour: readOptional(t, filepath.Join(dir, "near-neighbour")),
+		})
+	}
+	return cases
+}
+
+// readBuild reads a case's module set. One fact per line, so that a case is
+// read as a file rather than as a format somebody has to decode:
+//
+//	main <path> <version>
+//	revision <sha>
+//	modified true                           built from a tree carrying changes
+//	dep <path> <version>
+//	dep <path>                              recorded with no version at all
+//	dep <path> <version> replaces <path> <version>
+func readBuild(path string) (notices.Build, error) {
+	text, err := os.ReadFile(path)
+	if err != nil {
+		return notices.Build{}, err
+	}
+
+	var build notices.Build
+	for number, line := range strings.Split(string(text), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		switch {
+		case fields[0] == "main" && len(fields) == 3:
+			build.Main = notices.Module{Path: fields[1], Version: fields[2]}
+		case fields[0] == "revision" && len(fields) == 2:
+			build.Revision = fields[1]
+		case fields[0] == "modified" && len(fields) == 2:
+			build.Modified = fields[1] == "true"
+		case fields[0] == "dep" && len(fields) == 2:
+			build.Deps = append(build.Deps, notices.Module{Path: fields[1]})
+		case fields[0] == "dep" && len(fields) == 3:
+			build.Deps = append(build.Deps, notices.Module{Path: fields[1], Version: fields[2]})
+		case fields[0] == "dep" && len(fields) == 6 && fields[3] == "replaces":
+			build.Deps = append(build.Deps, notices.Module{
+				Path: fields[1], Version: fields[2],
+				ReplacedPath: fields[4], ReplacedVersion: fields[5],
+			})
+		default:
+			// The message names the line rather than only the file, because
+			// a harness that says a fixture is wrong and not where sends a
+			// reader to look through it.
+			return notices.Build{}, fmt.Errorf("%s: line %d is not a fact this harness reads: %s", path, number+1, line)
+		}
+	}
+	return build, nil
+}
+
+// readLines reads a file of one entry per line. An absent file is an empty list
+// rather than a failure, because most cases refuse nothing and a file holding
+// nothing is noise in every one of them.
+func readLines(t *testing.T, path string) []string {
+	t.Helper()
+
+	text, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("cannot read %s: %v", path, err)
+	}
+
+	var lines []string
+	for _, line := range strings.Split(string(text), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+// readOptional reads a one-line file, or the empty string where there is none.
+func readOptional(t *testing.T, path string) string {
+	t.Helper()
+
+	lines := readLines(t, path)
+	if len(lines) == 0 {
+		return ""
+	}
+	return lines[0]
+}

--- a/internal/notices/build.go
+++ b/internal/notices/build.go
@@ -1,0 +1,51 @@
+// Reading the module table out of what the toolchain recorded.
+//
+// WHY IT IS HERE RATHER THAN IN THE COMMAND THAT NEEDED IT FIRST. Two documents
+// are rendered from one input now, the notices and the bill of materials, and
+// both of them are statements about what is inside the same binary. A second
+// reader of the module table would let the two disagree about that, which is
+// the one failure neither document is allowed to have: an operator holding both
+// files would have no way to tell which of them was wrong. So the table is read
+// once, here, and both commands call this.
+
+package notices
+
+import "runtime/debug"
+
+// BuildOf turns what the toolchain recorded into what a render reads.
+//
+// THE REPLACEMENT IS CARRIED RATHER THAN FLATTENED. A replaced module is
+// recorded twice by the toolchain: the module the build asked for, carrying the
+// replacement, and the replacement itself. What is in the binary is the
+// replacement's code, so that is what the licence has to come from, and a
+// reader comparing a document against go.mod is looking for the module that was
+// asked for. Both are written down.
+func BuildOf(info *debug.BuildInfo) Build {
+	build := Build{
+		Main: Module{Path: info.Main.Path, Version: info.Main.Version},
+	}
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			build.Revision = setting.Value
+		case "vcs.modified":
+			build.Modified = setting.Value == "true"
+		}
+	}
+	for _, dep := range info.Deps {
+		if dep == nil {
+			continue
+		}
+		module := Module{Path: dep.Path, Version: dep.Version}
+		if dep.Replace != nil {
+			module = Module{
+				Path:            dep.Replace.Path,
+				Version:         dep.Replace.Version,
+				ReplacedPath:    dep.Path,
+				ReplacedVersion: dep.Version,
+			}
+		}
+		build.Deps = append(build.Deps, module)
+	}
+	return build
+}

--- a/internal/notices/notices.go
+++ b/internal/notices/notices.go
@@ -76,6 +76,14 @@ type Build struct {
 
 	// Deps is every module the binary contains beyond the main one.
 	Deps []Module
+
+	// Modified says the build was made from a working tree carrying changes
+	// the version control system does not hold. The toolchain records it as a
+	// build setting, so it is a fact about the binary in exactly the way the
+	// module set is, and it is carried here rather than derived from the
+	// version string: a version says the tree was dirty by appending a
+	// suffix, which is a spelling, and this is the answer.
+	Modified bool
 }
 
 // A Licence is the text one module shipped, and the filename it shipped it

--- a/testdata/bom/a-build-from-a-modified-tree/build
+++ b/testdata/bom/a-build-from-a-modified-tree/build
@@ -1,0 +1,3 @@
+main github.com/Flowfin/lab v1.0.0
+revision 8f3c1d9a2b7e4f60c5d8a1b3e6f902478c1d5e2a
+modified true

--- a/testdata/bom/a-build-from-a-modified-tree/expected
+++ b/testdata/bom/a-build-from-a-modified-tree/expected
@@ -1,0 +1,21 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:golang/github.com/Flowfin/lab@v1.0.0",
+      "name": "github.com/Flowfin/lab",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/Flowfin/lab@v1.0.0"
+    },
+    "properties": [
+      {
+        "name": "lab:vcs.revision",
+        "value": "8f3c1d9a2b7e4f60c5d8a1b3e6f902478c1d5e2a"
+      }
+    ]
+  },
+  "components": []
+}

--- a/testdata/bom/a-build-from-a-modified-tree/expected-refusals
+++ b/testdata/bom/a-build-from-a-modified-tree/expected-refusals
@@ -1,0 +1,1 @@
+build-is-from-a-modified-tree

--- a/testdata/bom/a-build-from-a-modified-tree/near-neighbour
+++ b/testdata/bom/a-build-from-a-modified-tree/near-neighbour
@@ -1,0 +1,1 @@
+a-release-with-no-dependencies

--- a/testdata/bom/a-build-that-is-not-at-a-tag/build
+++ b/testdata/bom/a-build-that-is-not-at-a-tag/build
@@ -1,0 +1,2 @@
+main github.com/Flowfin/lab v0.0.0-20260827021325-db0a15471e88
+revision 8f3c1d9a2b7e4f60c5d8a1b3e6f902478c1d5e2a

--- a/testdata/bom/a-build-that-is-not-at-a-tag/expected
+++ b/testdata/bom/a-build-that-is-not-at-a-tag/expected
@@ -1,0 +1,21 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:golang/github.com/Flowfin/lab@v0.0.0-20260827021325-db0a15471e88",
+      "name": "github.com/Flowfin/lab",
+      "version": "v0.0.0-20260827021325-db0a15471e88",
+      "purl": "pkg:golang/github.com/Flowfin/lab@v0.0.0-20260827021325-db0a15471e88"
+    },
+    "properties": [
+      {
+        "name": "lab:vcs.revision",
+        "value": "8f3c1d9a2b7e4f60c5d8a1b3e6f902478c1d5e2a"
+      }
+    ]
+  },
+  "components": []
+}

--- a/testdata/bom/a-build-that-is-not-at-a-tag/expected-refusals
+++ b/testdata/bom/a-build-that-is-not-at-a-tag/expected-refusals
@@ -1,0 +1,1 @@
+main-component-has-no-release-version

--- a/testdata/bom/a-build-that-is-not-at-a-tag/near-neighbour
+++ b/testdata/bom/a-build-that-is-not-at-a-tag/near-neighbour
@@ -1,0 +1,1 @@
+a-release-with-no-dependencies

--- a/testdata/bom/a-build-the-toolchain-knew-nothing-about/build
+++ b/testdata/bom/a-build-the-toolchain-knew-nothing-about/build
@@ -1,0 +1,2 @@
+main github.com/Flowfin/lab (devel)
+revision 8f3c1d9a2b7e4f60c5d8a1b3e6f902478c1d5e2a

--- a/testdata/bom/a-build-the-toolchain-knew-nothing-about/expected
+++ b/testdata/bom/a-build-the-toolchain-knew-nothing-about/expected
@@ -1,0 +1,21 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:golang/github.com/Flowfin/lab@%28devel%29",
+      "name": "github.com/Flowfin/lab",
+      "version": "(devel)",
+      "purl": "pkg:golang/github.com/Flowfin/lab@%28devel%29"
+    },
+    "properties": [
+      {
+        "name": "lab:vcs.revision",
+        "value": "8f3c1d9a2b7e4f60c5d8a1b3e6f902478c1d5e2a"
+      }
+    ]
+  },
+  "components": []
+}

--- a/testdata/bom/a-build-the-toolchain-knew-nothing-about/expected-refusals
+++ b/testdata/bom/a-build-the-toolchain-knew-nothing-about/expected-refusals
@@ -1,0 +1,1 @@
+main-component-has-no-release-version

--- a/testdata/bom/a-build-the-toolchain-knew-nothing-about/near-neighbour
+++ b/testdata/bom/a-build-the-toolchain-knew-nothing-about/near-neighbour
@@ -1,0 +1,1 @@
+a-release-with-no-dependencies

--- a/testdata/bom/a-build-with-no-revision/build
+++ b/testdata/bom/a-build-with-no-revision/build
@@ -1,0 +1,1 @@
+main github.com/Flowfin/lab v1.0.0

--- a/testdata/bom/a-build-with-no-revision/expected
+++ b/testdata/bom/a-build-with-no-revision/expected
@@ -1,0 +1,21 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:golang/github.com/Flowfin/lab@v1.0.0",
+      "name": "github.com/Flowfin/lab",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/Flowfin/lab@v1.0.0"
+    },
+    "properties": [
+      {
+        "name": "lab:vcs.revision",
+        "value": "the build carried no revision"
+      }
+    ]
+  },
+  "components": []
+}

--- a/testdata/bom/a-dependency-recorded-with-no-version/build
+++ b/testdata/bom/a-dependency-recorded-with-no-version/build
@@ -1,0 +1,3 @@
+main github.com/Flowfin/lab v1.0.0
+revision 8f3c1d9a2b7e4f60c5d8a1b3e6f902478c1d5e2a
+dep example.com/widget

--- a/testdata/bom/a-dependency-recorded-with-no-version/expected
+++ b/testdata/bom/a-dependency-recorded-with-no-version/expected
@@ -1,0 +1,21 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:golang/github.com/Flowfin/lab@v1.0.0",
+      "name": "github.com/Flowfin/lab",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/Flowfin/lab@v1.0.0"
+    },
+    "properties": [
+      {
+        "name": "lab:vcs.revision",
+        "value": "8f3c1d9a2b7e4f60c5d8a1b3e6f902478c1d5e2a"
+      }
+    ]
+  },
+  "components": []
+}

--- a/testdata/bom/a-dependency-recorded-with-no-version/expected-refusals
+++ b/testdata/bom/a-dependency-recorded-with-no-version/expected-refusals
@@ -1,0 +1,1 @@
+dependency-has-no-version

--- a/testdata/bom/a-dependency-recorded-with-no-version/near-neighbour
+++ b/testdata/bom/a-dependency-recorded-with-no-version/near-neighbour
@@ -1,0 +1,1 @@
+a-release-with-one-dependency

--- a/testdata/bom/a-dirty-build-that-is-not-at-a-tag/build
+++ b/testdata/bom/a-dirty-build-that-is-not-at-a-tag/build
@@ -1,0 +1,3 @@
+main github.com/Flowfin/lab v0.0.0-20260827021325-db0a15471e88+dirty
+revision db0a15471e8896e478960ba4dca2e8bb86da509a
+modified true

--- a/testdata/bom/a-dirty-build-that-is-not-at-a-tag/expected
+++ b/testdata/bom/a-dirty-build-that-is-not-at-a-tag/expected
@@ -1,0 +1,21 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:golang/github.com/Flowfin/lab@v0.0.0-20260827021325-db0a15471e88+dirty",
+      "name": "github.com/Flowfin/lab",
+      "version": "v0.0.0-20260827021325-db0a15471e88+dirty",
+      "purl": "pkg:golang/github.com/Flowfin/lab@v0.0.0-20260827021325-db0a15471e88+dirty"
+    },
+    "properties": [
+      {
+        "name": "lab:vcs.revision",
+        "value": "db0a15471e8896e478960ba4dca2e8bb86da509a"
+      }
+    ]
+  },
+  "components": []
+}

--- a/testdata/bom/a-dirty-build-that-is-not-at-a-tag/expected-refusals
+++ b/testdata/bom/a-dirty-build-that-is-not-at-a-tag/expected-refusals
@@ -1,0 +1,2 @@
+build-is-from-a-modified-tree
+main-component-has-no-release-version

--- a/testdata/bom/a-dirty-build-that-is-not-at-a-tag/near-neighbour
+++ b/testdata/bom/a-dirty-build-that-is-not-at-a-tag/near-neighbour
@@ -1,0 +1,1 @@
+a-release-with-no-dependencies

--- a/testdata/bom/a-release-candidate/build
+++ b/testdata/bom/a-release-candidate/build
@@ -1,0 +1,2 @@
+main github.com/Flowfin/lab v1.0.0-rc.1
+revision 8f3c1d9a2b7e4f60c5d8a1b3e6f902478c1d5e2a

--- a/testdata/bom/a-release-candidate/expected
+++ b/testdata/bom/a-release-candidate/expected
@@ -1,0 +1,21 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:golang/github.com/Flowfin/lab@v1.0.0-rc.1",
+      "name": "github.com/Flowfin/lab",
+      "version": "v1.0.0-rc.1",
+      "purl": "pkg:golang/github.com/Flowfin/lab@v1.0.0-rc.1"
+    },
+    "properties": [
+      {
+        "name": "lab:vcs.revision",
+        "value": "8f3c1d9a2b7e4f60c5d8a1b3e6f902478c1d5e2a"
+      }
+    ]
+  },
+  "components": []
+}

--- a/testdata/bom/a-release-that-replaced-a-dependency/build
+++ b/testdata/bom/a-release-that-replaced-a-dependency/build
@@ -1,0 +1,3 @@
+main github.com/Flowfin/lab v1.0.0
+revision 8f3c1d9a2b7e4f60c5d8a1b3e6f902478c1d5e2a
+dep example.com/widget v1.2.3 replaces example.com/gadget v0.9.0

--- a/testdata/bom/a-release-that-replaced-a-dependency/expected
+++ b/testdata/bom/a-release-that-replaced-a-dependency/expected
@@ -1,0 +1,30 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:golang/github.com/Flowfin/lab@v1.0.0",
+      "name": "github.com/Flowfin/lab",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/Flowfin/lab@v1.0.0"
+    },
+    "properties": [
+      {
+        "name": "lab:vcs.revision",
+        "value": "8f3c1d9a2b7e4f60c5d8a1b3e6f902478c1d5e2a"
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/example.com/widget@v1.2.3",
+      "name": "example.com/widget",
+      "version": "v1.2.3",
+      "purl": "pkg:golang/example.com/widget@v1.2.3",
+      "description": "stands in for example.com/gadget@v0.9.0, which is what the build asked for"
+    }
+  ]
+}

--- a/testdata/bom/a-release-with-no-dependencies/build
+++ b/testdata/bom/a-release-with-no-dependencies/build
@@ -1,0 +1,2 @@
+main github.com/Flowfin/lab v1.0.0
+revision 8f3c1d9a2b7e4f60c5d8a1b3e6f902478c1d5e2a

--- a/testdata/bom/a-release-with-no-dependencies/expected
+++ b/testdata/bom/a-release-with-no-dependencies/expected
@@ -1,0 +1,21 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:golang/github.com/Flowfin/lab@v1.0.0",
+      "name": "github.com/Flowfin/lab",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/Flowfin/lab@v1.0.0"
+    },
+    "properties": [
+      {
+        "name": "lab:vcs.revision",
+        "value": "8f3c1d9a2b7e4f60c5d8a1b3e6f902478c1d5e2a"
+      }
+    ]
+  },
+  "components": []
+}

--- a/testdata/bom/a-release-with-one-dependency/build
+++ b/testdata/bom/a-release-with-one-dependency/build
@@ -1,0 +1,3 @@
+main github.com/Flowfin/lab v1.0.0
+revision 8f3c1d9a2b7e4f60c5d8a1b3e6f902478c1d5e2a
+dep example.com/widget v1.2.3

--- a/testdata/bom/a-release-with-one-dependency/expected
+++ b/testdata/bom/a-release-with-one-dependency/expected
@@ -1,0 +1,29 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:golang/github.com/Flowfin/lab@v1.0.0",
+      "name": "github.com/Flowfin/lab",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/Flowfin/lab@v1.0.0"
+    },
+    "properties": [
+      {
+        "name": "lab:vcs.revision",
+        "value": "8f3c1d9a2b7e4f60c5d8a1b3e6f902478c1d5e2a"
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/example.com/widget@v1.2.3",
+      "name": "example.com/widget",
+      "version": "v1.2.3",
+      "purl": "pkg:golang/example.com/widget@v1.2.3"
+    }
+  ]
+}


### PR DESCRIPTION
Refs #37

## What this changes

The bill-of-materials half of #37. The notices half landed in #134 and #136; this is the generator beside it, and it lands ahead of the release workflow rather than inside it, because the workflow attaches artefacts and this produces one.

Three pieces.

`internal/notices/build.go` holds `BuildOf`, which reads the module table the toolchain wrote into a binary. It was a private function inside `cmd/notices` and is now the one reader both commands call. It also carries `vcs.modified`, which the toolchain records and which no reader here took before.

`internal/bom` renders CycloneDX 1.6 JSON from that table: sorted by module path, no timestamp, no serial number. Ten cases under `testdata/bom/`, in the shape `internal/notices` and `internal/contexts` are already proved with.

`cmd/bom` takes one argument, the binary to describe, and writes the document to standard output. No module cache, because this document reproduces no licence text. No connection, no environment variable.

## Which of #37 and #41 owns the generator

That question is open in the notes on both issues, and the body of #37 answers it: "the release workflow that attaches both is blocked on it". Generating belongs here and attaching belongs to #41, so the generator lands under this issue and the workflow that runs it lands under that one.

## The means

Go, standard library only, in the module that is already here. The document is rendered from `debug/buildinfo`, which the toolchain ships, so no dependency is added to a tree whose whole dependency count is zero and no second language arrives for one file. A generator written as a shell step in a workflow would be in a language this repository has no suite and no ledger for, and the three rules would have nothing to hold it to. The alternative considered was an external SBOM tool run as a build step, which would put the document's contents outside anything this repository can refuse and would make the release build depend on fetching it.

## What failure it prevents

A hand-maintained dependency list, which is correct on the day it is written and wrong shortly afterwards, in the direction that matters: a dependency present in the binary and absent from the list. Nothing here is maintained; the input is what the binary records.

Three properties, and each one is a failure somebody meets rather than a rule for symmetry.

`main-component-has-no-release-version` prevents a document published beside an artefact answering "which version am I running" with a commit timestamp.

`build-is-from-a-modified-tree` prevents a release built from a working tree carrying changes version control does not hold, where the revision written beside the components names a commit that is not what was compiled.

`dependency-has-no-version` prevents a row a scanner has to either ignore or guess at.

A fourth failure the render is written against rather than refusing: a clock. CycloneDX offers a timestamp and a serial number, both optional, and either would move between two runs of one build. #41 asks for two runs from one tag to produce identical checksums, and this file is published under one of them.

## What was wrong and how it was found

The version rule was written as a pattern anchored at the commit hash. This repository built itself and the run came back clean over

```
v0.0.0-20260827021325-db0a15471e88+dirty
```

because the suffix a modified tree adds comes after the hash. It was found by the case that reads a real binary rather than by reading the pattern: that case prints the version it saw, and the exit code beside it was 0.

The repair is in two parts, which is the part worth reading rather than the fix. The pattern now carries the trailing build metadata, so it is right about what a version derived from a commit looks like. The modified tree is refused under its own property, read from the `vcs.modified` build setting, because the setting is the answer and the suffix is a spelling of it, and a rule that reads a spelling is one rewording away from silence.

## What was run

At the head of this branch.

```
$ go build ./cmd/... ./internal/...
$ go vet ./cmd/... ./internal/...
$ gofmt -l cmd internal
$ go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
26 decision records read
0 refused
```

The suite:

```
$ go test -count=1 -v ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/bom	13.061s
ok  	github.com/Flowfin/lab/cmd/contexts	0.989s
ok  	github.com/Flowfin/lab/cmd/lab	8.162s
ok  	github.com/Flowfin/lab/cmd/notices	13.951s
ok  	github.com/Flowfin/lab/cmd/pullrequest	1.225s
ok  	github.com/Flowfin/lab/internal/bom	0.996s
ok  	github.com/Flowfin/lab/internal/check	1.253s
ok  	github.com/Flowfin/lab/internal/contexts	0.995s
ok  	github.com/Flowfin/lab/internal/hardware	1.227s
ok  	github.com/Flowfin/lab/internal/invariants	1.562s
ok  	github.com/Flowfin/lab/internal/notices	1.232s
ok  	github.com/Flowfin/lab/internal/prose	1.006s
ok  	github.com/Flowfin/lab/internal/pullrequest	0.998s
```

Ten cases, five of them refusing and each named against a neighbour that passes:

```
    bom_test.go:88: 10 case(s) read from ../../testdata/bom
    bom_test.go:125: 5 refusing case(s) proved against a neighbour that passes
```

Each guard proved by deleting it.

`if build.Modified {` replaced by `if false {` reddens exactly the two cases that declare it and leaves the other eight alone:

```
--- FAIL: TestEveryCaseIsRenderedAsItsFilesDeclare/a-build-from-a-modified-tree
--- FAIL: TestEveryCaseIsRenderedAsItsFilesDeclare/a-dirty-build-that-is-not-at-a-tag
--- PASS: TestEveryCaseIsRenderedAsItsFilesDeclare/a-build-that-is-not-at-a-tag
--- PASS: TestEveryCaseIsRenderedAsItsFilesDeclare/a-release-with-no-dependencies
```

`if !isReleaseVersion(build.Main.Version) {` replaced by `if false {` reddens the three that declare that one and leaves the modified-tree case green:

```
--- FAIL: TestEveryCaseIsRenderedAsItsFilesDeclare/a-build-that-is-not-at-a-tag
--- FAIL: TestEveryCaseIsRenderedAsItsFilesDeclare/a-build-the-toolchain-knew-nothing-about
--- FAIL: TestEveryCaseIsRenderedAsItsFilesDeclare/a-dirty-build-that-is-not-at-a-tag
--- PASS: TestEveryCaseIsRenderedAsItsFilesDeclare/a-build-from-a-modified-tree
```

`build.Deps = append(build.Deps, module)` in the shared reader replaced by a discard reddens one test in the whole tree, which is the collector proof #154 put back and which now covers both commands because it covers the one function they share:

```
--- FAIL: TestATreeWithADependencyAddedProducesADocumentThatListsIt (6.48s)
FAIL	github.com/Flowfin/lab/cmd/notices	21.733s
ok  	github.com/Flowfin/lab/cmd/bom	17.760s
```

The last line of that block is a bound rather than a result: `cmd/bom` stays green under that deletion, because the binary it reads has no third-party module, so its own suite could not have caught it.

## The size

This moves more lines than one reading is, and the run says so as a note rather than a refusal. What the lines are, counted at this head:

```
$ git diff --numstat origin/main...HEAD
fixtures 262, suites 570, source 598, total 1430
```

The property that holds across it is one render and its cases: `internal/bom` is the renderer, most of its length is the argument for each field, and every fixture is four short files. Splitting it would produce a renderer with no cases and cases with no renderer, and neither half is reviewable alone.

## What this does not do

It does not finish #37. Two legs of that issue's done-when ask for both artefacts to be generated by the release build and attached to the release, and there is no release workflow in this tree and no release:

```
$ gh api repos/Flowfin/lab/releases --jq 'length'
0
```

That workflow is #41 and it is where those two legs are met.

It does not validate the document against the published CycloneDX schema. Nothing here reads that schema, so what the suite holds is the fields this renderer writes and the shape it writes them in. A reader who needs conformance has to check it.

It does not identify a licence, and the package URL it writes is not validated against the package-url specification. The module path in that reference keeps the case the toolchain recorded rather than being folded, which is deliberate: two module paths differing only in case are different modules.

It removes no path from the tree. The only deletion is the private `buildOf` function inside `cmd/notices/main.go`, which moves to `internal/notices` under a name both commands call.

This board has no second reader tonight. What stands in place of one is the evidence above: every claim carries the command that produced it, and every guard carries the deletion that reddens it.
