### PR TITLE
Walk the download and the checksum in the operator guide

### DIFF
--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -31,19 +31,90 @@ first test on this board rather than from a later mechanism, which is
 
 ## Getting it
 
-There is nothing to download. This board publishes no binary, no checksum file
-and no release, so nothing on this page tells you how to verify a download, and
-whether anything is ever published is not decided. The route that exists is a
-checkout and a Go toolchain, and the toolchain version comes from `go.mod`:
+Two routes, and they are not equally strong. Downloading a file somebody else
+built lets you check this board without first building the checker out of the
+repository you are checking. Building from a checkout is the weaker position and
+it is the one that always works.
+
+### Downloading
+
+Releases are on the releases page of this repository, at
+`https://github.com/Flowfin/lab/releases`. Open it. If it lists nothing, no
+release has been cut yet and the checkout route below is the only one available
+to you; the rest of this section is written against the names the release
+workflow fixes rather than against a release anybody has published.
+
+A release is a set of files beside each other rather than an archive, so you
+download the ones you want and nothing unpacks. What is in one:
+
+- `lab_<tag>_<goos>_<goarch>` - one binary per platform, six of them, ending in
+  `.exe` on Windows. `<tag>` is the release tag, so the Linux build of `v0.1.0`
+  is `lab_v0.1.0_linux_amd64`.
+- `SHA256SUMS`, covering every other file in the release, and `SHA256SUMS.sig`,
+  a signature over that checksum file.
+- `NOTICE.md`, `LICENSE` and `privacy.md`, so the terms the code arrives under
+  and what the runner does with what it reads travel with the binary.
+- `THIRD-PARTY-NOTICES.md` and a bill of materials named
+  `lab_<tag>_sbom.cdx.json`.
+
+Download the binary for your platform, `SHA256SUMS` and `SHA256SUMS.sig` into
+one directory.
+
+### Checking what you downloaded
+
+The checksum says the bytes arrived as they left. It does not say who built
+them, because anybody who can place a file can place a checksum beside it. What
+answers that is the signature, and the release notes carry the commands for it
+alongside where the keys come from; they are in
+docs/release-notes-preamble.md in this tree, and every release
+is published with that text in its notes. Do not take the signing key from the
+release: a key published beside the signature it verifies proves nothing.
+
+Checking the digest is one command and the command differs by platform.
+`--ignore-missing` is what lets you check the two or three files you actually
+downloaded against a checksum file that covers eight.
+
+On Linux, with GNU coreutils:
+
+    sha256sum --check --ignore-missing SHA256SUMS
+
+On macOS, where the same tool is spelled differently:
+
+    shasum -a 256 --check --ignore-missing SHA256SUMS
+
+Both print one `OK` line per file they checked and exit non-zero if any line
+fails. A run that printed no `OK` line at all checked nothing, which is what
+happens when the filenames on disk are not the ones in the checksum file, and it
+is worth reading the output rather than the exit code for exactly that case.
+
+On Windows there is no `--check` equivalent in the shell, so the digest is
+computed and compared by eye. In PowerShell, for the binary you downloaded:
+
+    Get-FileHash -Algorithm SHA256 lab_v0.1.0_windows_amd64.exe
+    Select-String -Path SHA256SUMS -SimpleMatch lab_v0.1.0_windows_amd64.exe
+
+The first prints the hash of the file in front of you and the second prints the
+line the release published for it. They match or they do not, and the comparison
+is yours to make. `certutil -hashfile lab_v0.1.0_windows_amd64.exe SHA256` does
+the same in `cmd.exe` and prints the digest in lower case with spaces in it.
+
+A file whose digest does not match is not a file to run. There is no repair for
+it here beyond downloading it again from the releases page and, if it still does
+not match, saying so through the route in SECURITY.md rather than
+running it anyway.
+
+### Building from a checkout
+
+The route that needs no release. The toolchain version comes from `go.mod`:
 
     git clone https://github.com/Flowfin/lab
     cd lab
     go build -o lab ./cmd/lab
 
 Building the tool from the repository it is about is a weaker position than
-downloading one somebody else built, and it is the only position available
-today. The source of the checks is in the same checkout, which is the part that
-makes it worth anything: what each rule refuses is readable next to the rule.
+downloading one somebody else built and verifying where it came from, and this
+route makes no claim otherwise. What it buys is that the source of the checks is
+in the same checkout: what each rule refuses is readable next to the rule.
 
 ## The first run
 


### PR DESCRIPTION
Closes #42.

## What was wrong

`docs/operator-guide.md` opened its "Getting it" section with three sentences,
and two of them had stopped being true.

