### PR TITLE
Build the release from a tag and stop at the draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,341 @@
+# Cut a release: one run produces everything an operator needs and nothing they
+# do not.
+#
+# WHAT IT PRODUCES. A binary for each of the six platforms record 0012 fixes.
+# The third-party notices and the bill of materials, both generated from the
+# module table inside a binary this run built. The notice, the licence and the
+# privacy document beside them. A checksum file covering every one of those, and
+# a signature over that checksum file. Nothing else, and specifically no
+# installer, because this board asks nobody to install anything.
+#
+# THE ASSETS ARE FILES BESIDE EACH OTHER RATHER THAN ARCHIVES, and that is a
+# decision rather than a shortcut. An archive records a modification time per
+# entry, so two runs from one tag produce two archives whose bytes differ while
+# the files inside them are identical, and the reproducibility claim this
+# workflow makes would be about the archiver rather than about the build. The
+# issue asks for the documents alongside the binary, and beside it is where they
+# are.
+#
+# IT ENDS AT A DRAFT. The last step creates the release as a draft, so publishing
+# it is a person's act rather than this file's. That is deliberate: everything up
+# to the human act is automated and the act itself is not, so nothing reaches
+# anybody's download page because a tag was pushed by accident.
+#
+# ONE JOB RATHER THAN A MATRIX THAT FANS OUT AND REJOINS. Passing six binaries
+# between jobs needs the two artefact actions, which are not in this tree, and
+# pinning either of them to a commit is a dependency this workflow does not need:
+# the module has no dependencies, so cross-compiling six targets is six compiler
+# invocations and costs less than the fan-out would. What the job holds while it
+# carries a write scope is the toolchain and this repository's own source, and
+# nothing third-party executes in it at all.
+#
+# Hardened the way every other workflow in this tree is, because the audit job in
+# zizmor.yml refuses a new one that departs from it: permissions denied at the
+# top and granted per job, every action pinned to a commit with its version in a
+# comment, checkout without persisted credentials, and no cache restored.
+name: Release
+
+# A tag and nothing else. No pull-request trigger and no push trigger on a
+# branch, so a release cannot be produced by accident, and the check name this
+# job reports under therefore never arrives on a pull request. That is why
+# internal/contexts carries it as a permanent deliberate absence rather than as
+# one waiting for issue #26.
+on:
+  push:
+    tags:
+      - "v*"
+
+# Explicit deny-all at workflow level; the job below grants only what it needs.
+permissions: {}
+
+# NOT CANCELLED BY A NEWER RUN, which is the one place in this repository where
+# the run-cancelling concurrency every other workflow uses would be wrong. A
+# release half-published is worse than a release published twice: the assets that
+# made it up are already downloadable and the checksum file covering them may not
+# be. The exception is written here rather than left to be noticed.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # The one scope this workflow needs and the one job that holds it.
+      # Creating a draft release and uploading its assets is a write to the
+      # contents of this repository as the platform counts it.
+      contents: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The whole history, because the toolchain stamps the main module's
+          # version from the tags version control holds, and a clone that
+          # fetched one commit and no tag would stamp a version derived from
+          # the commit instead. The bill of materials refuses exactly that, so
+          # a shallow clone here would redden the run rather than publish a
+          # wrong document, but it would redden it for a reason that is about
+          # this file rather than about the release.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          # The toolchain comes from go.mod, so the version a release is built
+          # with moves when the module says so and never separately.
+          go-version-file: go.mod
+          # No cache. A cache is writable by jobs a release must not trust, and
+          # this module has no dependencies for one to hold in any case.
+          cache: false
+
+      - name: Say what this release is being cut from
+        # A release names a tag, and the tag has to be the thing that was
+        # checked out rather than the thing that triggered the run. They are
+        # the same on an ordinary tag push and they are not the same if a tag
+        # is moved while a run is in flight, which is the case worth refusing
+        # rather than discovering in a published artefact.
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          commit=$(git rev-parse HEAD)
+          echo "tag ${TAG} at commit ${commit}"
+          if [ "$(git rev-parse "refs/tags/${TAG}^{commit}")" != "${commit}" ]; then
+            echo "::error::The tag ${TAG} does not point at the commit this run checked out."
+            exit 1
+          fi
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::The checkout carries changes version control does not hold, so nothing built here would describe the tagged source."
+            git status --porcelain
+            exit 1
+          fi
+          echo "TAG=${TAG}" >> "${GITHUB_ENV}"
+          echo "COMMIT=${commit}" >> "${GITHUB_ENV}"
+
+      - name: Build every platform twice and compare
+        # THE REPRODUCIBILITY LEG, and it is a measurement this run makes rather
+        # than a claim written beside it. Each target is compiled into two
+        # directories and the checksums are compared, so a build that is not a
+        # function of its source reddens the release instead of producing two
+        # artefacts nobody can tell apart from one.
+        #
+        # THE BOUND: this is two builds in one run on one machine. It excludes a
+        # timestamp, a random identifier and a compiler that is not
+        # deterministic. It does not exclude a difference between two machines
+        # or two toolchain versions, and the release notes say so rather than
+        # letting a reader take it for the larger claim.
+        #
+        # -trimpath removes the build machine's directory layout from the
+        # binary, which is the ordinary reason two builds of one source differ.
+        # CGO_ENABLED=0 keeps a C toolchain the runner happens to have out of
+        # the result. The platform list is record 0012's six entries and no
+        # others.
+        env:
+          OUT: ${{ runner.temp }}/dist
+        run: |
+          set -euo pipefail
+          mkdir -p "${OUT}/first" "${OUT}/second"
+
+          platforms="linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64"
+          for platform in ${platforms}; do
+            goos=${platform%/*}
+            goarch=${platform#*/}
+            name="lab_${TAG}_${goos}_${goarch}"
+            if [ "${goos}" = "windows" ]; then
+              name="${name}.exe"
+            fi
+            for pass in first second; do
+              CGO_ENABLED=0 GOOS="${goos}" GOARCH="${goarch}" \
+                go build -trimpath -o "${OUT}/${pass}/${name}" ./cmd/lab
+            done
+            one=$(sha256sum "${OUT}/first/${name}" | cut -d' ' -f1)
+            two=$(sha256sum "${OUT}/second/${name}" | cut -d' ' -f1)
+            if [ "${one}" != "${two}" ]; then
+              echo "::error::Two builds of ${platform} from ${TAG} produced different bytes: ${one} and ${two}."
+              exit 1
+            fi
+            echo "${platform}: ${one} from both passes"
+          done
+          echo "built 6 platform(s), each twice, with matching checksums"
+
+      - name: Render the notices and the bill of materials
+        # Both documents come from the module table inside a binary this run
+        # built, which is where #37 put them and why neither is a list anybody
+        # maintains.
+        #
+        # ONE OF EACH FOR SIX BINARIES, AND THE RUN PROVES THAT IS RIGHT RATHER
+        # THAN ASSERTING IT. Neither document names a platform: what they carry
+        # is the module set and the revision, and those are properties of the
+        # module and the commit rather than of the target. So the documents are
+        # rendered from every one of the six binaries and required to come out
+        # byte for byte identical, and a release where that stops being true
+        # reddens here instead of publishing one document that describes one
+        # sixth of what was shipped.
+        #
+        # A REFUSAL FROM EITHER COMMAND STOPS THE RELEASE. The notices are a
+        # legal obligation and a document incomplete by named entries does not
+        # discharge it; the bill of materials refuses a build that names no
+        # release, which is precisely the thing that must not be published.
+        # Exit code 2 is the command unable to do its job, which is a different
+        # failure and is also fatal here. Record 0011 is the contract.
+        env:
+          OUT: ${{ runner.temp }}/dist
+        run: |
+          set -euo pipefail
+          cache=$(go env GOMODCACHE)
+          mkdir -p "${cache}"
+          mkdir -p "${OUT}/render"
+
+          for binary in "${OUT}"/first/*; do
+            name=$(basename "${binary}")
+            go run ./cmd/notices "${binary}" "${cache}" > "${OUT}/render/${name}.notices"
+            go run ./cmd/bom "${binary}" > "${OUT}/render/${name}.bom"
+          done
+
+          cd "${OUT}/render"
+          if [ "$(sha256sum ./*.notices | cut -d' ' -f1 | sort -u | wc -l)" -ne 1 ]; then
+            echo "::error::The six binaries produced different notices, so no single document describes this release."
+            sha256sum ./*.notices
+            exit 1
+          fi
+          if [ "$(sha256sum ./*.bom | cut -d' ' -f1 | sort -u | wc -l)" -ne 1 ]; then
+            echo "::error::The six binaries produced different bills of materials, so no single document describes this release."
+            sha256sum ./*.bom
+            exit 1
+          fi
+          echo "6 binaries produced one notices document and one bill of materials"
+
+      - name: Assemble what this release publishes
+        # The documents from the tree travel with the binaries, because an
+        # operator holding a downloaded file and nothing else has no way to
+        # reach them. NOTICE.md and LICENSE are the terms the code arrives
+        # under, and docs/privacy.md is what the runner does with what it
+        # reads.
+        env:
+          OUT: ${{ runner.temp }}/dist
+        run: |
+          set -euo pipefail
+          assets="${OUT}/assets"
+          mkdir -p "${assets}"
+
+          cp "${OUT}"/first/lab_* "${assets}/"
+          first_notices=$(find "${OUT}/render" -name '*.notices' | sort | head -1)
+          first_bom=$(find "${OUT}/render" -name '*.bom' | sort | head -1)
+          cp "${first_notices}" "${assets}/THIRD-PARTY-NOTICES.md"
+          cp "${first_bom}" "${assets}/lab_${TAG}_sbom.cdx.json"
+          cp NOTICE.md LICENSE docs/privacy.md "${assets}/"
+
+          cd "${assets}"
+          sha256sum ./* > SHA256SUMS
+          sed -i 's|\./||' SHA256SUMS
+          echo "assets in this release:"
+          cat SHA256SUMS
+          covered=$(wc -l < SHA256SUMS)
+          present=$(find . -type f ! -name SHA256SUMS | wc -l)
+          if [ "${covered}" -ne "${present}" ]; then
+            echo "::error::SHA256SUMS covers ${covered} file(s) and ${present} are being published."
+            exit 1
+          fi
+          echo "SHA256SUMS covers all ${present} published file(s)"
+
+      - name: Sign the checksum file
+        # Record 0021 decides that the artefacts are signed rather than
+        # published with a bare checksum, because a checksum beside the file it
+        # checksums proves the download arrived intact and says nothing about
+        # who built it.
+        #
+        # ONE SIGNATURE OVER THE CHECKSUM FILE COVERS EVERY ASSET. The checksum
+        # file names every published file and its digest, so a signature over it
+        # is a signature over the set, and a reader who verifies it and then
+        # checks a digest has checked that file. Signing each asset separately
+        # would publish seven signatures for one claim.
+        #
+        # THE KEY IS THE ACCOUNT'S AND IT IS NOT THIS BOARD'S TO INVENT.
+        # operations#1609 sets up the keys for the working accounts, and record
+        # 0023 requires a commit on the default branch to carry a signature from
+        # the same ones, which is what makes this one key-custody story rather
+        # than two. A reader verifies against the public signing keys the
+        # platform publishes for the account rather than against anything this
+        # release ships, and the release notes say so.
+        #
+        # IT FAILS CLOSED. Where the secret is absent the release stops here
+        # rather than publishing an unsigned set, because record 0021 says the
+        # artefacts are signed and a release that quietly drops the signature is
+        # the decision being reversed by an absent value.
+        env:
+          OUT: ${{ runner.temp }}/dist
+          SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SIGNING_KEY}" ]; then
+            echo "::error::No signing key is configured for this repository, and record 0021 says a release is signed. Set the RELEASE_SIGNING_KEY secret to the private half of the account signing key that operations#1609 sets up, then re-run."
+            exit 1
+          fi
+
+          key="${RUNNER_TEMP}/signing-key"
+          umask 077
+          printf '%s\n' "${SIGNING_KEY}" > "${key}"
+          ssh-keygen -Y sign -f "${key}" -n file "${OUT}/assets/SHA256SUMS"
+          rm -f "${key}"
+
+          if [ ! -s "${OUT}/assets/SHA256SUMS.sig" ]; then
+            echo "::error::Signing wrote no signature."
+            exit 1
+          fi
+          echo "signed SHA256SUMS, $(wc -c < "${OUT}/assets/SHA256SUMS.sig") byte(s)"
+
+      - name: Write the release notes
+        # The notes are assembled from a tracked document and the facts this run
+        # measured, rather than typed at the moment a release is cut. The fixed
+        # half is docs/release-notes-preamble.md, which carries what this is,
+        # what it is for, what it is not, and how a reader verifies the
+        # signature. The measured half is below it and is never written by hand.
+        env:
+          OUT: ${{ runner.temp }}/dist
+        run: |
+          set -euo pipefail
+          notes="${RUNNER_TEMP}/release-notes.md"
+          {
+            cat docs/release-notes-preamble.md
+            echo
+            echo "## What this release was built from"
+            echo
+            echo "Tag \`${TAG}\` at commit \`${COMMIT}\`."
+            echo
+            echo "Every binary here was compiled twice in the run that published it and the"
+            echo "two passes produced the same checksum. That is two builds on one machine"
+            echo "with one toolchain: it excludes a timestamp, a random identifier and a"
+            echo "compiler that is not deterministic, and it does not say that a build on"
+            echo "another machine would match."
+            echo
+            echo "The third-party notices and the bill of materials were rendered from the"
+            echo "module table inside each of the six binaries, and all six produced the same"
+            echo "two documents."
+            echo
+            echo '```'
+            cat "${OUT}/assets/SHA256SUMS"
+            echo '```'
+          } > "${notes}"
+          echo "NOTES=${notes}" >> "${GITHUB_ENV}"
+          wc -l < "${notes}" | xargs echo "release notes, lines:"
+
+      - name: Create the draft release
+        # A draft, so that publishing is a person's act. The assets are uploaded
+        # with it, so the thing a person publishes is the finished set rather
+        # than an empty shell they then have to fill.
+        env:
+          OUT: ${{ runner.temp }}/dist
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release create "${TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --draft \
+            --title "${TAG}" \
+            --notes-file "${NOTES}" \
+            "${OUT}"/assets/*
+          echo "created the draft release ${TAG} with $(find "${OUT}/assets" -type f | wc -l) asset(s)"
+          echo "It is a draft. Publishing it is the act this workflow deliberately does not take."

--- a/docs/release-notes-preamble.md
+++ b/docs/release-notes-preamble.md
@@ -1,0 +1,79 @@
+# What this is
+
+A runner for reading and checking this board's own records. You point it at a
+checkout of this repository and it reports what it examined and what it refused.
+
+Every release published here carries this text, because it is assembled into the
+notes by the release workflow rather than typed at the moment a release is cut.
+A sentence that has to be remembered is a sentence that eventually is not.
+
+## What this is not
+
+Three exclusions, and they are the ones this board was opened with. The last of
+them is the most important sentence here.
+
+It is not something a media server user is asked to install. The artefacts exist
+so that somebody checking this repository does not have to build the checker out
+of the repository they are checking, which is a weaker position to verify from.
+Whoever downloads one is an operator of this board and not a user of anything
+this organisation ships.
+
+It is not advertised anywhere. An experiment is allowed to fail, and something
+that has been announced cannot fail quietly.
+
+Nothing on any other board depends on it. Work that leaves here does so by
+promotion, which is a hand-over recorded on both sides, and never as a
+dependency edge pointing back at an experiment.
+
+## What is in a release
+
+A binary for each of the six platforms
+[record 0012](https://github.com/Flowfin/lab/blob/main/docs/decisions/0012-the-supported-platforms.md)
+fixes. Three of those six run the suite on every pull request and three are
+compiled and not tested, which that record says out loud.
+
+`THIRD-PARTY-NOTICES.md` and the bill of materials, both generated from the
+module table inside a binary this release published rather than from a list
+anybody maintains. Where this module carries no third-party dependency, the
+notices say exactly that: an empty result that was produced is a different
+statement from a file nobody created.
+
+`NOTICE.md`, `LICENSE` and `privacy.md`, so that the terms the code arrives
+under and what the runner does with what it reads travel with the file rather
+than staying behind in a repository.
+
+`SHA256SUMS`, covering every one of the files above, and `SHA256SUMS.sig`.
+
+## Checking what you downloaded
+
+The checksum file says the bytes arrived as they left. The signature says where
+they left from, and that is the claim somebody verifying this board actually
+needs, because anybody who can place a file can place a checksum beside it.
+
+Verify the digest of a file you downloaded against the line for it:
+
+```
+sha256sum --check --ignore-missing SHA256SUMS
+```
+
+Verify the signature over that checksum file against the public signing keys the
+platform publishes for the account that cut the release. The keys are not
+shipped in the release: a key published beside the signature it verifies proves
+nothing, because whoever placed one placed the other.
+
+```
+curl -s https://api.github.com/users/iderex/ssh_signing_keys \
+  | sed -n 's/.*"key": "\(.*\)".*/iderex \1/p' > allowed-signers
+ssh-keygen -Y verify -f allowed-signers -I iderex -n file \
+  -s SHA256SUMS.sig < SHA256SUMS
+```
+
+Key custody is
+[operations#1609](https://github.com/iderex/operations/issues/1609) and is not
+restated here, because a custody story written twice is a custody story with two
+answers.
+
+What this does not tell you is what to do when a check fails. Record 0021
+decides that the artefacts are signed and decides nothing about what a reader
+does when the verification does not pass, and a published signature nobody
+verifies is a file beside a file.

--- a/internal/contexts/contexts.go
+++ b/internal/contexts/contexts.go
@@ -127,6 +127,11 @@ var Absences = []Absence{
 		Why:   "the supply-chain self-audit publishes from the default branch and has no pull-request trigger, so requiring it would require a context that never arrives on the thing being gated",
 		Until: "",
 	},
+	{
+		Name:  "release",
+		Why:   "the release workflow runs on a tag and on nothing else, so this context arrives on no pull request at all, and requiring it would hold every merge open waiting for a tick that is not coming",
+		Until: "",
+	},
 	{Name: "build (linux/amd64)", Why: theSetIsEmpty, Until: "#26"},
 	{Name: "build (linux/arm64)", Why: theSetIsEmpty, Until: "#26"},
 	{Name: "build (darwin/amd64)", Why: theSetIsEmpty, Until: "#26"},


### PR DESCRIPTION
Closes #41

## What this changes

`.github/workflows/release.yml`, which runs on a tag and produces everything an operator needs: a binary for each of record 0012's six platforms, the third-party notices and the bill of materials from #37, the notice, the licence and the privacy document beside them, a checksum file covering all of it, and a signature over that file.

`docs/release-notes-preamble.md`, which the workflow assembles into the notes of every release. It carries what this is, what it is for, the three exclusions this board was opened with, and how a reader verifies the signature. Written down and assembled in rather than typed at the moment a release is cut, because a sentence that has to be remembered is a sentence that eventually is not.

`internal/contexts/contexts.go` gains one deliberate absence for the new check name, permanent rather than waiting on #26.

## What the note of 2026-08-26 on that issue said this was waiting on

Two things, and both are answered here rather than left standing.

**Which of #41 and #37 owns the bill-of-materials generator.** The generator landed under #37 in #208, merged as `024251ccf826445e63bf2a949c90ed39c96824ce`, and this workflow runs it. The body of #37 is what settled it: "the release workflow that attaches both is blocked on it".

**The keys.** The key-custody question is one I keep elsewhere rather than on this board; it is open, and this board carries no secret at all:

```
$ gh api repos/Flowfin/lab/actions/secrets --jq .total_count
0
```

So the signing step is written and cannot yet run. It fails closed rather than publishing an unsigned set, and the error names the secret and the issue. That is the one thing left between this workflow and a release, and it is a human act rather than work anybody can do here.

## The means

A workflow file, which is a forced means rather than a chosen one: the platform runs YAML and nothing else, and the release has to happen where the tag arrives. Held to its smallest surface, which is what the shape of this file is about. Everything that makes a judgement is a Go command in this tree with its own suite — `cmd/notices` and `cmd/bom` — and what is left in shell is copying files, taking checksums and calling `gh`. No action is used that is not already used elsewhere in this tree.

## What failure it prevents

A release produced by accident. It runs on a tag and on nothing else, so no push and no pull request can cut one, and the last step creates a **draft**, so publishing is a person's act.

A release that cannot be checked. Two builds of one target that differ are refused by the run rather than published as two things nobody can tell apart.

A release describing one sixth of itself. Both documents are rendered from every one of the six binaries and required to come out identical, so one notices file describing six artefacts is proved rather than assumed.

A release that quietly drops its signature. Record 0021 decides that the artefacts are signed, and a workflow that published without one where a secret happened to be missing would be that decision reversed by an absent value.

A cache in a publishing job, which is writable by jobs a release must not trust. There is none, and this module has no dependencies for one to hold in any case.

A release cancelled halfway. `cancel-in-progress` is false, which is the one place in this repository where the run-cancelling concurrency every other workflow uses would be wrong, and the exception is written at the workflow.

## What was run

The workflow cannot run before a tag is pushed, and pushing one is the act this change deliberately leaves to a person. So it was rehearsed instead: every step of it was run by hand, at a throwaway local tag on the head of this branch, and that tag was deleted afterwards and never pushed.

```
$ git tag -f v0.0.1-rehearsal.1 && git checkout v0.0.1-rehearsal.1
tag v0.0.1-rehearsal.1 at commit b1eb93ffe94a1674d5aa64140ec44f759157ccc4
tag points at the checked-out commit
tree clean
```

Every platform built twice, checksums compared:

```
linux/amd64: ed482a0d9fce64f6a0290088b8673101b20daf8f4bf85adf4927ef59772cffd5 from both passes
linux/arm64: 742c29335c320cb6deee370273fa4026ad5ba0a018cc10a1528c45699d5f3a11 from both passes
darwin/amd64: 693789a83477de22133022b2c917a379ab8ebdc72ffacae1f9c3ce15483d37f1 from both passes
darwin/arm64: 18e82f62dcda57efb35335a5b802963996d124717d1365a9c1fb36a1899b1748 from both passes
windows/amd64: c58018409b99bf36c4ccf9ffc3cd6ae465e1f71482ec4e5d30f84a4905e5fb42 from both passes
windows/arm64: a7185621d2a3fecc545d7ab95781622f94fed250a025b67b98ab86b008927d5f from both passes
```

Both documents rendered from all six binaries:

```
distinct notices documents: 1
distinct bom documents:     1
```

And the bill of materials at a tag names the tag, which is the thing `main-component-has-no-release-version` exists to require:

```
      "version": "v0.0.1-rehearsal.1",
      "purl": "pkg:golang/github.com/Flowfin/lab@v0.0.1-rehearsal.1"
