### PR TITLE
Read the answers that landed rather than the questions they replaced

### DIFF
--- a/docs/promotion.md
+++ b/docs/promotion.md
@@ -37,10 +37,25 @@ board is the GNU General Public License version 3, so that is what the code
 carries out and the receiving side inherits terms rather than finding none.
 This repository declares the same licence to the checks that read one, and
 [docs/decisions/0018-the-licence-of-this-board.md](docs/decisions/0018-the-licence-of-this-board.md)
-is the answer both of them come from. Entry three of issue #46 asks who may
-place a contributor's work under another board's terms and carries no answer,
-so a hand-over of somebody else's work still cannot be completed, and writing
-anything else into this line would be inventing permission nobody gave.
+is the answer both of them come from.
+
+The contributor's consent, where the receiving board's terms differ from that
+licence.
+[docs/decisions/0020-consent-to-promote-under-other-terms.md](decisions/0020-consent-to-promote-under-other-terms.md)
+decides that a result leaves under different terms only with the contributor's
+explicit consent, given at promotion time rather than agreed in advance, and
+written as a `Consent:` line in the promotion section naming who consented and
+the terms they consented to. A hand-over resting on a conversation is one
+nobody can check afterwards, and the moment it gets checked is the worst one
+there is. Where the receiving board carries the same licence there is nothing
+to consent to and this item is not asked for.
+
+Nothing in this repository refuses a promotion section that names no consent.
+The check that reads the section holds it to the four things record `0005`
+names, and adding a fifth is a change to the record format that goes through
+[docs/decisions/0013-how-the-record-format-changes.md](decisions/0013-how-the-record-format-changes.md).
+Record `0020` says as much of itself, and what stands behind this item until
+that lands is whoever does the hand-over and whoever reads the change.
 
 What would have to change for this to be production code, written by whoever
 did the work. They know and nobody else does. An experiment is allowed to cut

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -120,10 +120,12 @@ person follows here and no machine enforces it.
 `project has 0 contributing companies or organizations -- score normalized to 0`
 
 Accepted, and outside this repository's control. The check counts the
-organisations that the accounts contributing here belong to. Nothing a change in
-this tree can do moves it, and whether this board takes contributions from
-outside at all is an open question on issue #46 rather than something to score
-against.
+organisations that the accounts contributing here belong to, which the line
+above says is none. Nothing a change in this tree can do moves it, and who may
+contribute here is answered rather than open:
+`docs/decisions/0024-who-may-run-an-experiment-here.md` decides that this board
+takes experiments from anybody. An open door and a count of organisations are
+different things, and only the second is scored.
 
 ### Dangerous-Workflow, 10
 
@@ -204,10 +206,13 @@ rather than a finding. It will start reporting on its own.
 
 `packaging workflow not detected`
 
-Did not apply, and whether it ever should is an open question. Entry four on
-issue #46 asks whether this board publishes downloadable artefacts at all. If the
-answer is no, this check stays at `-1` permanently and that is the correct
-outcome rather than a gap.
+Did not apply, and the question this row rested on is answered.
+`docs/decisions/0021-what-this-board-publishes.md` decides that this board
+publishes downloadable artefacts and that they are signed, so the outcome this
+row used to name as correct - a permanent `-1` because nothing is ever
+published - is not available. What the check looks for is a packaging workflow,
+which a workflow publishing a release is not necessarily, so re-read this row
+against a scored run once a release exists rather than predicting it here.
 
 ### Pinned-Dependencies, 10
 
@@ -270,8 +275,10 @@ the deduction stays.
 `no releases found`
 
 Did not apply, and it cannot pass until there are releases. Accepted now, reopened
-by the release milestone. Whether artefacts are published and whether they are
-signed are both entry four on issue #46.
+by the release milestone. Both halves are decided rather than open:
+`docs/decisions/0021-what-this-board-publishes.md` says this board publishes
+downloadable artefacts and that they are signed, so what this row waits on is a
+release rather than an answer.
 
 ### Token-Permissions, 10
 


### PR DESCRIPTION
Refs #216

## What was wrong

Every entry of the plan's question issue was answered on 2026-08-24, eight
decision records landed for the eight answers, and two documents went on
describing entries of it as open.

`docs/promotion.md` was the one that cost something. It told a reader:

> Entry three of issue #46 asks who may place a contributor's work under another
> board's terms and carries no answer, so a hand-over of somebody else's work
> still cannot be completed, and writing anything else into this line would be
> inventing permission nobody gave.

Record `0020` answers exactly that question, is on the default branch, and says
of itself that the answer reaches this checklist and that the section gains a
fifth thing. It had not:

```
grep -c -i 'consent' docs/promotion.md
0
```

So the document refused a hand-over that the recorded decision permits.

## What the change does

The checklist gains the consent item: what it is, when it is asked for, when it
is not, and that it is written as a `Consent:` line in the promotion section.

It is added together with what does not stand behind it. Nothing in this
repository refuses a promotion section that names no consent, because the check
holds the section to the four things record `0005` names and adding a fifth is a
record-format change under record `0013`. Record `0020` states that residual and
the checklist now carries it too, because an item a reader takes for enforced is
worse than one they can see is owed.

`docs/supply-chain.md` rested three triage rows on the same entries. The
`Contributors` row called who may contribute an open question, which record
`0024` answers. The `Packaging` and `Signed-Releases` rows rested on whether this
board publishes artefacts at all, which record `0021` answers, and `Packaging`
named a permanent `-1` as the correct outcome on a branch that can no longer be
taken.

No re-score was run. Nothing here claims a score moved, and both rows now say to
re-read them against a scored run once a release exists.

## What this does not finish

#216. One site is left and it is a question rather than an edit:
`docs/decisions/0012-the-supported-platforms.md` states the entry `is open`, and
record `0000` says a landed record takes exactly one edit, the line naming what
superseded it. What repairs a landed record carrying a claim that has stopped
reproducing is a rule nobody here has taken, and taking it inside this change
would be worse than leaving three words in place. The issue carries it.

Two sites named in that issue are deliberately untouched because neither is
wrong: `0001` and `0005` say an entry is not decided in the record carrying the
sentence, which is a statement about that record's own scope and is still true.

## A defect found on the way and not repaired here

The two existing links in `docs/promotion.md` are written relative to the
repository root and do not resolve from a file inside `docs/`:

```
grep -n '](docs/decisions/' docs/promotion.md
10:[docs/decisions/0005-how-a-result-leaves.md](docs/decisions/0005-how-a-result-leaves.md),
39:[docs/decisions/0018-the-licence-of-this-board.md](docs/decisions/0018-the-licence-of-this-board.md)
```

`docs/operator-guide.md` and `docs/privacy.md` write theirs relative to `docs/`,
and the two links added here follow them. Repairing the other two is a different
topic from this change and it is written into the issue rather than done here.

## The means

Markdown prose in two documents that already exist, because what is wrong is what
those documents say. Nothing here adds a language, a runtime or a dependency.
Whether a document describes an answered question as open is a judgement about
meaning that no reading of this tree makes, so no check is owed for it and none
is added.

## The gate, run at this head

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
go test -count=1 ./cmd/... ./internal/...
go run ./cmd/lab check .
```

Every one silent or green; `gofmt -l` printed nothing, which is its passing
result. All thirteen packages returned `ok`, and the runner's own verb:

```
examined .
1 experiment directory walked, 1 record read
26 decision records read
0 refused
```

## Reading

There is no second reader for this change tonight. The evidence above stands in
place of one rather than replacing it.