```
git show origin/main:docs/operator-guide.md | sed -n '34,36p'
There is nothing to download. This board publishes no binary, no checksum file
and no release, so nothing on this page tells you how to verify a download, and
whether anything is ever published is not decided. The route that exists is a
```

Whether anything is ever published is decided:

```
git show origin/main:docs/decisions/0021-what-this-board-publishes.md | sed -n '5,6p'
This board publishes downloadable release artefacts. They are signed. The
release notes say, in the notes themselves rather than only here, that the
```

And the reason the download walk could not be written has ended. The last thing
recorded on #42 said a walk written before the artefact names existed would name
files by guessing them. Those names are fixed in the tree now:

```
git show origin/main:.github/workflows/release.yml | grep -nE 'name="lab_|cp NOTICE|sha256sum \./\* >|THIRD-PARTY|sbom'
146:            name="lab_${TAG}_${goos}_${goarch}"
227:          cp "${first_notices}" "${assets}/THIRD-PARTY-NOTICES.md"
228:          cp "${first_bom}" "${assets}/lab_${TAG}_sbom.cdx.json"
229:          cp NOTICE.md LICENSE docs/privacy.md "${assets}/"
232:          sha256sum ./* > SHA256SUMS
```

So the walk is written against what that file produces rather than against a
guess, and every asset name in the new section comes from those lines.

## What this changes

One file. `docs/operator-guide.md` gains a download route, a per-platform
checksum check and a pointer to where the signature is verified, and keeps the
checkout route it already had as the one that always works.

The per-platform half is what the issue asks for in as many words - "with the
command written out for each platform, because a checksum nobody knows how to
check is decoration". Linux and macOS get the two spellings of the same tool
with `--ignore-missing`, which is what lets a reader check the two or three
files they actually downloaded against a checksum file covering eight. Windows
gets `Get-FileHash` with the `Select-String` line to compare it against, and
`certutil` beside it, because neither shell there has a `--check` equivalent and
the comparison is the reader's to make by eye.

## What it deliberately does not do

**It does not restate the signature verification.** `docs/release-notes-preamble.md`
carries those commands and where the keys come from, and every release is
published with that text in its notes. A second copy here would be
`restated-not-referenced` against the one a downloader actually holds, so the
guide points at it and adds the one sentence a reader needs before following it:
do not take the key from the release.

**It makes no claim that a release exists, and none has been cut:**

```
gh api repos/Flowfin/lab/releases --jq 'length'
0

gh api repos/Flowfin/lab/tags --jq 'length'
0
```

The page tells a reader to open the releases page and says that an empty one
means the checkout route is the only one available to them. That sentence is
true today and stays true on the day the first release is cut, which a sentence
asserting either state would not.

## The means

Markdown prose in `docs/`, which is the means every other operator-facing
document on this board already uses and the one the prose rules and the paths
leg of the invariants scan can read. Nothing here needs a mechanism that prose
cannot carry: what the section asserts about the release is checkable against
`.github/workflows/release.yml`, which is quoted above rather than paraphrased,
and the commands it hands the reader are run on their machine rather than by
anything here.

## The gate

Run at the head of this branch, `2edacce`:

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
(no output)
go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/bom	16.688s
ok  	github.com/Flowfin/lab/cmd/contexts	2.160s
ok  	github.com/Flowfin/lab/cmd/lab	5.862s
ok  	github.com/Flowfin/lab/cmd/notices	51.160s
ok  	github.com/Flowfin/lab/cmd/pullrequest	1.394s
ok  	github.com/Flowfin/lab/internal/bom	1.651s
ok  	github.com/Flowfin/lab/internal/check	3.282s
ok  	github.com/Flowfin/lab/internal/contexts	1.788s
ok  	github.com/Flowfin/lab/internal/hardware	1.377s
ok  	github.com/Flowfin/lab/internal/invariants	2.252s
ok  	github.com/Flowfin/lab/internal/notices	1.531s
ok  	github.com/Flowfin/lab/internal/prose	1.830s
ok  	github.com/Flowfin/lab/internal/pullrequest	1.423s

go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
26 decision records read
the time this run read is 2026-08-27T08:52:41Z
0 refused
```

The paths leg of that last run is the one that matters for a change of this
shape: it resolves every repository-relative path a document under `docs/` names
and refuses one that is not in the tree. `docs/release-notes-preamble.md` is
named in prose and resolves. The release asset names are bare words with no
leading directory segment, which that reading deliberately does not treat as
paths, so nothing here asks it to resolve a file that only exists inside a
published release.

## No second reader

This change has had no reader other than whoever wrote it. The evidence above
stands in place of one: the sentences it replaces are quoted from the default
branch, every asset name it introduces is quoted from the workflow that produces
it, and the two negative claims - no release, no tag - are the output of the
commands beside them rather than an assertion.
