### PR TITLE
Give five contexts a verdict and re-read the trigger walk where it stopped reproducing

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -438,8 +438,15 @@ unaffected.
 
 A context that arrives on some pull requests and not on others is what this
 section is written against, and three of the ways to build one are readable in
-these files rather than walked. The readings below were made at `1fc6961` and
-cover every workflow file in the tree at that commit.
+these files rather than walked. The readings below were made at
+`9208ceb599a294328bde3d8b660c65a5fd3c5fb5` and cover every workflow file in the
+tree at that commit. They replace a reading made at `1fc6961`, two of whose five
+pastes had stopped reproducing by the time this one was taken: five files carry
+no branch filter that reads every branch where three did, and two carry a type
+filter where one did. Both differences are this board gaining the release and
+smoke workflows, and neither of those runs on a pull request. The other three,
+the path filters, the branch filter under `dependency-review.yml` and the `if:`
+keys, reproduce unchanged at this commit.
 
 A path filter is the ordinary way it happens, and no workflow here carries one:
 
@@ -449,30 +456,43 @@ exit=1
 ```
 
 A trigger narrowed to some branches is the same failure by a second route, and
-three of these files carry no branch filter that reads every branch:
+five of these files carry no branch filter that reads every branch:
 
 ```
 git grep -L 'branches: \[ *"\*\*" *\]' origin/main -- .github/workflows/
 origin/main:.github/workflows/dco.yml
 origin/main:.github/workflows/dependency-review.yml
+origin/main:.github/workflows/release.yml
 origin/main:.github/workflows/scorecard.yml
+origin/main:.github/workflows/smoke.yml
 ```
 
-The third is the supply-chain self-audit, which declares no pull-request
-trigger at all and is outside the required set already. Neither of the other
-two narrows anything. `dependency-review.yml` writes no branch filter under any
-of its triggers, which is every branch:
+Three of the five declare no pull-request trigger at all and are outside the
+required set already, permanently rather than until #26. The supply-chain
+self-audit publishes from the default branch; the release and smoke workflows
+read a tag or a published release, which is the verdict written for them above
+under what this board adds. A file that runs on no pull request cannot narrow
+one, so the membership of this command grows every time this board gains a
+workflow of that shape, and the growth answers nothing the section asks. What
+it is worth reading for is a file that does run on a pull request appearing in
+it.
+
+Neither of the two that do narrows anything. `dependency-review.yml` writes no
+branch filter under any of its triggers, which is every branch:
 
 ```
 git grep -n 'branches:' origin/main -- .github/workflows/dependency-review.yml ; echo "exit=$?"
 exit=1
 ```
 
-`dco.yml` carries the only type filter in these files:
+`dco.yml` carries the only type filter on a pull-request trigger in these
+files. One other carries the key, on a trigger that is not a pull request at
+all:
 
 ```
 git grep -n 'types:' origin/main -- .github/workflows/
 origin/main:.github/workflows/dco.yml:13:    types: [opened, synchronize, reopened]
