### PR TITLE
Re-read the two trigger-walk pastes that had stopped reproducing

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -254,14 +254,24 @@ any of them goes into a required set. Issue #62 holds this walk.
 ### The command above reads a commit no pull request produced
 
 `git rev-parse origin/main` resolves a commit on the default branch, which is
-reached by a push. Three workflows in this tree carry no push trigger:
+reached by a push. Four workflows in this tree carry no push trigger:
 
 ```
 git grep -L 'push:' origin/main -- .github/workflows/
 origin/main:.github/workflows/dco.yml
 origin/main:.github/workflows/dependency-review.yml
 origin/main:.github/workflows/pull-request.yml
+origin/main:.github/workflows/smoke.yml
 ```
+
+Three of those four run on a pull request and the fourth runs on neither kind of
+commit, and only the first three are what this section is about.
+`.github/workflows/smoke.yml` triggers on a published release, on a schedule and
+on a manual dispatch, so it reports on no pull request and on no push, and it is
+in this list for a reason the list is not about. That is the thing to read the
+grep for: it gains a member every time this board adds a workflow that runs on
+neither, and what would matter here is a file that does run on a pull request
+appearing in it.
 
 So the two kinds of commit report different sets, and the difference runs in
 both directions. Between the head of the default branch and the head of a pull
@@ -312,8 +322,8 @@ suite 86798670354, success
 suite 86798547856, success
 ```
 
-The cause is one trigger. Every push trigger in these files names the default
-branch except one:
+The cause is one trigger. Every push trigger in these files that names a branch
+names the default branch except one, and one names no branch at all:
 
 ```
 for f in $(git ls-tree --name-only origin/main .github/workflows/); do
@@ -327,10 +337,16 @@ done
 .github/workflows/invariants.yml branches: [main]
 .github/workflows/prose.yml branches: [main]
 .github/workflows/records.yml branches: [main]
+.github/workflows/release.yml tags:
 .github/workflows/scorecard.yml branches: [main]
 .github/workflows/unicode-guard.yml branches: ["**"]
 .github/workflows/zizmor.yml branches: [ main ]
 ```
+
+The `tags:` line is the second kind and it doubles nothing. A tag push is not a
+branch push, so `.github/workflows/release.yml` starts on neither a pull request
+nor the branch one is opened from, and the file says that at its own trigger.
+What produces the repeated name is the entry above carrying every branch.
 
 A branch pushed for a pull request therefore starts that one workflow twice,
 and both runs report under its job name. The file gives the reason its trigger


### PR DESCRIPTION
## What was wrong and how I found it

The section `docs/quality-parity.md` carries for #62 discloses that its readings
were taken at `1fc6961` while the commands beside them resolve `origin/main`, so
each paste under them is a claim a reader re-runs. I re-ran all of them at
`f59943dff615779fcb0bd7a35bad8514375faecf` before writing anything. Two no
longer returned what stood under them.

The grep for workflow files with no push trigger:

```
git grep -L 'push:' origin/main -- .github/workflows/
origin/main:.github/workflows/dco.yml
origin/main:.github/workflows/dependency-review.yml
origin/main:.github/workflows/pull-request.yml
origin/main:.github/workflows/smoke.yml
```

Four, where the document pasted three and the sentence above it said three.

The loop over push triggers:

```
for f in $(git ls-tree --name-only origin/main .github/workflows/); do
  s=$(git show "origin/main:$f" | sed -n '/^  push:/{n;s/^ *//;p;}')
  [ -n "$s" ] && printf '%s %s\n' "$f" "$s"
done
.github/workflows/build.yml branches: [main]
.github/workflows/codeql.yml branches: [main]
.github/workflows/contexts.yml branches: [main]
.github/workflows/headless.yml branches: [main]
.github/workflows/invariants.yml branches: [main]
.github/workflows/prose.yml branches: [main]
.github/workflows/records.yml branches: [main]
.github/workflows/release.yml tags:
.github/workflows/scorecard.yml branches: [main]
.github/workflows/unicode-guard.yml branches: ["**"]
.github/workflows/zizmor.yml branches: [ main ]
```

Eleven lines, where the document pasted ten under a sentence saying every push
trigger in these files names the default branch except one.
`.github/workflows/release.yml` names no branch at all, so that sentence was
wrong rather than merely short.

Both differences have one cause: this board gained `.github/workflows/release.yml`
and `.github/workflows/smoke.yml` since the reading, and neither runs on a pull
request.

I re-ran the other three pastes in that section as well. The path-filter grep,
the branch grep over `dependency-review.yml` and the `if:` grep all reproduce
unchanged, and the `sed -n '76,84p'` paste of the zizmor upload condition still
returns the block it shows.

## What this changes

The stale output is replaced by what the command returns, and each repair then
says which member is which kind rather than leaving the list to be counted. A
tag-triggered or release-triggered workflow joins both greps for a reason
neither section is about: it runs on neither a pull request nor a branch push,
so it cannot narrow a pull request and it cannot double a context. What is worth
reading either list for is a file that does run on a pull request appearing in
it.

That is the same separation the neighbouring branch-filter section already
carries, and the reason it is worth writing twice is that both lists grow for
the same reason and neither said so.

## Means

Prose in the document the walk's result already lives in, edited in place. The
subject is a paste that stopped reproducing, so the artefact is the paragraph
around it and nothing else fits; no language, runtime or dependency is added,
and the existing prose suite is what judges the file.

## What this does not reach

Nothing here observes a run. These are readings of trigger blocks in the
workflow files, which is what the section already bounds itself to. The
done-condition of #62 is unmoved by this: the required set is still empty and
the fork route is still unwalked, and what those wait on is written on the issue
rather than repeated here.

## Gate

Run on this machine at the head of this branch:

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
go test -count=1 ./cmd/... ./internal/...
go run ./cmd/lab check .
```

All green; `gofmt -l` printed nothing and `lab check` refused nothing.

No second person has read this change. That is stated rather than softened, and
the evidence above stands in place of one.