```

The checksum file covering every asset:

```
covered=11 present=11
SHA256SUMS covers all 11 published file(s)
```

The signing step, with a key generated for the rehearsal and deleted after it. The account key was not read and no private key was written anywhere in this repository:

```
$ ssh-keygen -Y sign -f "${key}" -n file SHA256SUMS
Signing file .../SHA256SUMS
Write signature to .../SHA256SUMS.sig
294 SHA256SUMS.sig
$ ssh-keygen -Y verify -f allowed-signers -I throwaway -n file -s SHA256SUMS.sig < SHA256SUMS
Good "file" signature for throwaway with ED25519 key SHA256:POp4F1mOvRikWDMdE/GXIxaDCW/c7st0GQVGhUFpVlQ
```

and the same signature over a checksum file with one line added to it:

```
Signature verification failed: incorrect signature
Could not verify signature.
```

The tag is gone and never left this machine:

```
$ git tag -l | wc -l
0
$ gh api repos/Flowfin/lab/tags --jq 'length'
0
```

The tree's own gate at this head:

```
$ go build ./cmd/... ./internal/... && go vet ./cmd/... ./internal/...
$ gofmt -l cmd internal
$ go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/bom	15.385s
ok  	github.com/Flowfin/lab/cmd/contexts	0.769s
ok  	github.com/Flowfin/lab/cmd/lab	3.828s
ok  	github.com/Flowfin/lab/cmd/notices	16.750s
ok  	github.com/Flowfin/lab/cmd/pullrequest	0.512s
ok  	github.com/Flowfin/lab/internal/bom	0.711s
ok  	github.com/Flowfin/lab/internal/check	0.837s
ok  	github.com/Flowfin/lab/internal/contexts	0.784s
ok  	github.com/Flowfin/lab/internal/hardware	0.512s
ok  	github.com/Flowfin/lab/internal/invariants	0.889s
ok  	github.com/Flowfin/lab/internal/notices	0.517s
ok  	github.com/Flowfin/lab/internal/prose	0.543s
ok  	github.com/Flowfin/lab/internal/pullrequest	0.784s
$ go run ./cmd/lab check .
0 refused
$ go run ./cmd/contexts
0 refusal(s), 3 note(s)
```

The audit leg of the done-when is the `Audit workflows (zizmor)` check on this pull request. It is not quoted here, because a result pasted from a local run would be a claim about a machine and the check on this head is the measurement.

## What this does not do

It does not cut a release, and it cannot. There is no tag on this board:

```
$ gh api repos/Flowfin/lab/tags --jq 'length'
0
```

The done-when here asks that a tag produce the artefacts listed. What is landed is the workflow that does it, rehearsed step by step at a tag on this machine. The run on the platform waits for a tag to be pushed, which is the human act I stop short of. #45 is where I flag it.

**The reproducibility leg is measured with a stated bound rather than claimed in full.** Two builds in one run on one machine with one toolchain. That excludes a timestamp, a random identifier and a compiler that is not deterministic. It does not exclude a difference between two machines or two toolchain versions, and the release notes carry that sentence rather than letting a reader take the tick for the larger claim.

It does not sign anything today. The step is written, it refuses to publish without a key, and the key waits on an issue I keep elsewhere.

It publishes files beside each other rather than archives. An archive records a modification time per entry, so two runs from one tag would produce archives whose bytes differ while their contents are identical, and the reproducibility claim would become a claim about the archiver.

It says nothing about what a reader does when a signature does not verify. Record 0021 decides that the artefacts are signed and decides nothing about who checks them, and the preamble repeats that rather than softening it.

It removes no path from the tree.

This board has no second reader tonight. What stands in place of one is the rehearsal above: every step of the workflow was executed by hand at a real tag before it was written down as done.