+origin/main:.github/workflows/smoke.yml:41:    types: [published]
 ```
 
 The claim about the three types it names is that they are the three the

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -152,6 +152,79 @@ it is outside the target's. It publishes from the default branch and cannot
 gate a pull request, so requiring it would require a context that never
 arrives on the thing being gated.
 
+Five more names this tree declares carried no verdict here until this
+paragraph, and they are a different case from the five above. Those are waiting
+for a required set to join. These can never join one.
+
+The sweep, read at `9208ceb599a294328bde3d8b660c65a5fd3c5fb5` rather than at
+`origin/main`, because the paragraphs below are what change its output and a
+paste that stops reproducing the moment it lands is the drift this document
+warns about at the top:
+
+```
+git show 9208ceb599a294328bde3d8b660c65a5fd3c5fb5:internal/contexts/contexts.go \
+  | grep -oE 'Name: +"[^"]+"' | sed 's/Name: *"//; s/"$//' | sort -u \
+  | while read -r n; do
+      git grep -q -F "$n" 9208ceb599a294328bde3d8b660c65a5fd3c5fb5 \
+        -- docs/quality-parity.md || echo "no literal: $n"
+    done
+no literal: build (darwin/amd64)
+no literal: build (darwin/arm64)
+no literal: build (linux/amd64)
+no literal: build (linux/arm64)
+no literal: build (windows/amd64)
+no literal: build (windows/arm64)
+no literal: smoke (darwin/arm64)
+no literal: smoke (linux/amd64)
+no literal: smoke (windows/amd64)
+no literal: verify the published artefacts
+```
+
+The six `build` entries are the one place a literal is deliberately absent.
+Their verdict is the `build` row of the table above, which reaches them through
+`docs/decisions/0012-the-supported-platforms.md`, and writing the six strings
+out here would be this document enumerating what that record decides. The other
+four are a gap. A fifth name is one too and this sweep cannot show it:
+`release` matches as a word inside the reason on the SBOM row rather than as a
+verdict of its own, which is the false pass a fixed-string comparison gives and
+the reason the tree holds the list that decides this in
+`internal/contexts/contexts.go` instead.
+
+All five are dropped from the required set, permanently rather than until #26.
+What their jobs read is a tag or a published release, and a pull request has
+neither, so these contexts arrive on nothing a merge is waiting for and
+requiring one would hold every merge open for a tick that is not coming. That
+is what `required-context-nothing-reports` exists to refuse, so the two
+directions of the comparison would contradict each other. Four of the five
+carry that reason as a shared constant:
+
+```
+git show origin/main:internal/contexts/contexts.go \
+  | awk '/^var Absences/,/^}$/' | tr '\n' ' ' \
+  | grep -oE '\{[^{}]*neverOnAPullRequest[^{}]*\}' | grep -oE 'Name: +"[^"]+"'
+Name:  "verify the published artefacts"
+Name: "smoke (linux/amd64)"
+Name: "smoke (windows/amd64)"
+Name: "smoke (darwin/arm64)"
+```
+
+`release` carries a reason of its own in the same list because its job runs on a
+tag push and on nothing else, which is narrower than what the shared sentence
+says. The workflow files agree with the list rather than being described by it:
+`.github/workflows/release.yml` triggers on `push` with a tag pattern and
+declares no pull-request trigger, and `.github/workflows/smoke.yml` says at its
+own trigger block that the names its jobs report under arrive on no pull
+request at all and that `internal/contexts` carries them as permanent
+deliberate absences.
+
+Dropped from the gate is not dropped as a rule, and the smoke jobs are the case
+where the difference matters most. They are the only thing in this repository
+that reads what an operator downloads rather than the source it was built from,
+which is the distance every other check here is blind to. They hold that rule
+on a published release and on a schedule instead of on a pull request, so what
+is given up by leaving them out of the required set is the moment the failure is
+caught rather than whether it is caught.
+
 ## What each side reports today
 
 Neither list is written here. Both are printed, from a completed run rather


### PR DESCRIPTION
Two documents-only changes to `docs/quality-parity.md`, on one branch and one
pull request because both land prose in the same file and separate landings
would move the mainline under each other.

## What I found, and how

### #26: five declared check names had no verdict in the document

The done-condition of #26 assembles the required set from this document. A
comment on that issue recorded that every check name this tree declares carried
a verdict there, evidenced by a sweep whose only output was the six `build`
entries. I re-ran that sweep at `9208ceb599a294328bde3d8b660c65a5fd3c5fb5`
before writing anything, and it prints ten:

```
git show 9208ceb599a294328bde3d8b660c65a5fd3c5fb5:internal/contexts/contexts.go \
  | grep -oE 'Name: +"[^"]+"' | sed 's/Name: *"//; s/"$//' | sort -u \
  | while read -r n; do
      git grep -q -F "$n" 9208ceb599a294328bde3d8b660c65a5fd3c5fb5 \
        -- docs/quality-parity.md || echo "no literal: $n"
    done
