### PR TITLE
Refuse a quarantine the record declares nothing about

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,18 +125,23 @@ borrows nothing writes no such line.
 Some of that a run refuses and some of it it does not, and the difference is
 worth knowing before you lean on any of it. A `borrowed/` directory with no
 `LICENSE` beside it is refused. So is a record declaring `Borrowed:` in an
-experiment that holds no such directory. So is a directory named `borrowed`
+experiment that holds no such directory, and so is the other direction of the
+same disagreement, a `borrowed/` directory in an experiment whose record
+declares no `Borrowed:` at all. So is a directory named `borrowed`
 anywhere else inside an experiment, since `experiments/<slug>/borrowed` is the
 one place a quarantine lives and one is all record `0019` allows. A directory
 of that name inside the quarantine is not refused: what is in there is somebody
 else's code laid out somebody else's way, and this board's rules stop at that
 edge.
 
-What still passes is a `borrowed/` directory in an experiment whose record
-declares nothing, because a field added to the format after
+The direction that reads an undeclared quarantine is refused on the directory
+and never on the absent field, and that is the reason it is allowed to exist.
 [docs/decisions/0013-how-the-record-format-changes.md](docs/decisions/0013-how-the-record-format-changes.md)
-is never refused for being absent. That one is yours to keep rather than the
-gate's.
+says a field added to the format after it is optional and that an absent field
+is never a refusal, and nothing here reads an absence: the subject is a
+directory that is present, and a tree carrying one has already said it borrows
+before any header is opened. An experiment that borrows nothing still writes
+nothing and is still never asked about the field.
 
 Nothing opens the licence file. A green run says the layout and the declaration
 do not contradict each other, and it says nothing about which licence the code

--- a/docs/experiment-template.md
+++ b/docs/experiment-template.md
@@ -33,7 +33,8 @@ field filled in teaches every new record to declare a value it does not have, an
 almost every experiment borrows nothing. The code itself goes in
 `experiments/<slug>/borrowed/`, which carries its own `LICENSE` naming those
 terms, and a record declaring the field with no such directory is refused, as is
-a borrowed directory with no licence file in it.
+a borrowed directory with no licence file in it and a borrowed directory in an
+experiment whose record declares the field nowhere.
 
 That directory is the only place a quarantine may be, and one is all record
 `0019` allows, so a directory named `borrowed` anywhere else in the experiment
@@ -43,8 +44,10 @@ by whoever wrote it and this board does not rearrange it.
 What that refusal does not do is worth knowing before you rely on it. Nothing
 reads the licence file, so a green run says the layout and the declaration agree
 and says nothing about which licence the code is actually under or whether the
-result may be promoted anywhere. A borrowed directory in an experiment whose
-record declares nothing passes, because an absent field is never refused.
+result may be promoted anywhere. The undeclared quarantine is refused on the
+directory rather than on the missing field, so an experiment that borrows
+nothing is still never asked for one: an absent field is refused nowhere here,
+and what is read is a directory that is there.
 
 Add `Held-back` where the experiment is held back under
 `docs/decisions/0010-a-flaw-in-shipped-software.md`, with the date of the report

--- a/internal/check/borrowed.go
+++ b/internal/check/borrowed.go
@@ -69,6 +69,31 @@ const (
 	// quarantine is undeclared by construction however carefully the header
 	// was written.
 	AQuarantineOutsideThePlaceQuarantinesLive = "quarantine-outside-the-place-quarantines-live"
+
+	// BorrowedDirectoryTheRecordDoesNotDeclare refuses an experiment that holds
+	// a quarantine while its record declares no Borrowed field. That is the
+	// second direction of the disagreement above: the tree says the experiment
+	// borrows and the record says nothing, so the person promoting the work
+	// reads a boundary and finds no source and no licence named anywhere they
+	// would look for one.
+	//
+	// IT IS KEYED ON THE DIRECTORY AND NOT ON THE ABSENT FIELD, and the
+	// difference is the whole reason it may exist. Record 0013 says a field
+	// added to the format after it is optional and that an absent field is
+	// never a refusal, which is why refuseHardware declines the identical shape
+	// one field over. Nothing here reads an absence and refuses it: what is
+	// refused is a directory that is present, and a tree carrying one has
+	// already said it borrows without the header being consulted at all. So
+	// every experiment that borrows nothing goes on writing nothing, which is
+	// the property record 0013 bought and this does not spend.
+	//
+	// WHERE IT DOES NOT REACH. A quarantine somewhere other than
+	// experiments/<slug>/borrowed is not this arm's subject - it is refused by
+	// the arm above, whose repair is to move it, and this one then reads the
+	// moved directory. So an experiment whose only borrowed directory is in the
+	// wrong place is refused once rather than twice, and the second refusal
+	// arrives with the repair rather than beside the defect.
+	BorrowedDirectoryTheRecordDoesNotDeclare = "borrowed-directory-the-record-does-not-declare"
 )
 
 // refuseBorrowed holds an experiment's borrowed quarantine and its record's
