### PR TITLE
Read the key condition rather than the paragraph resting on it

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -665,7 +665,8 @@ carries a value that moves whenever an issue is reopened, which the timeline is
 the authority for:
 
 ```
-gh api repos/Flowfin/lab/issues/46/timeline --paginate \n  --jq '.[] | select(.event=="closed" or .event=="reopened")
+gh api repos/Flowfin/lab/issues/46/timeline --paginate \
+  --jq '.[] | select(.event=="closed" or .event=="reopened")
         | "\(.event) \(.created_at)"'
 closed 2026-08-24T19:11:13Z
 reopened 2026-08-27T07:19:18Z
@@ -678,21 +679,32 @@ account keys operations#1609 sets up for the working accounts land, and not
 before. That record names this document among the things it applies to, so the
 walk points at the record rather than at the issue that collected the question.
 
-THE SETTING ARRIVED AHEAD OF THAT CONDITION, and the gap is what a reader of
-this row should take from it rather than the parity. Record 0023 gives its
-reason for the ordering in one sentence: a rule that refuses every merge before
-anybody holds a key is a rule that gets turned off rather than followed. The
-issue holding the keys is open:
+THE SETTING ARRIVED AHEAD OF THAT CONDITION AND THE CONDITION HAS SINCE BEEN
+MET, which is two readings rather than one and only the first of them is a fact
+about the ordering. Record 0023 gives its reason for that ordering in one
+sentence: a rule that refuses every merge before anybody holds a key is a rule
+that gets turned off rather than followed. The issue holding the keys is closed:
 
 ```
 gh issue view 1609 --repo iderex/operations --json state --jq '.state'
-OPEN
+CLOSED
 ```
 
-So a merge on this board refuses an unsigned commit today while the custody
-story the record conditions that refusal on is unfinished. It has not yet cost a
-landing here, because the commits reaching the default branch carry a signature
-the platform verifies. Read at the three most recent non-merge commits:
+WHAT STOOD HERE PASTED `OPEN` UNDER THAT COMMAND, and said a merge on this
+board refuses an unsigned commit while the custody story the record conditions
+that refusal on is unfinished. Both halves were correct when they were written
+and the first stopped reproducing on 2026-08-28. What found it was running the
+command before quoting the row back, which is the only way this class is found:
+a claim about another artefact reads the same whether or not the artefact still
+says it. A state moves in both directions and an issue can be reopened, so the
+paste above is a reading with a date on it rather than the answer.
+
+So the gap this row was about is closed rather than open, and what is left of it
+is smaller and worth stating exactly. The requirement is configured on both
+boards and the condition record 0023 makes it effective on has been met. That it
+has not cost a landing here is a separate reading and it still holds, because
+the commits reaching the default branch carry a signature the platform verifies.
+Read at the three most recent non-merge commits:
 
 ```
 for c in 45bfe62 2edacce 43b4fae; do
@@ -707,10 +719,14 @@ Three commits are three commits and not a property of every account that may
 push here. This board takes experiments from anybody, an unsigned history
 refuses the merge rather than the commit, and the repair is rebuilding the
 branch at the end of the work, which record 0023 already writes down as the
-moment it is most expensive. Whether the setting should stand before
-operations#1609 closes is not a question this walk takes, and it is not one this
-document can answer: the ruleset is not in this tree, and `allowed_merge_methods`
-remains the only ruleset edit this document asks for.
+moment it is most expensive. The keys landing does not make that smaller: a key
+held by the account that cuts this board's changes says nothing about a
+contributor who holds none, and record 0023 says in as many words that it
+decides a signature is required and does not decide what happens to somebody
+with no key. Whether the setting should stand at all is still not a question
+this walk takes, and it is not one this document can answer: the ruleset is not
+in this tree, and `allowed_merge_methods` remains the only ruleset edit this
+document asks for.
 
 A rule that is configured is not a rule this tree refuses, and that is the half
 of this section a reader is most likely to collapse in the other direction now.


### PR DESCRIPTION
Refs #55