no literal: build (darwin/amd64)
no literal: build (darwin/arm64)
no literal: build (linux/amd64)
no literal: build (linux/arm64)
no literal: build (windows/amd64)
no literal: build (windows/arm64)
no literal: smoke (darwin/arm64)
no literal: smoke (linux/amd64)
no literal: smoke (windows/amd64)
no literal: verify the published artefacts
```

The six `build` entries are the deliberate absence the `build` row already
covers through `docs/decisions/0012-the-supported-platforms.md`. The other four
are a gap. A fifth, `release`, is a gap the sweep cannot show: the word matches
inside the reason on the SBOM row, and a fixed-string comparison cannot tell
that from a verdict.

All five read a tag or a published release, so they arrive on no pull request
and requiring one would hold every merge open for a tick that is not coming,
which is what `required-context-nothing-reports` refuses. The paragraph I added
drops them permanently rather than until #26, in the terms the table uses, and
says what dropping them from the gate does not drop: the smoke jobs are the only
thing here that reads what an operator downloads rather than the source it was
built from.

`internal/contexts/contexts.go` already carries all five as absences, four of
them under the shared `neverOnAPullRequest` reason, so the tree and the document
now agree instead of only the tree holding the answer.

### #62: two of the five pastes in the trigger walk had stopped reproducing

The section that reads which contexts arrive discloses that its readings were
made at `1fc6961`, and its commands resolve `origin/main`. Two of them no longer
return what is pasted beside them. Read at
`9208ceb599a294328bde3d8b660c65a5fd3c5fb5`:

```
git grep -L 'branches: \[ *"\*\*" *\]' origin/main -- .github/workflows/
origin/main:.github/workflows/dco.yml
origin/main:.github/workflows/dependency-review.yml
origin/main:.github/workflows/release.yml
origin/main:.github/workflows/scorecard.yml
origin/main:.github/workflows/smoke.yml

git grep -n 'types:' origin/main -- .github/workflows/
origin/main:.github/workflows/dco.yml:13:    types: [opened, synchronize, reopened]
origin/main:.github/workflows/smoke.yml:41:    types: [published]
```

Three files where the document says three, and two type filters where it says
one. Both differences are the same cause: this board gained `release.yml` and
`smoke.yml`, and neither runs on a pull request.

I re-ran the other three pastes in that section as well. The path-filter grep,
the branch grep over `dependency-review.yml` and the `if:` count all reproduce
unchanged, and the new prose names them as such rather than leaving a reader to
re-derive them.

The repair is more than fresh output. A grep for files carrying no
every-branch filter gains a member every time this board adds a tag-triggered or
release-triggered workflow, and those members answer nothing the section asks.
The new prose separates the two kinds of member and says the thing worth reading
for is a file that does run on a pull request appearing in the list.

## What this does not do

Neither issue closes. #26 waits on the ruleset edit that adds the required set,
which is a repository setting rather than anything a change to this tree
reaches; #62 waits on that set existing to compare against, and on a pull
request opened from a fork. Both reasons are already written on those issues and
I have not repeated them there.

Nothing here measures a fork route, opens a licence file, or says what any job
found. The five names this change gives a verdict to are dropped from a required
set that does not exist yet, so the verdict is a statement about what may join
it rather than about anything holding a merge today.

## The gate, run at the head of this branch

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
(no output)
go test -count=1 ./cmd/... ./internal/...
ok  github.com/Flowfin/lab/cmd/bom
ok  github.com/Flowfin/lab/cmd/contexts
ok  github.com/Flowfin/lab/cmd/lab
ok  github.com/Flowfin/lab/cmd/notices
ok  github.com/Flowfin/lab/cmd/pullrequest
ok  github.com/Flowfin/lab/internal/bom
ok  github.com/Flowfin/lab/internal/check
ok  github.com/Flowfin/lab/internal/contexts
ok  github.com/Flowfin/lab/internal/hardware
ok  github.com/Flowfin/lab/internal/invariants
ok  github.com/Flowfin/lab/internal/notices
ok  github.com/Flowfin/lab/internal/prose
ok  github.com/Flowfin/lab/internal/pullrequest

go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
27 decision records read
0 refused
```

The timings are dropped from the suite output and nothing else is changed. The
run above was made with `-count=1` and the `-v` run that carries the
integration-hardware disclosure was made separately and passed; that harness was
not asked for and asking for it needs the hardware it names.

## Means

Prose in the parity document rather than a new file or a new check. What was
missing in both halves is a verdict and a reading a person uses when assembling
a required set by hand, `internal/contexts` already holds the machine-readable
half of the first, and a list of workflow files written into a document would
drift against the directory that decides it.

## Reading

No second reader on this board tonight, so this body carries the evidence in
place of one: every command above was run before the sentence beside it was
written, and each paste names the commit it was read at.

Refs #26
Refs #62
