### PR TITLE
Filter the six platform literals out of the sweep this document pastes

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -167,25 +167,29 @@ git show 9208ceb599a294328bde3d8b660c65a5fd3c5fb5:internal/contexts/contexts.go 
   | while read -r n; do
       git grep -q -F "$n" 9208ceb599a294328bde3d8b660c65a5fd3c5fb5 \
         -- docs/quality-parity.md || echo "no literal: $n"
-    done
-no literal: build (darwin/amd64)
-no literal: build (darwin/arm64)
-no literal: build (linux/amd64)
-no literal: build (linux/arm64)
-no literal: build (windows/amd64)
-no literal: build (windows/arm64)
+    done | grep -v '^no literal: build ('
 no literal: smoke (darwin/arm64)
 no literal: smoke (linux/amd64)
 no literal: smoke (windows/amd64)
 no literal: verify the published artefacts
 ```
 
-The six `build` entries are the one place a literal is deliberately absent.
-Their verdict is the `build` row of the table above, which reaches them through
-`docs/decisions/0012-the-supported-platforms.md`, and writing the six strings
-out here would be this document enumerating what that record decides. The other
-four are a gap. A fifth name is one too and this sweep cannot show it:
-`release` matches as a word inside the reason on the SBOM row rather than as a
+The last stage is why this paste is four lines rather than ten, and it is not
+tidying. The sweep also returns the six per-platform `build` entries, whose
+verdict is the `build` row of the table above and reaches them through
+`docs/decisions/0012-the-supported-platforms.md`. Those six are the one place a
+literal is deliberately absent here, so pasting the unfiltered output would
+write the six strings into this document and end the absence in the act of
+describing it. The stage drops them by the row name the table already carries
+rather than by naming any of the six.
+
+That the paste needs the stage at all is the shape to take from this section: a
+sweep for names this document does not carry cannot have its full output pasted
+into this document, because the paste is what makes the answer wrong. What is
+left after the stage is the gap, and it is four names.
+
+A fifth name is one too and this sweep cannot show it at all. `release`
+matches as a word inside the reason on the SBOM row rather than as a
 verdict of its own, which is the false pass a fixed-string comparison gives and
 the reason the tree holds the list that decides this in
 `internal/contexts/contexts.go` instead.


### PR DESCRIPTION
A correction to the paragraph that landed in `bc32ccd` under #26, found by
re-running its own sweep at the merge commit.

## What was wrong

That paragraph pastes the sweep that finds declared check names carrying no
verdict in this document. Six of its ten output lines are the per-platform
`build` names, and those six literals are the one place this document
deliberately carries no literal: their verdict is the `build` row, which reaches
them through `docs/decisions/0012-the-supported-platforms.md`, and writing the
strings out is this document enumerating what that record decides.

Pasting the full output wrote all six into the file. Two things followed. The
absence ended in the same sentence that described it, and the sweep stopped
answering: every name it looks for is now present in the document, inside its
own pasted output. Read at the merge commit, one minute after it landed:

```
git show origin/main:internal/contexts/contexts.go \
  | grep -oE 'Name: +"[^"]+"' | sed 's/Name: *"//; s/"$//' | sort -u \
  | while read -r n; do
      git grep -q -F "$n" origin/main -- docs/quality-parity.md \
        || echo "no literal: $n"
    done
(no output)

git grep -n -F 'build (darwin/amd64)' origin/main -- docs/quality-parity.md
origin/main:docs/quality-parity.md:171:no literal: build (darwin/amd64)
```

Ten lines a minute earlier, and the one match is the paste itself.

## The repair

One more pipeline stage, dropping those six by the row name the table already
carries rather than by naming any of the six:

```
git show 9208ceb599a294328bde3d8b660c65a5fd3c5fb5:internal/contexts/contexts.go \
  | grep -oE 'Name: +"[^"]+"' | sed 's/Name: *"//; s/"$//' | sort -u \
  | while read -r n; do
      git grep -q -F "$n" 9208ceb599a294328bde3d8b660c65a5fd3c5fb5 \
        -- docs/quality-parity.md || echo "no literal: $n"
    done | grep -v '^no literal: build ('
no literal: smoke (darwin/arm64)
no literal: smoke (linux/amd64)
no literal: smoke (windows/amd64)
no literal: verify the published artefacts
```

The command now produces exactly what is pasted beside it. The prose says why
the stage is there, because a filter that reads as tidying is the next thing
somebody removes, and it says the general shape: a sweep for names a document
does not carry cannot have its full output pasted into that document, because
the paste is what makes the answer wrong.

The four names the paragraph gives a verdict to are unchanged and their verdict
is unchanged. Nothing else in the section moved.

## What this does not do

This change does not finish #26. What that issue waits on is the ruleset edit,
already written on the issue rather than repeated here.

## The gate, run at the head of this branch

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
(no output)
go test -count=1 ./cmd/... ./internal/...
ok  github.com/Flowfin/lab/cmd/bom
ok  github.com/Flowfin/lab/cmd/contexts
ok  github.com/Flowfin/lab/cmd/lab
ok  github.com/Flowfin/lab/cmd/notices
ok  github.com/Flowfin/lab/cmd/pullrequest
ok  github.com/Flowfin/lab/internal/bom
ok  github.com/Flowfin/lab/internal/check
ok  github.com/Flowfin/lab/internal/contexts
ok  github.com/Flowfin/lab/internal/hardware
ok  github.com/Flowfin/lab/internal/invariants
ok  github.com/Flowfin/lab/internal/notices
ok  github.com/Flowfin/lab/internal/prose
ok  github.com/Flowfin/lab/internal/pullrequest

go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
27 decision records read
0 refused
```

Timings are dropped from the suite output and nothing else is changed.

## Means

The same prose and the same command, one pipeline stage longer, because what was
wrong is the paste rather than the reading.

## Reading

No second reader on this board tonight, so this body carries the evidence in
place of one. Every command above was run before the sentence beside it was
written.

Refs #26