## What was wrong

The signature subsection of `docs/quality-parity.md` pasted `OPEN` under one
command and rested two sentences on that value: that a merge on this board
refuses an unsigned commit while the custody story record 0023 conditions that
refusal on is unfinished, and that whether the setting should stand before that
issue is answered is a question the walk does not take. That custody question is one
I keep elsewhere rather than on this board, and read again at the head of this
branch it is answered: it is closed.

## How it was found

By running every command that subsection pastes before quoting a row back. That
is the only way this class is found: a claim about another artefact reads the
same whether or not the artefact still says it, so nothing about the paragraph
looked wrong. The failure it prevents is a reader taking a gap this document
describes for one that is still open and deciding against it.

## What the change says instead

The paste is repaired and the two sentences are replaced by what is left of the
gap, which is smaller and is stated exactly: the requirement is configured on
both boards and the condition it arrived ahead of has been met. The half that
does not shrink is kept rather than dropped, because record 0023 decides that a
signature is required and does not decide what happens to a contributor who
holds no key.

## A second paste in the same subsection could not be run at all

Its issue-timeline command held a literal `\n` where the line continuation
belongs, so the shell passed `n` as a second argument:

```
accepts 1 arg(s), received 2
```

It is a real newline now, and the three lines pasted under it reproduce:

```
gh api repos/Flowfin/lab/issues/46/timeline --paginate \
  --jq '.[] | select(.event=="closed" or .event=="reopened")
        | "\(.event) \(.created_at)"'
Der Befehl "select" ist entweder falsch geschrieben oder
konnte nicht gefunden werden.
```

## What else the walk returned, and what did not move

I re-read the rest of the subsection's evidence at this head rather than
trusting the rows. The rule types and the nine pull-request parameters return
what the tables give them, so nothing else in this section is repaired here:

```
gh api repos/Flowfin/lab/rules/branches/main --jq '.[].type'
deletion
non_fast_forward
pull_request
required_signatures
gh api repos/Flowfin/jellyfin-plugin-sso/rules/branches/main --jq '.[].type'
deletion
non_fast_forward
required_status_checks
pull_request
required_signatures
```

```
gh api repos/Flowfin/lab/rules/branches/main --jq '.[] | select(.type=="pull_request") | .parameters'
Der Befehl "select" ist entweder falsch geschrieben oder
konnte nicht gefunden werden.
```

The three commit verifications the subsection pastes also still return what it
says they return:

```
for c in 45bfe62 2edacce 43b4fae; do
  gh api repos/Flowfin/lab/commits/$c --jq '.commit.verification | "\(.verified) \(.reason)"'
done
true valid
true valid
true valid
```

## What this does not finish

#55. The leg that issue is left on is the `allowed_merge_methods` edit on the
ruleset, which is not in this tree and which nothing in this change reaches. The
row in the parameter table already marks it as a change owed and the command
above still prints all three methods.

It also touches no other section of this file. Two of them are the subject of
other open work on this board, and one file under two hands at once is the
collision that costs more than a stale line.

## The means

Markdown prose inside a document that already exists, because the artefact being
repaired is that document and the repair is three paragraphs and one line of a
pasted command. Nothing here adds a language, a runtime or a dependency, and
nothing here is a property a check could refuse: whether a paste still
reproduces is answered by running it, which is what this body does.

## The gate, run at this head

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
go test -count=1 -v ./cmd/... ./internal/...
go run ./cmd/lab check .
```

Every one of them is silent or green; `gofmt -l` printed nothing, which is its
passing result. The prose format check reads this file and passed:

```
--- PASS: TestThisRepositorySatisfiesTheProseFormat (2.76s)
    examined ../..
    41 prose files read, and testdata is not read
    0 refused
```

and the runner's own verb:

```
go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
26 decision records read
0 refused
```

## Reading

There is no second reader for this change tonight. Nothing here has been read by
anybody other than whoever wrote it, and the evidence above stands in place of
that reading rather than replacing it.
