### PR TITLE
Write the three sites in the first person instead of naming a role

### DIFF
--- a/docs/promotion.md
+++ b/docs/promotion.md
@@ -65,8 +65,8 @@ names which corners those were while the reason is still remembered.
 ## What promotion does not create
 
 It is not a promise of support from this board. Nothing here is maintained
-against anybody else's use of it, and an experiment does not gain a maintainer
-by being taken somewhere.
+against anybody else's use of it, and an experiment does not gain anybody who
+will keep it working by being taken somewhere.
 
 It is not a claim that the code is finished. The line above about what would
 have to change is the measure of that, and it is part of the hand-over rather

--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -705,7 +705,7 @@ below is the one that was absent either way.
 | Parameter | Here | Target | Verdict |
 | --- | --- | --- | --- |
 | `allowed_merge_methods` | `["merge","squash","rebase"]` | `["merge"]` | Change owed. This is the one deviation in this walk worth closing rather than reasoning away, and the reason is below. |
-| `required_approving_review_count` | `0` | `0` | Kept. A count above zero on a board with one maintainer refuses every merge, and a rule nobody can satisfy is switched off in a hurry rather than met. |
+| `required_approving_review_count` | `0` | `0` | Kept. A count above zero on a board where I am the only reviewer refuses every merge, and a rule nobody can satisfy is switched off in a hurry rather than met. |
 | `dismiss_stale_reviews_on_push` | `false` | `false` | Kept. It only bites where a review is required, and none is required at a count of zero. |
 | `require_last_push_approval` | `false` | `false` | Kept, for the reason in the row above. |
 | `required_review_thread_resolution` | `false` | `false` | Kept, for the reason two rows above. |

--- a/internal/invariants/invariants.go
+++ b/internal/invariants/invariants.go
@@ -71,9 +71,9 @@ const (
 )
 
 // DeclaredLicence is the licence this repository has decided on. Record 0018
-// answers entry one of the maintainer question issue with GPL-3.0, one licence
-// for the runner and the experiment content alike, and issue #47 is the change
-// that lands the file and sets this string.
+// answers entry one of issue #46 with GPL-3.0, one licence for the runner and
+// the experiment content alike, and issue #47 is the change that lands the file
+// and sets this string.
 //
 // IT IS SPELLED AS THE TITLE LINE RATHER THAN AS THE SPDX IDENTIFIER, and that
 // is forced by what the leg below asks. The leg asks whether the licence file
@@ -368,7 +368,7 @@ func licenceLeg(root, declaredLicence string) (Leg, []Refusal) {
 		return Leg{
 			Name: "the licence",
 			NotAsked: fmt.Sprintf("no licence is declared, so there is nothing to compare %s against. "+
-				"asking costs answering entry one of the maintainer question issue and landing the file, "+
+				"asking costs answering entry one of issue #46 and landing the file, "+
 				"the repository metadata and the decision record that names it, which is issue #47", LicenceName),
 		}, nil
 	}


### PR DESCRIPTION
Closes #229.

## What changed

Three tracked files carried a role word describing me from outside, at four
sites. All four are rewritten and none of them was replaced with a synonym.

`docs/promotion.md` said an experiment does not gain that role by being taken
somewhere. The sentence is about nobody taking on the duty of keeping the code
working, so it now says that instead of naming a post.

`docs/quality-parity.md` justified `required_approving_review_count: 0` by a
property of the board's staffing. The reason is mine and is now written as
mine: I am the only reviewer here, and a count above zero would refuse every
merge.

`internal/invariants/invariants.go` named the tracker issue by that role twice
- in the comment on `DeclaredLicence` and in the `NotAsked` message the licence
leg prints. Both now name issue #46, which is how every other reference to that
issue in this tree is written and is a pointer a reader can follow instead of
having to know who is meant.

## The done-condition, run against the head of this branch

The issue's done-condition is that a case-insensitive grep for the word returns
only files whose vocabulary is somebody else's - a licence, a code of conduct
adopted verbatim, a platform syntax. Run at `7a24e99`:

```
$ git grep -il <the word>
$ echo "exit=$?"
exit=1
```

**It returns nothing at all, so there is no file of that last kind to name
here.** The issue asked me to list each such file with its reason; the list is
empty rather than omitted. `LICENSE` and `DCO` are the two files in this tree
whose text I did not write, and neither of them contains the word - which is
why the grep above is empty rather than showing two lines.

## The means

Prose in the two documents and a comment plus a format string in Go, all of
them the means the files already use. Nothing is added: no language, no
runtime, no dependency, no new file. The change is four sentences, so the
means question here is only whether it belongs in the files that carry the
sentences, and it does.

## Evidence, run on this branch before pushing

```
$ gofmt -l ./cmd ./internal
$ go build ./cmd/... ./internal/...
$ go test -count=1 ./cmd/... ./internal/...
ok  	github.com/Flowfin/lab/cmd/bom	23.217s
ok  	github.com/Flowfin/lab/cmd/contexts	1.231s
ok  	github.com/Flowfin/lab/cmd/lab	5.480s
ok  	github.com/Flowfin/lab/cmd/notices	23.897s
ok  	github.com/Flowfin/lab/cmd/pullrequest	1.194s
ok  	github.com/Flowfin/lab/internal/bom	1.578s
ok  	github.com/Flowfin/lab/internal/check	3.479s
ok  	github.com/Flowfin/lab/internal/contexts	1.434s
ok  	github.com/Flowfin/lab/internal/hardware	1.113s
ok  	github.com/Flowfin/lab/internal/invariants	2.728s
ok  	github.com/Flowfin/lab/internal/notices	1.478s
ok  	github.com/Flowfin/lab/internal/prose	2.111s
ok  	github.com/Flowfin/lab/internal/pullrequest	1.366s

$ go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
27 decision records read
the time this run read is 2026-08-31T07:53:24Z
0 refused
```

`TestTheLicenceLegSaysWhetherItWasAsked` asserts that the `NotAsked` message
still names `#47`, and it does: only the phrase carrying the role word moved,
and the issue reference the test reads is untouched. That test is inside the
`internal/invariants` line above and also runs in the invariants workflow.

## What this does not do

It does not touch the four sentences' meaning anywhere except where naming the
role WAS the meaning, and in `docs/promotion.md` that is the one place a reader
should check me: I read "does not gain a role-holder" as "nobody takes on
keeping it working", and if that reading is wrong the sentence is now wrong in
a way the grep cannot see.

It adds no guard. Nothing in this tree refuses the word, so a fifth site
written tomorrow lands green. Making that refusable is not attempted here and
this pull request claims no protection against a recurrence.

**This change has had no second reader.** The evidence above stands in place of
one rather than alongside one, and every line of it is a command run at the head
being pushed.
