### PR TITLE
Re-read the target's required set against the table it carries a row per (#26)

### DIFF
--- a/docs/quality-parity.md
+++ b/docs/quality-parity.md
@@ -15,10 +15,68 @@ gh api repos/Flowfin/jellyfin-plugin-sso/rules/branches/main \
         | .parameters.required_status_checks[].context'
 ```
 
-On 2026-08-10 that printed thirteen contexts, and the table below carries one
-row for each of them. Re-run the command before trusting the table. A row that
-no longer has an entry behind it, or an entry with no row, is the drift this
-document is most likely to develop, and finding it costs one command.
+On 2026-08-10 that printed thirteen contexts, and the table below was written
+with one row for each of them. Re-run the command before trusting the table. A
+row that no longer has an entry behind it, or an entry with no row, is the drift
+this document is most likely to develop, and finding it costs one command.
+
+That drift is here, in the direction of a row with nothing behind it. Both sides
+read in the same minute, at `5500dc763f2f91c910b1e8c59abc1f05c611017d`:
+
+```
+gh api repos/Flowfin/jellyfin-plugin-sso/rules/branches/main \
+  --jq '.[] | select(.type=="required_status_checks")
+        | .parameters.required_status_checks[].context' | sort > entries.txt
+wc -l < entries.txt
+12
+
+git show origin/main:docs/quality-parity.md \
+  | sed -n '/^| Target context/,/^$/p' | grep '^| `' \
+  | sed 's/^| `//; s/`.*//' | sort > rows.txt
+wc -l < rows.txt
+13
+
+comm -23 rows.txt entries.txt
+Package (JPRM) / Generate SBOM
+
+comm -13 rows.txt entries.txt
+(no output)
+```
+
+One row and no entry, and nothing the other way, so the table is thirteen rows
+over a set of twelve. The last reading in which that row had an entry is this
+document's own, above, and it is three weeks old; when the entry left is not
+something either command says.
+
+What that costs the table is less than the count suggests, and the reason is
+worth reading before the row. The verdict in it is this board's own rather than
+one inherited from the target: a bill of materials is owed for anything
+downloadable whoever else requires one, and #37 is where it is built. So the row
+stays and its reason is untouched. What it stops being is a row about something
+the target requires today, and it is marked as such in the table rather than
+here.
+
+The set #26 assembles is unmoved either way. That row is already outside this
+board's gate rather than kept in it, so a reading that took its entry as present
+and a reading that takes it as gone assemble the same required set.
+
+The job the entry named is still declared on the target, behind a job-level
+condition:
+
+```
+gh api repos/Flowfin/jellyfin-plugin-sso/contents/.github/workflows/build.yml \
+  --jq '.content' | base64 -d | sed -n '102,105p'
+  sbom:
+    name: Generate SBOM
+    if: ${{ inputs.attest }}
+    runs-on: ubuntu-latest
+```
+
+A job behind a condition reports nothing at all rather than reporting success,
+which is the third of the three cases #62 is written against, and this is the
+first of the three readable on the target rather than on this board. Whether
+that condition is why the entry is no longer required is not something the
+reading above says, and nothing here was asked that would answer it.
 
 ## The gap this rests on
 
@@ -52,7 +110,7 @@ today no tick does.
 | `build` | Kept, renamed | This repository builds a runner rather than a plugin assembly, and the entries are per platform, which `docs/decisions/0012-the-supported-platforms.md` fixes. |
 | `ABI floor build` | Dropped | It exists so a plugin loads against the oldest server it claims to support, and nothing here loads into a host. |
 | `Package (JPRM) / Build package` | Dropped | This repository ships no plugin, so there is no package to build. |
-| `Package (JPRM) / Generate SBOM` | Kept in substance, moved out of the gate | A bill of materials is owed for anything downloadable, and this one is produced by the release build rather than by a check on a pull request. Issue #37 builds it and nothing in this tree produces one today. |
+| `Package (JPRM) / Generate SBOM` | Kept in substance, moved out of the gate, and the entry behind this row has left the target's set | A bill of materials is owed for anything downloadable, and this one is produced by the release build rather than by a check on a pull request. Issue #37 builds it and nothing in this tree produces one today. The target no longer requires this context, which is read at the top of this document; the verdict here rests on this board's own reason and does not move with it. |
 | `CodeQL` | Kept, retargeted | Static analysis of the runner's own source, in the language record `0001` chose rather than in C#. Two strings arrive here for it, the analysis job's `CodeQL (go)` and the code-scanning upload's `CodeQL`. Which of the two a required set can hold is open rather than decided below: the section on which contexts arrive separates the strings, and says of the upload name that the route which would decide it has not been walked. Issue #62 holds that walk. |
 | `Analyze (csharp)` | Dropped as a name | The language-specific analysis job is replaced by the equivalent for this language rather than carried across under a name that describes nothing here. |
 | `DCO sign-off` | Kept unchanged | Already in the tree, asserting the text at `DCO` on every non-merge commit. |


### PR DESCRIPTION
## What was wrong

`docs/quality-parity.md` opens by printing the target's required set rather than
copying it, says that on 2026-08-10 the command returned thirteen contexts and
that the table carries one row for each of them, and names a row with no entry
behind it as the drift it is most likely to develop.

That drift is here. I re-ran the command the document hands the reader before
writing anything, at `5500dc763f2f91c910b1e8c59abc1f05c611017d`, and compared it
against the row literals in the table in both directions:

```
gh api repos/Flowfin/jellyfin-plugin-sso/rules/branches/main \
  --jq '.[] | select(.type=="required_status_checks")
        | .parameters.required_status_checks[].context' | sort > entries.txt