@@ -82,13 +107,7 @@ const (
 // record 0019 explicitly leaves undecided. What passes here is a layout and a
 // declaration that do not contradict each other, and nothing further.
 //
-// WHERE IT DOES NOT REACH, in three places rather than one.
-//
-// A borrowed directory in an experiment whose record declares no Borrowed field
-// passes. That is the second direction of the disagreement above and it is a
-// refusal on an absent field, which record 0013 forbids in the words
-// refuseHardware already declines the same shape in. Closing it is a change to
-// that record rather than a wider check here.
+// WHERE IT DOES NOT REACH, in two places rather than three.
 //
 // A Borrowed declaration written with nothing after the colon is a declaration,
 // so the directory half above is read against it, and nothing here asks whether
@@ -141,16 +160,26 @@ func refuseBorrowed(fsys fs.FS, root, inside, record string, data []byte) ([]Ref
 	if err != nil {
 		return refusals, nil
 	}
-	if _, declared := parsed.Field(FieldBorrowed); !declared || held {
-		return refusals, nil
+	_, declared := parsed.Field(FieldBorrowed)
+
+	switch {
+	case declared && !held:
+		refusals = append(refusals, Refusal{
+			Property: RecordBorrowedDeclarationNamesNoDirectory,
+			Subject:  record,
+			Detail: fmt.Sprintf("it declares %s and there is no %s directory in %s, so the record says the experiment borrows and the tree says it does not",
+				FieldBorrowed, BorrowedDir, inside),
+		})
+	case held && !declared:
+		refusals = append(refusals, Refusal{
+			Property: BorrowedDirectoryTheRecordDoesNotDeclare,
+			Subject:  at(root, quarantine),
+			Detail: fmt.Sprintf("it holds code under somebody else's terms and %s declares no %s, so the tree says the experiment borrows and the record says nothing. record 0019 puts the source and the licence in that field",
+				record, FieldBorrowed),
+		})
 	}
 
-	return append(refusals, Refusal{
-		Property: RecordBorrowedDeclarationNamesNoDirectory,
-		Subject:  record,
-		Detail: fmt.Sprintf("it declares %s and there is no %s directory in %s, so the record says the experiment borrows and the tree says it does not",
-			FieldBorrowed, BorrowedDir, inside),
-	}), nil
+	return refusals, nil
 }
 
 // refuseQuarantineElsewhere walks an experiment for a directory named borrowed

--- a/testdata/cases/a-borrowed-directory-the-record-does-not-declare/expected
+++ b/testdata/cases/a-borrowed-directory-the-record-does-not-declare/expected
@@ -1,0 +1,4 @@
+directories 1
+records 1
+experiments present
+decisions absent

--- a/testdata/cases/a-borrowed-directory-the-record-does-not-declare/expected-refusals
+++ b/testdata/cases/a-borrowed-directory-the-record-does-not-declare/expected-refusals
@@ -1,0 +1,1 @@
+borrowed-directory-the-record-does-not-declare

--- a/testdata/cases/a-borrowed-directory-the-record-does-not-declare/near-neighbour
+++ b/testdata/cases/a-borrowed-directory-the-record-does-not-declare/near-neighbour
@@ -1,0 +1,1 @@
+an-experiment-that-borrows-and-declares-it

--- a/testdata/cases/a-borrowed-directory-the-record-does-not-declare/tree/experiments/one/EXPERIMENT.md
+++ b/testdata/cases/a-borrowed-directory-the-record-does-not-declare/tree/experiments/one/EXPERIMENT.md
@@ -1,0 +1,14 @@
+Slug: one
+State: asking
+Question-Written: 2026-01-01
+Needs-Hardware: none
+
+## Question
+
+Does the reference implementation lose a frame when the stream stalls?
+
+## Method
+
+The implementation was read and run from the copy this experiment carries.
+
+## Answer

--- a/testdata/cases/a-borrowed-directory-the-record-does-not-declare/tree/experiments/one/borrowed/LICENSE
+++ b/testdata/cases/a-borrowed-directory-the-record-does-not-declare/tree/experiments/one/borrowed/LICENSE
@@ -1,0 +1,7 @@
+MIT License
+
+Copyright (c) 2026 the author of the borrowed implementation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files, to deal in the software
+without restriction.

--- a/testdata/cases/a-borrowed-directory-the-record-does-not-declare/tree/experiments/one/borrowed/source.txt
+++ b/testdata/cases/a-borrowed-directory-the-record-does-not-declare/tree/experiments/one/borrowed/source.txt
@@ -1,0 +1,1 @@
+The borrowed implementation would sit here.


### PR DESCRIPTION
Closes #188.

Record `0019` allows an experiment to borrow only inside
`experiments/<slug>/borrowed`, requires that directory to carry its own
`LICENSE`, and requires the experiment record to declare the borrowing in a
`Borrowed:` field. #189 landed two of the three disagreements that layout can
produce. The third was left unbuilt: a borrowed directory in an experiment
whose record declares no `Borrowed:` passed, so borrowed material could sit in
the tree with its source and its licence named nowhere a header reader would
look.

## Why it may exist now, when it could not before

It was left unbuilt because it read as a refusal on an absent field, which
record `0013` forbids and which `refuseHardware` declines one field over for
exactly that reason. It is not one. The subject is the directory, which is
present; a tree carrying a quarantine has already said it borrows before any
header is opened. Nothing here reads an absence, so an experiment that borrows
nothing writes nothing and is never asked about the field, which is the whole
of what `0013` bought. The decision to key it that way was taken on #188 on
2026-08-31 and this change executes it rather than re-taking it.

## The means

Go, in `internal/check/`, because this is a second arm on `refuseBorrowed`
rather than a new artefact: the runner already walks `experiments/`, already
reads the header, already resolves the quarantine path, and the case harness
under `testdata/cases/` already compares whole refusal sets. A means that
carries a refusable property, an executed proof and a command behind every
claim is what the standpoint asks for, and this one is already carrying all
three for its two neighbours.

## What it refuses

```
go run ./cmd/lab check testdata/cases/a-borrowed-directory-the-record-does-not-declare/tree
examined testdata/cases/a-borrowed-directory-the-record-does-not-declare/tree
1 experiment directory walked, 1 record read
no docs/decisions directory in this tree
0 decision records read
the time this run read is 2026-08-31T17:50:32Z
1 refused
  ...\experiments\one\borrowed: it holds code under somebody else's terms and ...\experiments\one\EXPERIMENT.md declares no Borrowed, so the tree says the experiment borrows and the record says nothing. record 0019 puts the source and the licence in that field (borrowed-directory-the-record-does-not-declare)
```

The message names the directory it refuses and the record that declares
nothing, because which of the two is wrong decides the repair. The subject is
the directory rather than the record, which is the same sentence as the
paragraph above read off the output.

## Proof that the guard bites, in both directions

The case declares exactly this refusal and no other, and its tree is identical
to its near neighbour `an-experiment-that-borrows-and-declares-it` apart from
one header line:

```
diff -r testdata/cases/an-experiment-that-borrows-and-declares-it/tree \
        testdata/cases/a-borrowed-directory-the-record-does-not-declare/tree
5d4
< Borrowed: the reference implementation from example.invalid, under the MIT licence
```

Deleting the refusal site reddens the new case and nothing else:

```
go test ./internal/check/ -count=1
--- FAIL: TestCases/a-borrowed-directory-the-record-does-not-declare (0.00s)
    check_test.go:46: expected refusal not produced: borrowed-directory-the-record-does-not-declare
FAIL
```

Widening the condition from `held && !declared` to `held`, which is the
one-character mistake available here, reddens the neighbour and every other
case that borrows and declares it:

```
go test ./internal/check/ -count=1
--- FAIL: TestCases/a-borrowed-directory-inside-the-quarantine (0.00s)
    check_test.go:46: refusal produced that no case expected: borrowed-directory-the-record-does-not-declare
--- FAIL: TestCases/a-quarantine-outside-the-place-quarantines-live (0.00s)
    check_test.go:46: refusal produced that no case expected: borrowed-directory-the-record-does-not-declare
--- FAIL: TestCases/a-borrowed-directory-with-no-licence-file (0.00s)
    check_test.go:46: refusal produced that no case expected: borrowed-directory-the-record-does-not-declare
--- FAIL: TestCases/an-experiment-that-borrows-and-declares-it (0.00s)
    check_test.go:46: refusal produced that no case expected: borrowed-directory-the-record-does-not-declare
FAIL
```

Both runs were made and then reverted; the tree here carries neither break.

## The gate on this branch

```
go build ./cmd/... ./internal/...
go vet ./cmd/... ./internal/...
gofmt -l cmd internal
(no output)
go test -count=1 -v ./cmd/... ./internal/...
(every package ok)

go run ./cmd/lab check .
examined .
1 experiment directory walked, 1 record read
27 decision records read
the time this run read is 2026-08-31T17:50:35Z
0 refused
```

## What record `0019` does not get, deliberately

That record says in bold that nothing in this repository refuses a violation of
its rule today. That sentence is now wrong about the tree and it is not edited.
It is evidence of the day the record landed, and
`docs/decisions/0026-evidence-in-a-landed-record-that-stopped-reproducing.md`
decides that a landed record's evidence is never brought up to date and that a
paste under a standing decision is history rather than error. The decision
`0019` took is unchanged by this, so it gains no successor either. What is
repaired instead are the two documents outside `docs/decisions/` that describe
the gate as it is today: `CONTRIBUTING.md` and `docs/experiment-template.md`
both said this case still passes.

## What a green run still does not prove

Nothing here opens the licence file or reads a word of it, and that bound is
written at `refuseBorrowed` rather than only here. A pass says the layout and
the declaration do not contradict each other. It says nothing about which
licence the borrowed code is actually under, and nothing about whether the
result may be promoted into a board under other terms, which `0019` leaves
undecided on purpose.

Where this arm does not reach is at its own constant: a quarantine somewhere
other than `experiments/<slug>/borrowed` is the neighbouring arm's subject, so
an experiment whose only borrowed directory is in the wrong place is refused
once, and this arm reads the directory after it has been moved.

## No second reader

Nobody but me has read this change. The evidence above stands in place of a
second reader rather than beside one, and the two break-and-watch runs are what
there is instead.