wc -l < entries.txt
12

git show origin/main:docs/quality-parity.md \
  | sed -n '/^| Target context/,/^$/p' | grep '^| `' \
  | sed 's/^| `//; s/`.*//' | sort > rows.txt
wc -l < rows.txt
13

comm -23 rows.txt entries.txt
Package (JPRM) / Generate SBOM

comm -13 rows.txt entries.txt
(no output)
```

Thirteen rows over a set of twelve, one row with nothing behind it, and nothing
the other way.

## What this changes

The document carries both readings, the comparison in both directions, and the
row is marked in the table as one whose entry has left the target's set.

It also writes down what the difference does not change, because that is the part
a reader gets wrong in the expensive direction:

- **The row stays.** Its verdict is this board's own reason - a bill of materials
  is owed for anything downloadable - rather than one inherited from the target,
  and #37 is where it is built. Deleting the row would delete that verdict and
  the pointer with it.
- **The set #26 assembles is unmoved.** That row is already outside this board's
  gate rather than kept in it, so both readings assemble the same required set.

The job the entry named is still declared on the target, behind a job-level
condition:

```
gh api repos/Flowfin/jellyfin-plugin-sso/contents/.github/workflows/build.yml \
  --jq '.content' | base64 -d | sed -n '102,105p'
  sbom:
    name: Generate SBOM
    if: ${{ inputs.attest }}
    runs-on: ubuntu-latest
```

A job behind a condition reports nothing rather than reporting success, which is
the third of the three cases #62 is written against, and this is the first of
them readable on the target rather than on this board.

## What I am not claiming

That the condition is why the entry is no longer required. Neither command above
says so, and I asked nothing that would answer it. The last reading in which that
row had an entry is the document's own 2026-08-10, so when the entry left is also
not something this change establishes.

Nothing here observes a run, on either board. Both readings are of a live ruleset
and of a workflow file.

## The means

Prose in the document that already holds this walk, edited in place. The result
this change carries is a comparison between a live setting and a table, which is
what that document exists to hold, and no other means was considered because
adding one would put the answer somewhere a reader of the table would not meet
it.

## The gate

Run at the head of this branch, from a checkout:

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
(no output)
go test -count=1 ./cmd/... ./internal/... 
ok  	github.com/Flowfin/lab/cmd/bom	54.510s
ok  	github.com/Flowfin/lab/cmd/contexts	3.788s
ok  	github.com/Flowfin/lab/cmd/lab	16.728s
ok  	github.com/Flowfin/lab/cmd/notices	33.116s
ok  	github.com/Flowfin/lab/cmd/pullrequest	1.633s
ok  	github.com/Flowfin/lab/internal/bom	3.673s
ok  	github.com/Flowfin/lab/internal/check	12.010s
ok  	github.com/Flowfin/lab/internal/contexts	7.741s
ok  	github.com/Flowfin/lab/internal/hardware	1.638s
ok  	github.com/Flowfin/lab/internal/invariants	8.510s
ok  	github.com/Flowfin/lab/internal/notices	3.796s
ok  	github.com/Flowfin/lab/internal/prose	5.658s
ok  	github.com/Flowfin/lab/internal/pullrequest	1.634s

go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
27 decision records read
0 refused
```

No guard is added or changed here, so nothing is proved by deletion: this change
is text.

## No second reader

Nothing on this board read this change before it was opened. The evidence above
stands in place of one: every claim it makes is a command a reader can re-run,
and the two that decide the change are the comparison in both directions at the
top.
